### PR TITLE
Network audio input (--input ws) and default port 8833

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -33,6 +33,7 @@ CPUだけでリアルタイム音声認識をやろうとすると、普通はWh
 | 翻訳 | `--translate en,zh,ko`で日本語行をリアルタイム翻訳（en=FuguMT、zh/ko=M2M-100） |
 | ホットワード/置換辞書 | `--hotwords`で固有名詞認識を強化、`--replace`で事後の検索置換 |
 | OBSオーバーレイ+ダッシュボード | `--serve`でローカルHTTPサーバーを起動、ブラウザソースオーバーレイとライブダッシュボードを提供 |
+| ネットワーク音声入力 | `--input ws`でWebSocket経由のマイク音声（スマホ、ESP32/スタックチャン等）を受け付け、`--serve`のダッシュボード/オーバーレイにもそのまま流れる |
 | メモリ上限管理 | LRUモデル退避で常駐モデルを上限内（既定<2GB）に制御 |
 | CPUのみ | すべてのモデルがsherpa-onnx経由の量子化ONNXとして動作。GPU・PyTorch不要 |
 
@@ -40,16 +41,36 @@ CPUだけでリアルタイム音声認識をやろうとすると、普通はWh
 
 `--serve`を付けるとローカルサーバーが立ち、ブラウザから3つのページを開けます。
 
-- **`http://localhost:8765/dashboard`**: ライブダッシュボード。発話中のテキスト、
+- **`http://localhost:8833/dashboard`**: ライブダッシュボード。発話中のテキスト、
   確定した行（言語バッジと話者、行ごとの応答時間つき）、その下に翻訳、右側に清書版の
   トランスクリプトが流れます。
-- **`http://localhost:8765/`**: OBS用のシンプルなオーバーレイ。OBSのブラウザソースに
+- **`http://localhost:8833/`**: OBS用のシンプルなオーバーレイ。OBSのブラウザソースに
   このURLを入れると配信画面に字幕が載ります。
-- **`http://localhost:8765/transcript`**: 清書トランスクリプトだけを流すページ。
+- **`http://localhost:8833/transcript`**: 清書トランスクリプトだけを流すページ。
 
 ![dashboard](docs/images/dashboard.png)
 
 🎬 **[デモ動画を見る](https://github.com/oboroge0/hayamimi/releases/download/v0.1.0/hayamimi_demo.mp4)**: 実際の4言語音声（日英韓中）を文字起こししたときの記録を、そのまま再生した動画です。
+
+## ネットワーク音声入力
+
+`--input ws`を付けると、ローカルマイクの代わりにWebSocket経由で音声を受け付ける
+モードになります。スマホやESP32ベースのスタックチャンからマイク音声をLAN越しに
+送って、hayamimiの通常パイプラインでそのまま文字起こしできます。
+
+```bash
+.venv/Scripts/python scripts/realtime_transcribe.py --input ws --serve
+# -> ws://<host>:8766/ingest が音声を受け付け、http://localhost:8833/dashboard に結果が出る
+```
+
+プロトコル: `/ingest`に接続し、最初にJSONテキストフレームを1通送ります
+（`{"sr": 16000, "format": "pcm_s16le", "channels": 1}`）。以降は生の
+`pcm_s16le`音声をバイナリフレームで連続送信します。16kHz以外はサーバー側で
+リサンプリングし、ダッシュボードのSSEストリームと同じpartial/final/translation/refine
+のJSONイベントを返すので、クライアント側で独自に字幕表示することもできます。
+音声を送るクライアントは同時に1本だけ受け付けます。`scripts/ws_mic_client.py`は
+外部ライブラリ不要の参照クライアント（wavファイルを実時間ペースで送信）で、
+スマホ/ESP32クライアントを作るときのテンプレートにもなります。
 
 ## 動作環境
 
@@ -76,7 +97,7 @@ python -m venv .venv
 
 # ダッシュボード + OBSオーバーレイ付き
 .venv/Scripts/python scripts/realtime_transcribe.py --serve
-# -> ブラウザで http://localhost:8765/dashboard を開く
+# -> ブラウザで http://localhost:8833/dashboard を開く
 ```
 
 `scripts/download_models.py`は約3.1GB分のモデルを`models/`（git管理外）にダウンロードします。
@@ -91,12 +112,15 @@ python -m venv .venv
 |---|---|---|
 | `--wav PATH` | マイク入力 | マイクの代わりに16kHzモノラルWAVファイルからのストリーミングをシミュレート |
 | `--no-realtime` | オフ | `--wav`使用時、チャンク間でスリープしない（高速バッチ処理） |
+| `--input {mic,wav,ws}` | mic、`--wav`指定時はwav | 音声入力元。`ws`はネットワーク経由で音声を受け付ける（上記参照） |
+| `--ws-host HOST` | `0.0.0.0` | `--input ws`の`/ingest`エンドポイントのバインドホスト |
+| `--ws-port PORT` | 8766 | `--input ws`の`/ingest`エンドポイントのポート |
 | `--threads N` | 4 | モデルごとの推論スレッド数 |
 | `--no-partial` | オフ | 発話中の速報字幕を無効化 |
 | `--min-silence SEC` | 0.35 | 発話終了とみなす無音時間。小さいほど確定が速くなるが分割も増える |
 | `--max-speech SEC` | 12.0 | 連続発話がこの秒数を超えたら強制的に確定させる |
 | `--max-resident N` | 3 | tier0以外で常駐させるモデル数の上限（LRU退避）。`0`以下で無制限 |
-| `--serve [PORT]` | オフ、8765 | `http://localhost:PORT`でダッシュボード+OBSオーバーレイを配信 |
+| `--serve [PORT]` | オフ、8833 | `http://localhost:PORT`でダッシュボード+OBSオーバーレイを配信 |
 | `--no-refine` | オフ | 発話群の二段パス再デコードを無効化 |
 | `--transcript PATH` | なし | 清書済みトランスクリプト行をこのファイルに追記 |
 | `--hotwords PATH` | なし | 日本語デコードを固有名詞側に寄せるホットワード一覧（1行1語） |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ same clips, while running at 10-50x realtime on a 6-core desktop CPU.
 | Translation | `--translate en,zh,ko` translates Japanese lines live (en via FuguMT, zh/ko via M2M-100) |
 | Hotwords / user dictionary | `--hotwords` biases decoding toward proper nouns; `--replace` does post-hoc find/replace |
 | OBS overlay + dashboard | `--serve` starts a local HTTP server with a browser-source overlay and a live dashboard |
+| Network audio input | `--input ws` accepts mic audio over a WebSocket (phone, ESP32/stackchan) and feeds it through the same pipeline, including `--serve`'s dashboard/overlay |
 | Memory-bounded | LRU model eviction keeps resident models under a configurable cap (default: <2GB total) |
 | CPU-only | every model runs as quantized ONNX via sherpa-onnx; no GPU or PyTorch required |
 
@@ -43,18 +44,38 @@ same clips, while running at 10-50x realtime on a 6-core desktop CPU.
 
 `--serve` starts a local server exposing three views:
 
-- **`http://localhost:8765/dashboard`** -- the live dashboard: a partial-text
+- **`http://localhost:8833/dashboard`** -- the live dashboard: a partial-text
   strip for in-progress speech, a finals feed with language badges, speaker
   chips, and per-line latency, inline translations under each line, and a
   second column with the refined (two-pass) transcript as it lands.
-- **`http://localhost:8765/`** -- a minimal OBS browser-source overlay
+- **`http://localhost:8833/`** -- a minimal OBS browser-source overlay
   (add this URL as a Browser Source in OBS for stream captions).
-- **`http://localhost:8765/transcript`** -- plain scrolling transcript
+- **`http://localhost:8833/transcript`** -- plain scrolling transcript
   history.
 
 ![dashboard](docs/images/dashboard.png)
 
 🎬 **[Watch the demo video](https://github.com/oboroge0/hayamimi/releases/download/v0.1.0/hayamimi_demo.mp4)** — real 4-language audio (ja/en/ko/zh) transcribed live, replayed frame-accurately from a captured session.
+
+## Network audio input
+
+`--input ws` runs a WebSocket ingest endpoint instead of reading the local
+microphone, so a phone or a stackchan-class ESP32 board can stream mic audio
+over the LAN and get it transcribed through hayamimi's normal pipeline:
+
+```bash
+.venv/Scripts/python scripts/realtime_transcribe.py --input ws --serve
+# -> ws://<host>:8766/ingest accepts audio; http://localhost:8833/dashboard shows the results
+```
+
+Protocol: connect to `/ingest`, send one JSON text frame
+(`{"sr": 16000, "format": "pcm_s16le", "channels": 1}`), then stream raw
+`pcm_s16le` audio as binary frames. The server resamples non-16kHz audio and
+replies with the same partial/final/translation/refine JSON events the
+dashboard's SSE stream carries, so a client can show its own subtitles too.
+Only one audio-producing client is accepted at a time; `scripts/ws_mic_client.py`
+is a dependency-free reference client (streams a wav file at real-time pace)
+that doubles as a template for a phone/ESP32 implementation.
 
 ## Requirements
 
@@ -81,7 +102,7 @@ python -m venv .venv
 
 # With the dashboard + OBS overlay
 .venv/Scripts/python scripts/realtime_transcribe.py --serve
-# -> open http://localhost:8765/dashboard in a browser
+# -> open http://localhost:8833/dashboard in a browser
 ```
 
 `scripts/download_models.py` pulls ~3.1GB of pretrained models into
@@ -97,12 +118,15 @@ All flags are on `scripts/realtime_transcribe.py`:
 |---|---|---|
 | `--wav PATH` | mic input | simulate streaming from a 16kHz mono WAV file instead of the microphone |
 | `--no-realtime` | off | with `--wav`, don't sleep between chunks (fast batch processing) |
+| `--input {mic,wav,ws}` | mic, or wav if `--wav` is given | audio source; `ws` accepts audio over the network (see below) |
+| `--ws-host HOST` | `0.0.0.0` | bind host for `--input ws`'s `/ingest` endpoint |
+| `--ws-port PORT` | 8766 | port for `--input ws`'s `/ingest` endpoint |
 | `--threads N` | 4 | inference threads per model |
 | `--no-partial` | off | disable in-progress draft subtitles |
 | `--min-silence SEC` | 0.35 | silence duration that ends an utterance; lower = snappier finals, more splits |
 | `--max-speech SEC` | 12.0 | force-finalize an utterance after this many seconds of continuous speech |
 | `--max-resident N` | 3 | max non-tier0 models kept resident (LRU eviction); `<=0` = unlimited |
-| `--serve [PORT]` | off, 8765 | serve the dashboard + OBS overlay at `http://localhost:PORT` |
+| `--serve [PORT]` | off, 8833 | serve the dashboard + OBS overlay at `http://localhost:PORT` |
 | `--no-refine` | off | disable the second-pass re-decode of utterance groups |
 | `--transcript PATH` | none | append refined transcript lines to this file |
 | `--hotwords PATH` | none | hotword list (one per line) to bias Japanese decoding toward proper nouns |

--- a/scripts/audio_utils.py
+++ b/scripts/audio_utils.py
@@ -1,0 +1,43 @@
+"""Pure audio helpers shared by the realtime pipeline and the WS ingest path.
+
+Kept dependency-free (numpy only) so PCM decode/resample can run without any
+extra audio codec library on either the server or the ESP32/phone-facing
+test client (scripts/ws_mic_client.py).
+"""
+import numpy as np
+
+
+def resample_linear(samples: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
+    """Linear-interpolation resample.
+
+    Good enough for speech-band PCM from a cheap mic (ESP32 I2S, phone mic
+    at an odd sample rate); this is NOT a substitute for a proper
+    polyphase/sinc resampler if a project ever needs broadcast-quality
+    audio. No scipy/soxr/librosa dependency exists in this project yet, so
+    this mirrors the same trade-off realtime_transcribe.py already made for
+    --wav file resampling.
+    """
+    if src_rate == dst_rate:
+        return samples
+    duration = len(samples) / src_rate
+    dst_n = int(round(duration * dst_rate))
+    if dst_n <= 0:
+        return np.zeros(0, dtype=np.float32)
+    src_x = np.arange(len(samples)) / src_rate
+    dst_x = np.arange(dst_n) / dst_rate
+    return np.interp(dst_x, src_x, samples).astype(np.float32)
+
+
+def decode_pcm16(data: bytes, channels: int = 1) -> np.ndarray:
+    """Raw little-endian s16 PCM bytes -> float32 mono samples in [-1, 1].
+
+    Drops a trailing odd byte instead of raising: a flaky WiFi client
+    (ESP32) can hand us a chunk boundary that lands mid-sample, and losing
+    one sample is much better than killing the connection over it.
+    """
+    n = len(data) - (len(data) % 2)
+    samples = np.frombuffer(data[:n], dtype="<i2").astype(np.float32) / 32768.0
+    if channels > 1 and len(samples) >= channels:
+        usable = len(samples) - (len(samples) % channels)
+        samples = samples[:usable].reshape(-1, channels).mean(axis=1)
+    return samples

--- a/scripts/realtime_transcribe.py
+++ b/scripts/realtime_transcribe.py
@@ -21,21 +21,12 @@ import numpy as np
 import sherpa_onnx
 
 from asr_engine import RoutedASR
+from audio_utils import resample_linear
 
 SAMPLE_RATE = 16000
 WINDOW_SIZE = 512  # samples per VAD chunk, ~32ms @ 16kHz
 MODELS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "models")
 VAD_MODEL = os.path.join(MODELS_DIR, "silero_vad.onnx")
-
-
-def resample_linear(samples: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
-    if src_rate == dst_rate:
-        return samples
-    duration = len(samples) / src_rate
-    dst_n = int(round(duration * dst_rate))
-    src_x = np.arange(len(samples)) / src_rate
-    dst_x = np.arange(dst_n) / dst_rate
-    return np.interp(dst_x, src_x, samples).astype(np.float32)
 
 
 def read_wave(path: str, target_rate: int = SAMPLE_RATE):
@@ -103,6 +94,35 @@ def mic_chunks():
                          blocksize=WINDOW_SIZE, callback=callback):
         while True:
             yield q.get()
+
+
+def ws_chunks(ingest):
+    """Re-chunk a ws_ingest.IngestServer's variable-sized network reads into
+    fixed WINDOW_SIZE frames, the shape the VAD expects.
+
+    Blocks on ingest.audio_q, same as mic_chunks() blocks on sounddevice's
+    queue -- if the client disconnects, this just idles until the next one
+    connects and starts pushing audio again; the pipeline stays alive.
+
+    ingest.audio_q can also carry a non-ndarray "flush" sentinel (see
+    ws_ingest.FLUSH), pushed when a streaming client disconnects. It is
+    passed straight through to run_stream(), which treats any non-ndarray
+    item as "flush the in-progress VAD segment now" -- otherwise a segment
+    left open when the client vanishes would sit unfinalized forever.
+    """
+    leftover = np.zeros(0, dtype=np.float32)
+    while True:
+        item = ingest.audio_q.get()
+        if not isinstance(item, np.ndarray):
+            if len(leftover):
+                yield np.pad(leftover, (0, WINDOW_SIZE - len(leftover)))
+                leftover = np.zeros(0, dtype=np.float32)
+            yield item
+            continue
+        leftover = np.concatenate([leftover, item])
+        while len(leftover) >= WINDOW_SIZE:
+            yield leftover[:WINDOW_SIZE]
+            leftover = leftover[WINDOW_SIZE:]
 
 
 PARTIAL_EVERY_S = 0.5   # decode a draft this often (in audio time) during speech
@@ -415,6 +435,20 @@ def run_stream(chunks, vad, sample_rate: int, asr: RoutedASR, stats: SessionStat
     if history is None:
         history = AudioHistory(sample_rate)
     for chunk in chunks:
+        if not isinstance(chunk, np.ndarray):
+            # non-ndarray = a "flush now" signal (ws_ingest.FLUSH on client
+            # disconnect): finalize whatever the VAD has in progress instead
+            # of waiting for silence that may never arrive.
+            vad.flush()
+            if drain_segments(vad, sample_rate, asr, stats, printer, history, early_lang,
+                              spans_out=refiner.spans if refiner else None,
+                              translator_worker=translator_worker,
+                              speaker_labeler=speaker_labeler):
+                early_lang = None
+            if refiner is not None:
+                refiner.maybe_refine(int(audio_pos * sample_rate), force=True)
+            continue
+
         vad.accept_waveform(chunk)
         history.push(chunk)
         audio_pos += len(chunk) / sample_rate
@@ -451,8 +485,8 @@ def main():
                     help="force-finalize an utterance after this many seconds of continuous speech")
     ap.add_argument("--max-resident", type=int, default=3,
                     help="max non-tier0 models kept in memory (LRU eviction); 0 or less = unlimited")
-    ap.add_argument("--serve", type=int, nargs="?", const=8765, default=None, metavar="PORT",
-                    help="serve an OBS browser-source overlay at http://localhost:PORT (default 8765)")
+    ap.add_argument("--serve", type=int, nargs="?", const=8833, default=None, metavar="PORT",
+                    help="serve an OBS browser-source overlay at http://localhost:PORT (default 8833)")
     ap.add_argument("--no-refine", action="store_true",
                     help="disable the second-pass re-decode of utterance groups")
     ap.add_argument("--transcript", metavar="PATH",
@@ -469,6 +503,13 @@ def main():
     ap.add_argument("--translate", nargs="?", const="en", default=None, metavar="LANGS",
                     help="translate Japanese lines to these languages, comma-separated "
                          "(en/zh/ko; default en). en=FuguMT, zh/ko=M2M-100")
+    ap.add_argument("--input", choices=["mic", "wav", "ws"], default=None,
+                    help="audio source; default is mic, or wav if --wav is given")
+    ap.add_argument("--ws-host", default="0.0.0.0", metavar="HOST",
+                    help="bind host for --input ws (default 0.0.0.0, so an ESP32/phone "
+                         "on the LAN can reach it; use 127.0.0.1 to restrict to localhost)")
+    ap.add_argument("--ws-port", type=int, default=8766, metavar="PORT",
+                    help="port for the --input ws /ingest endpoint (default 8766)")
     args = ap.parse_args()
 
     server = None
@@ -516,15 +557,28 @@ def main():
         if refiner is not None:
             refiner.maybe_refine(0, force=True)
 
+    input_mode = args.input or ("wav" if args.wav else "mic")
+
     try:
         if server is not None:
             server.publish({"type": "session_start"})
-        if args.wav:
+        if input_mode == "wav":
+            if not args.wav:
+                ap.error("--input wav requires --wav PATH")
             samples, sr = read_wave(args.wav)  # resampled to SAMPLE_RATE if needed
             run_stream(wav_chunks(samples, sr, realtime=not args.no_realtime),
                        vad, sr, asr, stats, printer, refiner, history, translator_worker,
                        speaker_labeler)
             finish(sr)
+        elif input_mode == "ws":
+            from ws_ingest import INGEST_PATH, IngestServer
+
+            ingest = IngestServer(args.ws_host, args.ws_port, sample_rate=SAMPLE_RATE,
+                                  subtitle_server=server).start()
+            print(f"ws ingest: ws://{args.ws_host}:{args.ws_port}{INGEST_PATH}  "
+                  f"(JSON handshake, then binary pcm_s16le frames)", file=sys.stderr)
+            run_stream(ws_chunks(ingest), vad, SAMPLE_RATE, asr, stats, printer, refiner,
+                       history, translator_worker, speaker_labeler)
         else:
             run_stream(mic_chunks(), vad, SAMPLE_RATE, asr, stats, printer, refiner, history,
                        translator_worker, speaker_labeler)

--- a/scripts/subtitle_server.py
+++ b/scripts/subtitle_server.py
@@ -74,7 +74,7 @@ DASHBOARD_HTML = '<!doctype html>\n<html lang="ja">\n<meta charset="utf-8">\n<me
 class SubtitleServer:
     """Fan-out of subtitle events to any number of SSE clients."""
 
-    def __init__(self, port: int = 8765):
+    def __init__(self, port: int = 8833):
         self.port = port
         self._clients: list[queue.Queue] = []
         self._refines: list[str] = []  # recent refine events, replayed to new clients
@@ -98,6 +98,24 @@ class SubtitleServer:
         self.publish({"type": "final", "text": text, "lang": lang,
                       "speaker": speaker, "latency_ms": latency_ms, "tier": tier})
 
+    def subscribe(self) -> queue.Queue:
+        """Register a new consumer; past `refine` events are replayed first.
+
+        Used by the /events SSE handler and by ws_ingest.py to mirror the
+        same broadcast onto a WebSocket ingest client.
+        """
+        q: queue.Queue = queue.Queue()
+        with self._lock:
+            for past in self._refines:
+                q.put(past)
+            self._clients.append(q)
+        return q
+
+    def unsubscribe(self, q: queue.Queue):
+        with self._lock:
+            if q in self._clients:
+                self._clients.remove(q)
+
     def start(self):
         server = self
 
@@ -112,11 +130,7 @@ class SubtitleServer:
                     self.send_header("Cache-Control", "no-cache")
                     self.send_header("Access-Control-Allow-Origin", "*")
                     self.end_headers()
-                    q: queue.Queue = queue.Queue()
-                    with server._lock:
-                        for past in server._refines:  # replay history to newcomers
-                            q.put(past)
-                        server._clients.append(q)
+                    q = server.subscribe()
                     try:
                         while True:
                             data = q.get()
@@ -125,9 +139,7 @@ class SubtitleServer:
                     except (ConnectionAbortedError, ConnectionResetError, BrokenPipeError):
                         pass
                     finally:
-                        with server._lock:
-                            if q in server._clients:
-                                server._clients.remove(q)
+                        server.unsubscribe(q)
                 elif self.path == "/dashboard":
                     body = DASHBOARD_HTML.encode("utf-8")
                     self.send_response(200)

--- a/scripts/ws_ingest.py
+++ b/scripts/ws_ingest.py
@@ -1,0 +1,215 @@
+"""WebSocket audio ingest for realtime_transcribe.py's --input ws mode.
+
+Protocol:
+  1. HTTP upgrade to ws://host:port/ingest (RFC 6455 handshake).
+  2. First WS message: one JSON text frame,
+     {"sr": 16000, "format": "pcm_s16le", "channels": 1}.
+  3. After that: binary frames of raw PCM (little-endian s16), one message
+     per chunk, sent continuously for the life of the connection.
+  4. Server replies with JSON text frames carrying the same subtitle events
+     the SSE dashboard sees (partial/final/translation/refine), so a
+     stackchan-class client can show its own results if it wants to. This
+     also means audio sent to /ingest shows up on the existing /dashboard
+     and OBS overlay for free -- both read off the same SubtitleServer.
+
+Only one audio-producing client is accepted at a time; a second connection
+gets a JSON {"type": "error", ...} frame and is closed immediately, keeping
+the server dead simple (no need to mix multiple mic streams). A client that
+disconnects just leaves the ingest queue idle -- the pipeline and server
+keep running, and the next connection resumes feeding it.
+"""
+import asyncio
+import json
+import queue
+import threading
+
+import numpy as np
+
+from audio_utils import decode_pcm16, resample_linear
+from ws_protocol import (OP_BINARY, OP_CLOSE, OP_PING, OP_PONG, OP_TEXT,
+                         build_handshake_response, decode_frame, encode_frame,
+                         parse_handshake_request)
+
+READ_CHUNK = 4096
+MAX_HEADER_BYTES = 16384
+INGEST_PATH = "/ingest"
+
+# Sentinel pushed onto audio_q when a streaming client disconnects, so the
+# pipeline can flush its in-progress VAD segment instead of waiting on
+# silence that may never come once the client is gone (see
+# realtime_transcribe.run_stream(), which treats any non-ndarray item on the
+# queue as "flush now"). Any object works; identity is never compared.
+FLUSH = object()
+
+
+class IngestServer:
+    """Accepts PCM over a WS connection, exposes it as a chunk queue.
+
+    `audio_q` yields whatever-sized float32 mono arrays the network handed
+    us, already resampled to `sample_rate`; realtime_transcribe.py's
+    ws_chunks() re-chunks that into fixed VAD windows.
+    """
+
+    def __init__(self, host: str, port: int, sample_rate: int = 16000, subtitle_server=None):
+        self.host = host
+        self.port = port
+        self.sample_rate = sample_rate
+        self.subtitle_server = subtitle_server
+        self.audio_q: "queue.Queue[np.ndarray]" = queue.Queue()
+        self._active = False
+        self._lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def start(self) -> "IngestServer":
+        ready = threading.Event()
+        error: list[Exception] = []
+
+        def run():
+            try:
+                self._loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self._loop)
+                self._loop.create_task(self._serve(ready))
+                self._loop.run_forever()
+            except Exception as exc:  # surfaced to the caller via ready.wait
+                error.append(exc)
+                ready.set()
+
+        threading.Thread(target=run, daemon=True, name="ws-ingest").start()
+        ready.wait(timeout=5)
+        if error:
+            raise error[0]
+        return self
+
+    async def _serve(self, ready: threading.Event):
+        server = await asyncio.start_server(self._handle, self.host, self.port)
+        ready.set()
+        async with server:
+            await server.serve_forever()
+
+    async def _read_handshake_head(self, reader: asyncio.StreamReader) -> bytes | None:
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            chunk = await reader.read(READ_CHUNK)
+            if not chunk:
+                return None
+            buf += chunk
+            if len(buf) > MAX_HEADER_BYTES:  # runaway header: bail
+                return None
+        return buf.split(b"\r\n\r\n", 1)[0]
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            head = await self._read_handshake_head(reader)
+            if head is None:
+                writer.close()
+                return
+            req = parse_handshake_request(head)
+            if req is None or req["path"] != INGEST_PATH:
+                writer.write(b"HTTP/1.1 404 Not Found\r\n\r\n")
+                await writer.drain()
+                writer.close()
+                return
+            writer.write(build_handshake_response(req["key"]))
+            await writer.drain()
+        except (ConnectionError, asyncio.IncompleteReadError, OSError):
+            writer.close()
+            return
+
+        with self._lock:
+            if self._active:
+                try:
+                    await self._send_json(writer, {"type": "error",
+                                                    "message": "already streaming; only one audio "
+                                                               "client is accepted at a time"})
+                except (ConnectionError, OSError):
+                    pass
+                writer.close()
+                return
+            self._active = True
+
+        forward_task = None
+        got_handshake = False
+        try:
+            if self.subtitle_server is not None:
+                forward_task = asyncio.ensure_future(self._forward_events(writer))
+
+            buf = bytearray()
+            channels = 1
+            src_rate = self.sample_rate
+
+            while True:
+                data = await reader.read(READ_CHUNK)
+                if not data:
+                    break
+                buf += data
+                while True:
+                    result = decode_frame(bytes(buf))
+                    if result is None:
+                        break
+                    opcode, payload, consumed = result
+                    del buf[:consumed]
+
+                    if opcode == OP_CLOSE:
+                        return
+                    elif opcode == OP_PING:
+                        writer.write(encode_frame(payload, opcode=OP_PONG))
+                        await writer.drain()
+                    elif opcode == OP_PONG:
+                        pass
+                    elif opcode == OP_TEXT and not got_handshake:
+                        try:
+                            cfg = json.loads(payload.decode("utf-8"))
+                            src_rate = int(cfg.get("sr", self.sample_rate))
+                            channels = max(1, int(cfg.get("channels", 1)))
+                            fmt = cfg.get("format", "pcm_s16le")
+                        except (ValueError, UnicodeDecodeError, TypeError):
+                            await self._send_json(writer, {"type": "error",
+                                                            "message": "bad handshake JSON"})
+                            return
+                        if fmt != "pcm_s16le":
+                            await self._send_json(writer, {"type": "error",
+                                                            "message": f"unsupported format "
+                                                                       f"{fmt!r}, only pcm_s16le"})
+                            return
+                        got_handshake = True
+                        await self._send_json(writer, {"type": "ready", "sr": self.sample_rate})
+                    elif opcode == OP_BINARY:
+                        if not got_handshake:
+                            continue  # audio before the JSON handshake: drop and wait
+                        samples = decode_pcm16(payload, channels)
+                        if len(samples) == 0:
+                            continue
+                        if src_rate != self.sample_rate:
+                            samples = resample_linear(samples, src_rate, self.sample_rate)
+                        self.audio_q.put(samples)
+                    # OP_TEXT after handshake / OP_CONT: ignored, not part of this protocol
+        except (ConnectionError, asyncio.IncompleteReadError, OSError):
+            pass
+        finally:
+            if forward_task is not None:
+                forward_task.cancel()
+            with self._lock:
+                self._active = False
+            if got_handshake:
+                self.audio_q.put(FLUSH)
+            writer.close()
+
+    async def _send_json(self, writer: asyncio.StreamWriter, obj: dict):
+        data = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        writer.write(encode_frame(data, opcode=OP_TEXT))
+        await writer.drain()
+
+    async def _forward_events(self, writer: asyncio.StreamWriter):
+        """Mirror the SubtitleServer's broadcast (partial/final/...) onto
+        this WS connection, the same events the SSE dashboard receives."""
+        q = self.subtitle_server.subscribe()
+        loop = asyncio.get_event_loop()
+        try:
+            while True:
+                data = await loop.run_in_executor(None, q.get)
+                writer.write(encode_frame(data.encode("utf-8"), opcode=OP_TEXT))
+                await writer.drain()
+        except (ConnectionError, asyncio.CancelledError, OSError):
+            pass
+        finally:
+            self.subtitle_server.unsubscribe(q)

--- a/scripts/ws_mic_client.py
+++ b/scripts/ws_mic_client.py
@@ -1,0 +1,154 @@
+"""Reference client for hayamimi's --input ws /ingest endpoint.
+
+Streams a local wav file at real-time pace over a raw WebSocket connection
+and prints whatever subtitle events come back. This is both the smoke-test
+client used against realtime_transcribe.py --input ws, and a template for a
+future phone or stackchan/ESP32 client: the wire protocol (ws_protocol.py)
+needs no websocket library, just a plain TCP socket.
+
+Usage:
+    python scripts/ws_mic_client.py --wav testdata/eval_real/ja_01.wav \
+        --host 127.0.0.1 --port 8766
+"""
+import argparse
+import base64
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import wave
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+from ws_protocol import (OP_BINARY, OP_CLOSE, OP_TEXT, build_handshake_request,
+                         decode_frame, encode_frame)
+
+CHUNK_S = 0.1  # seconds of audio per network frame
+
+
+def ws_connect(host: str, port: int, path: str, timeout: float = 10.0) -> socket.socket:
+    sock = socket.create_connection((host, port), timeout=timeout)
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    sock.sendall(build_handshake_request(host, port, path, key))
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        data = sock.recv(4096)
+        if not data:
+            raise ConnectionError("server closed the connection during handshake")
+        buf += data
+    status_line = buf.split(b"\r\n", 1)[0]
+    if b"101" not in status_line:
+        raise ConnectionError(f"handshake failed: {status_line!r}")
+    return sock
+
+
+def recv_events(sock: socket.socket, stop: threading.Event, events: list):
+    buf = bytearray()
+    sock.settimeout(0.5)
+    while not stop.is_set():
+        try:
+            data = sock.recv(4096)
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        if not data:
+            break
+        buf += data
+        while True:
+            result = decode_frame(bytes(buf))
+            if result is None:
+                break
+            opcode, payload, consumed = result
+            del buf[:consumed]
+            if opcode == OP_TEXT:
+                text = payload.decode("utf-8")
+                events.append(text)
+                print("<-", text)
+            elif opcode == OP_CLOSE:
+                stop.set()
+                return
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--wav", required=True, help="16-bit PCM wav file to stream")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8766)
+    ap.add_argument("--path", default="/ingest")
+    ap.add_argument("--no-realtime", action="store_true",
+                    help="send the whole file as fast as possible instead of at playback pace")
+    ap.add_argument("--wait-final", type=float, default=8.0,
+                    help="seconds to keep listening for events after the file finishes sending")
+    ap.add_argument("--tail-silence", type=float, default=1.5, metavar="SEC",
+                    help="seconds of silence to stream after the file, so the server's VAD sees "
+                         "an actual pause and finalizes while we're still connected -- a real "
+                         "mic-always-on client (phone/ESP32) does this implicitly; a one-shot "
+                         "clip needs it spelled out, or the last utterance only finalizes once "
+                         "we disconnect and it's too late for us to hear the result")
+    args = ap.parse_args()
+
+    with wave.open(args.wav, "rb") as f:
+        sr = f.getframerate()
+        channels = f.getnchannels()
+        assert f.getsampwidth() == 2, "expected 16-bit PCM wav"
+        pcm = f.readframes(f.getnframes())
+
+    sock = ws_connect(args.host, args.port, args.path)
+    print(f"connected to ws://{args.host}:{args.port}{args.path}", file=sys.stderr)
+
+    events: list = []
+    stop = threading.Event()
+    listener = threading.Thread(target=recv_events, args=(sock, stop, events), daemon=True)
+    listener.start()
+
+    handshake = json.dumps({"sr": sr, "format": "pcm_s16le", "channels": channels})
+    sock.sendall(encode_frame(handshake.encode("utf-8"), opcode=OP_TEXT, mask=True))
+
+    bytes_per_s = sr * channels * 2
+    chunk_bytes = max(2, int(bytes_per_s * CHUNK_S))
+    chunk_bytes -= chunk_bytes % 2
+    # a real mic-always-on client (phone/ESP32) keeps streaming through
+    # silence too, which is what lets the server's VAD ever see a pause and
+    # finalize; append some so a one-shot clip behaves the same way instead
+    # of just stopping mid-utterance from the VAD's point of view.
+    payload = pcm + b"\x00" * (int(bytes_per_s * args.tail_silence) // 2 * 2)
+    start = time.perf_counter()
+    sent = 0
+    pos = 0
+    while pos < len(payload):
+        chunk = payload[pos:pos + chunk_bytes]
+        sock.sendall(encode_frame(chunk, opcode=OP_BINARY, mask=True))
+        pos += len(chunk)
+        sent += len(chunk)
+        if not args.no_realtime:
+            target = start + sent / bytes_per_s
+            delay = target - time.perf_counter()
+            if delay > 0:
+                time.sleep(delay)
+    print(f"sent {len(pcm)} bytes of PCM ({len(pcm) / bytes_per_s:.1f}s audio) "
+          f"+ {args.tail_silence:.1f}s trailing silence", file=sys.stderr)
+
+    time.sleep(args.wait_final)
+    stop.set()
+    try:
+        sock.sendall(encode_frame(b"", opcode=OP_CLOSE, mask=True))
+    except OSError:
+        pass
+    sock.close()
+
+    parsed = [json.loads(e) for e in events]
+    finals = [e for e in parsed if e.get("type") == "final"]
+    refines = [e for e in parsed if e.get("type") == "refine"]
+    print(f"received {len(events)} events: {len(finals)} final(s), {len(refines)} refine(s)",
+          file=sys.stderr)
+    for e in finals:
+        print(f"  final [{e.get('lang')}] {e.get('text')}")
+    for e in refines:
+        print(f"  refine [{e.get('lang')}] {e.get('text')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ws_protocol.py
+++ b/scripts/ws_protocol.py
@@ -1,0 +1,138 @@
+"""Minimal RFC 6455 WebSocket framing/handshake -- no external ws library.
+
+hayamimi's ingest endpoint targets bare-metal clients (ESP32 firmware) that
+won't carry a full websocket stack, so both the server (ws_ingest.py) and
+the reference test client (ws_mic_client.py) implement only the subset that
+matters here: single, unfragmented text/binary/close/ping/pong frames, no
+compression, no extensions. This is intentionally not a general-purpose
+WebSocket implementation.
+"""
+import base64
+import hashlib
+import os
+import struct
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+OP_CONT = 0x0
+OP_TEXT = 0x1
+OP_BINARY = 0x2
+OP_CLOSE = 0x8
+OP_PING = 0x9
+OP_PONG = 0xA
+
+
+def compute_accept_key(client_key: str) -> str:
+    digest = hashlib.sha1((client_key + WS_GUID).encode("ascii")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def parse_handshake_request(head: bytes) -> dict | None:
+    """Parse an HTTP upgrade request's head (everything before the blank
+    line that ends the headers) into {"method", "path", "key"}, or None if
+    it isn't a usable WebSocket upgrade request.
+    """
+    try:
+        text = head.decode("iso-8859-1")
+    except UnicodeDecodeError:
+        return None
+    lines = text.split("\r\n")
+    if not lines or not lines[0]:
+        return None
+    parts = lines[0].split()
+    if len(parts) < 2:
+        return None
+    method, path = parts[0], parts[1]
+    headers = {}
+    for line in lines[1:]:
+        if not line or ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        headers[k.strip().lower()] = v.strip()
+    if headers.get("upgrade", "").lower() != "websocket":
+        return None
+    key = headers.get("sec-websocket-key")
+    if not key:
+        return None
+    return {"method": method, "path": path, "key": key}
+
+
+def build_handshake_response(client_key: str) -> bytes:
+    accept = compute_accept_key(client_key)
+    return (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+    ).encode("ascii")
+
+
+def build_handshake_request(host: str, port: int, path: str, key: str) -> bytes:
+    return (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    ).encode("ascii")
+
+
+def encode_frame(payload: bytes, opcode: int = OP_BINARY, mask: bool = False) -> bytes:
+    """Build one complete, unfragmented WS frame.
+
+    `mask=True` for client->server frames -- RFC 6455 requires clients to
+    mask every frame they send; servers must not mask theirs.
+    """
+    fin_opcode = 0x80 | (opcode & 0x0F)
+    length = len(payload)
+    if length < 126:
+        header = bytes([fin_opcode, length | (0x80 if mask else 0)])
+    elif length < 65536:
+        header = bytes([fin_opcode, 126 | (0x80 if mask else 0)]) + struct.pack(">H", length)
+    else:
+        header = bytes([fin_opcode, 127 | (0x80 if mask else 0)]) + struct.pack(">Q", length)
+    if not mask:
+        return header + payload
+    mask_key = os.urandom(4)
+    masked = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+    return header + mask_key + masked
+
+
+def decode_frame(buf: bytes):
+    """Try to decode one frame from the front of `buf`.
+
+    Returns (opcode, payload, consumed_bytes) on success, or None if `buf`
+    doesn't yet hold a complete frame. The caller drops `consumed_bytes`
+    from the front of its buffer and calls again in case more than one
+    frame arrived in the same read.
+    """
+    if len(buf) < 2:
+        return None
+    b0, b1 = buf[0], buf[1]
+    opcode = b0 & 0x0F
+    masked = bool(b1 & 0x80)
+    length = b1 & 0x7F
+    pos = 2
+    if length == 126:
+        if len(buf) < pos + 2:
+            return None
+        length = struct.unpack(">H", buf[pos:pos + 2])[0]
+        pos += 2
+    elif length == 127:
+        if len(buf) < pos + 8:
+            return None
+        length = struct.unpack(">Q", buf[pos:pos + 8])[0]
+        pos += 8
+    mask_key = b""
+    if masked:
+        if len(buf) < pos + 4:
+            return None
+        mask_key = buf[pos:pos + 4]
+        pos += 4
+    if len(buf) < pos + length:
+        return None
+    payload = buf[pos:pos + length]
+    if masked:
+        payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+    return opcode, bytes(payload), pos + length

--- a/tests/test_ws_ingest.py
+++ b/tests/test_ws_ingest.py
@@ -1,0 +1,183 @@
+"""Unit tests for the WS ingest protocol's pure functions: handshake parsing,
+frame encode/decode, PCM decode, and resampling. No network, no models.
+
+Run with: .venv/Scripts/python -m pytest tests -q
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+
+from audio_utils import decode_pcm16, resample_linear
+from ws_protocol import (OP_BINARY, OP_CLOSE, OP_PING, OP_TEXT, build_handshake_request,
+                         build_handshake_response, compute_accept_key, decode_frame,
+                         encode_frame, parse_handshake_request)
+
+# ---- handshake --------------------------------------------------------------
+
+# RFC 6455 section 1.3 worked example.
+RFC_KEY = "dGhlIHNhbXBsZSBub25jZQ=="
+RFC_ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+
+
+def test_compute_accept_key_matches_rfc_example():
+    assert compute_accept_key(RFC_KEY) == RFC_ACCEPT
+
+
+def test_parse_handshake_request_extracts_path_and_key():
+    req = (b"GET /ingest HTTP/1.1\r\n"
+           b"Host: localhost:8766\r\n"
+           b"Upgrade: websocket\r\n"
+           b"Connection: Upgrade\r\n" +
+           f"Sec-WebSocket-Key: {RFC_KEY}\r\n".encode("ascii") +
+           b"Sec-WebSocket-Version: 13\r\n")
+    parsed = parse_handshake_request(req)
+    assert parsed is not None
+    assert parsed["path"] == "/ingest"
+    assert parsed["key"] == RFC_KEY
+
+
+def test_parse_handshake_request_rejects_non_websocket():
+    req = b"GET /ingest HTTP/1.1\r\nHost: localhost\r\n"
+    assert parse_handshake_request(req) is None
+
+
+def test_parse_handshake_request_rejects_missing_key():
+    req = b"GET /ingest HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+    assert parse_handshake_request(req) is None
+
+
+def test_build_handshake_response_contains_correct_accept():
+    resp = build_handshake_response(RFC_KEY)
+    assert b"101" in resp
+    assert RFC_ACCEPT.encode("ascii") in resp
+
+
+def test_build_handshake_request_roundtrips_through_parse():
+    req = build_handshake_request("127.0.0.1", 8766, "/ingest", RFC_KEY)
+    parsed = parse_handshake_request(req)
+    assert parsed["path"] == "/ingest"
+    assert parsed["key"] == RFC_KEY
+
+
+# ---- frame encode/decode ----------------------------------------------------
+
+def test_frame_roundtrip_unmasked_binary():
+    payload = bytes(range(256)) * 4  # > 126 bytes, exercises 16-bit length
+    frame = encode_frame(payload, opcode=OP_BINARY, mask=False)
+    result = decode_frame(frame)
+    assert result is not None
+    opcode, out, consumed = result
+    assert opcode == OP_BINARY
+    assert out == payload
+    assert consumed == len(frame)
+
+
+def test_frame_roundtrip_masked_text():
+    payload = '{"sr": 16000, "format": "pcm_s16le", "channels": 1}'.encode("utf-8")
+    frame = encode_frame(payload, opcode=OP_TEXT, mask=True)
+    opcode, out, consumed = decode_frame(frame)
+    assert opcode == OP_TEXT
+    assert out == payload
+    assert consumed == len(frame)
+
+
+def test_frame_masked_bytes_differ_from_plaintext_on_wire():
+    payload = b"\x00" * 32  # all-zero payload would be trivially unmasked otherwise
+    frame = encode_frame(payload, opcode=OP_BINARY, mask=True)
+    header_len = 2 + 4  # short length + 4-byte mask key
+    assert frame[header_len:] != payload  # masked on the wire
+    assert decode_frame(frame)[1] == payload  # but decodes back correctly
+
+
+def test_decode_frame_incomplete_returns_none():
+    payload = b"x" * 50
+    frame = encode_frame(payload, opcode=OP_BINARY)
+    assert decode_frame(frame[:5]) is None
+
+
+def test_decode_frame_two_frames_in_one_buffer():
+    f1 = encode_frame(b"one", opcode=OP_TEXT)
+    f2 = encode_frame(b"two", opcode=OP_TEXT)
+    buf = f1 + f2
+    opcode1, payload1, consumed1 = decode_frame(buf)
+    assert (opcode1, payload1) == (OP_TEXT, b"one")
+    opcode2, payload2, consumed2 = decode_frame(buf[consumed1:])
+    assert (opcode2, payload2) == (OP_TEXT, b"two")
+    assert consumed1 + consumed2 == len(buf)
+
+
+def test_decode_frame_large_payload_uses_64bit_length():
+    payload = b"z" * 70000  # forces the 127 / 64-bit extended length form
+    frame = encode_frame(payload, opcode=OP_BINARY)
+    opcode, out, consumed = decode_frame(frame)
+    assert opcode == OP_BINARY
+    assert len(out) == 70000
+    assert consumed == len(frame)
+
+
+def test_frame_close_and_ping_opcodes_roundtrip():
+    for op in (OP_CLOSE, OP_PING):
+        frame = encode_frame(b"", opcode=op)
+        opcode, payload, _ = decode_frame(frame)
+        assert opcode == op
+        assert payload == b""
+
+
+# ---- PCM decode --------------------------------------------------------------
+
+def test_decode_pcm16_mono_roundtrip():
+    src = np.array([0, 16384, -16384, 32767, -32768], dtype=np.int16)
+    out = decode_pcm16(src.tobytes(), channels=1)
+    expected = src.astype(np.float32) / 32768.0
+    np.testing.assert_allclose(out, expected, atol=1e-6)
+
+
+def test_decode_pcm16_drops_trailing_odd_byte():
+    src = np.array([100, 200], dtype=np.int16).tobytes() + b"\x7f"  # one stray byte
+    out = decode_pcm16(src, channels=1)
+    assert len(out) == 2  # stray trailing byte silently dropped, no crash
+
+
+def test_decode_pcm16_averages_stereo_to_mono():
+    # interleaved L/R: (1000, -1000) pairs -> average 0 for every frame
+    src = np.array([1000, -1000, 2000, -2000], dtype=np.int16)
+    out = decode_pcm16(src.tobytes(), channels=2)
+    assert len(out) == 2
+    np.testing.assert_allclose(out, [0.0, 0.0], atol=1e-6)
+
+
+def test_decode_pcm16_empty_input():
+    assert len(decode_pcm16(b"", channels=1)) == 0
+
+
+# ---- resampling ---------------------------------------------------------------
+
+def test_resample_linear_identity_when_rates_match():
+    samples = np.arange(10, dtype=np.float32)
+    out = resample_linear(samples, 16000, 16000)
+    np.testing.assert_array_equal(out, samples)
+
+
+def test_resample_linear_upsamples_to_expected_length():
+    samples = np.zeros(8000, dtype=np.float32)  # 1s @ 8kHz
+    out = resample_linear(samples, 8000, 16000)
+    assert len(out) == 16000  # 1s @ 16kHz
+
+
+def test_resample_linear_downsamples_to_expected_length():
+    samples = np.zeros(48000, dtype=np.float32)  # 1s @ 48kHz
+    out = resample_linear(samples, 48000, 16000)
+    assert len(out) == 16000
+
+
+def test_resample_linear_preserves_a_ramp_shape():
+    # a linear ramp resampled linearly should still be (close to) linear
+    samples = np.linspace(0.0, 1.0, 1600, dtype=np.float32)  # 0.1s @ 16kHz
+    out = resample_linear(samples, 16000, 8000)
+    assert len(out) == 800
+    np.testing.assert_allclose(out[0], 0.0, atol=1e-3)
+    np.testing.assert_allclose(out[-1], 1.0, atol=1e-2)


### PR DESCRIPTION
## What

- New `--input ws` mode: a LAN device (ESP32 robot, phone) streams mic audio to hayamimi over WebSocket (`/ingest`) and the transcription flows through the normal pipeline, fanning out to the existing dashboard / OBS overlay.
- Dependency-free RFC 6455 subset (`scripts/ws_protocol.py`) so bare-metal firmware can speak it without a WebSocket library.
- Reference client `scripts/ws_mic_client.py` (streams a wav at real-time pace) doubles as the template for phone/ESP32 clients.
- **Default `--serve` port changed 8765 → 8833** (8=ha, 8=ya, 33=mimi). Existing OBS browser-source URLs need updating, or pass `--serve 8765`.

## Verification

- pytest 44/44 (21 new protocol/PCM/resample tests)
- End-to-end smoke: streamed `testdata/eval_real/ja_01.wav` through `/ingest`, received the correct final transcript on both the WS connection and the `/dashboard` SSE stream.
- Found and fixed during testing: a WS-fed utterance with no trailing silence never finalized (VAD closes on silence only) — client disconnect now pushes a FLUSH sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket audio input for real-time transcription.
  * Added support for microphone, WAV, or WebSocket input selection.
  * Added configurable WebSocket host and port settings.
  * Added a reference client for streaming WAV audio and receiving subtitle events.
  * Added PCM decoding, channel mixing, and audio resampling support.

* **Documentation**
  * Updated setup instructions, protocol details, CLI options, and dashboard URLs.
  * Updated the default server port from 8765 to 8833.

* **Bug Fixes**
  * Improved stream finalization when an audio client disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->