### PR TITLE
Stack-chan (M5Stack CoreS3) firmware client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ session.txt
 Thumbs.db
 .claude/
 .playwright-mcp/
+
+# firmware/stackchan (PlatformIO)
+firmware/stackchan/.pio/
+firmware/stackchan/include/config.h

--- a/firmware/stackchan/README.md
+++ b/firmware/stackchan/README.md
@@ -1,0 +1,120 @@
+# hayamimi stackchan client (M5Stack CoreS3)
+
+Streams the CoreS3's built-in mic to hayamimi's `/ingest` WebSocket and
+shows the returned subtitles on screen. Single board, no wiring required.
+
+## Build / flash
+
+Requires [PlatformIO](https://platformio.org/) (`pip install platformio`).
+
+```
+cd firmware/stackchan
+cp include/config.h.example include/config.h   # then edit config.h
+pio run                 # build
+pio run -t upload       # build + flash (board connected over USB)
+pio device monitor       # serial log, 115200 baud
+```
+
+`config.h` is gitignored -- it holds your Wi-Fi credentials and the
+hayamimi server address, so it's never committed.
+
+## Configuration (`include/config.h`)
+
+| Macro | Meaning |
+|---|---|
+| `WIFI_SSID` / `WIFI_PASSWORD` | Wi-Fi the CoreS3 joins |
+| `HAYAMIMI_HOST` | IP/hostname of the machine running hayamimi |
+| `HAYAMIMI_PORT` | hayamimi's `/ingest` WS port -- **default 8766**, not the dashboard port (see below) |
+| `HAYAMIMI_PATH` | always `/ingest` |
+
+## Running hayamimi
+
+On the machine hayamimi runs on:
+
+```
+python scripts/realtime_transcribe.py --input ws --serve
+```
+
+- `--input ws` opens the `/ingest` WebSocket the firmware streams PCM to.
+  It binds `--ws-host` (default `0.0.0.0`) : `--ws-port` (default
+  **8766**) -- point `HAYAMIMI_PORT` at this port.
+- `--serve` (bare, defaults to port 8833) additionally starts the
+  SSE dashboard/OBS-overlay HTTP server on a *separate* port. It's
+  optional for the firmware itself -- audio sent to `/ingest` is
+  broadcast to both the WS reply frames the firmware reads and the
+  dashboard, off the same `SubtitleServer`, so `--serve` is only useful
+  if you also want to watch the dashboard in a browser at the same time.
+
+If both ports collide with something else on your network, pass
+`--ws-port <port>` and update `HAYAMIMI_PORT` to match.
+
+## Protocol
+
+Implemented from `../../scripts/ws_protocol.py` and
+`../../scripts/ws_ingest.py`, which are the source of truth -- do not
+change the framing here without checking those first.
+
+1. RFC 6455 WebSocket handshake to `ws://HAYAMIMI_HOST:HAYAMIMI_PORT/ingest`.
+2. First frame: one JSON text frame `{"sr":16000,"format":"pcm_s16le","channels":1}`.
+3. After that: binary frames of raw little-endian s16 PCM, sent
+   continuously (including silence) for the life of the connection --
+   the server's VAD needs to see actual pauses to finalize utterances.
+4. Server replies with JSON text frames: `partial`, `final`,
+   `translation`, `refine`, `ready`, `error`. The firmware shows `final`
+   text as the main subtitle, `partial` dimmed underneath it, `refine`
+   text replaces the last `final`, and `translation`/`error` show briefly
+   in the status line.
+
+## WebSocket library
+
+[`links2004/WebSockets`](https://github.com/Links2004/arduinoWebSockets)
+(PlatformIO registry name `links2004/WebSockets`), not
+`gilmaimon/ArduinoWebsockets`. Reasons:
+
+- Built-in reconnect handling (`setReconnectInterval`) -- this is an
+  always-on mic client, so losing and regaining Wi-Fi/AP needs to be a
+  non-event, not something the app has to hand-roll.
+- Callback shape (`WStype_t type, uint8_t* payload, size_t length`)
+  cleanly separates `WStype_TEXT` (server's JSON events) from
+  `WStype_BINARY`/outgoing `sendBIN` for PCM, matching this protocol's
+  text-then-binary-frames shape without extra plumbing.
+- Long, stable maintenance history and wide usage on ESP32 Arduino
+  projects, including other M5Stack builds.
+
+`links2004/WebSockets` masks outgoing client frames automatically, which
+is what `ws_protocol.py`'s server-side `decode_frame` requires (RFC 6455:
+clients must mask, servers must not).
+
+## Architecture
+
+- `micTask` (FreeRTOS task pinned to core 0): blocking
+  `M5.Mic.record()` calls, one 100ms/3200-sample chunk at a time, sent
+  via `webSocket.sendBIN()` once the WS is connected and the JSON
+  handshake has been sent.
+- `loop()` (core 1, Arduino default): `webSocket.loop()` (drives
+  reconnect + incoming frame parsing) and Wi-Fi reconnect checks.
+- A mutex (`wsMutex`) guards every `webSocket.*` call since it's touched
+  from both tasks; `WebSocketsClient` itself isn't documented as
+  thread-safe.
+- Display: an `M5Canvas` off-screen sprite is redrawn and pushed on every
+  status/subtitle change (avoids flicker vs. drawing straight to the
+  panel). Japanese text uses the bundled `lgfxJapanGothic` fonts (M5GFX).
+
+## Known limitations / what still needs real hardware
+
+This was built and build-verified on Windows without a physical CoreS3 --
+no on-device testing was possible in this environment. Before trusting it
+end-to-end, still verify on real hardware:
+
+- Actual mic quality/gain -- `M5.Mic.config()` defaults were used as-is;
+  levels may need tuning against a real room.
+- Screen must stay on for the firmware to be useful (no attempt is made
+  to keep the display awake beyond M5Unified's defaults) -- if CoreS3
+  auto-dims/sleeps the panel, subtitles stop being visible even though
+  streaming keeps running.
+- Real Wi-Fi drop/reconnect behavior (`setReconnectInterval` + the
+  `loop()`-level Wi-Fi status check are untested against actual AP
+  roaming/dropouts).
+- Long-run stability (memory, task scheduling) hasn't been soak-tested.
+- `M5Canvas`/`lgfxJapanGothic` font rendering was only checked by reading
+  M5GFX's API, not by seeing actual glyphs on a panel.

--- a/firmware/stackchan/include/config.h.example
+++ b/firmware/stackchan/include/config.h.example
@@ -1,0 +1,15 @@
+// Copy this file to config.h (same directory) and fill in your own values.
+// config.h is gitignored -- never commit real Wi-Fi credentials.
+#pragma once
+
+// --- Wi-Fi ---
+#define WIFI_SSID "your-ssid"
+#define WIFI_PASSWORD "your-password"
+
+// --- hayamimi /ingest endpoint ---
+// Run hayamimi with:  python scripts/realtime_transcribe.py --input ws --serve
+// The ws /ingest server listens on --ws-port (default 8766), separate from
+// the --serve dashboard port (default 8833). Point this at --ws-port.
+#define HAYAMIMI_HOST "192.168.1.100"
+#define HAYAMIMI_PORT 8766
+#define HAYAMIMI_PATH "/ingest"

--- a/firmware/stackchan/platformio.ini
+++ b/firmware/stackchan/platformio.ini
@@ -1,0 +1,22 @@
+; PlatformIO project for hayamimi's stackchan (M5Stack CoreS3) client.
+;
+; Streams the CoreS3's built-in mic (16kHz mono PCM) to hayamimi's /ingest
+; WebSocket endpoint and shows the returned subtitles on the display.
+; See ../../scripts/ws_protocol.py and ../../scripts/ws_ingest.py for the
+; authoritative wire protocol this firmware implements.
+
+[env:m5stack-cores3]
+platform = espressif32
+board = m5stack-cores3
+framework = arduino
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+
+lib_deps =
+    m5stack/M5Unified@^0.2.2
+    links2004/WebSockets@^2.7.3
+    bblanchon/ArduinoJson@^7.2.0
+
+build_flags =
+    -DCORE_DEBUG_LEVEL=1
+    -DBOARD_HAS_PSRAM

--- a/firmware/stackchan/src/main.cpp
+++ b/firmware/stackchan/src/main.cpp
@@ -87,7 +87,23 @@ void setStatus(const String &s) {
 }
 
 void handleEventJson(const uint8_t *payload, size_t len) {
-  JsonDocument doc;
+  // Reused across calls instead of a fresh JsonDocument per event: this
+  // fires once per server text frame (partial/final/refine/... -- i.e.
+  // continuously for the life of a session), and ArduinoJson v7's
+  // JsonDocument owns a heap-backed memory pool that grows on demand but
+  // is only released when the document is destroyed. A local (stack)
+  // JsonDocument would therefore malloc/free that pool on every single
+  // event, which is exactly the allocate/free churn that fragments the
+  // ESP32's heap over a long-running session. `static` keeps one instance
+  // (and its already-grown pool) alive for the process's lifetime, and
+  // clear() below empties its contents without releasing the pool, so
+  // steady-state parsing does no allocation at all. Safe as a function-
+  // static here because handleEventJson only ever runs on the main loop()
+  // task (via webSocketEvent() <- webSocket.loop(), see loop()) -- never
+  // from micTask on the other core -- so there's no concurrent access to
+  // guard against.
+  static JsonDocument doc;
+  doc.clear();
   if (deserializeJson(doc, payload, len)) return; // malformed frame: drop silently
 
   const char *type = doc["type"] | "";

--- a/firmware/stackchan/src/main.cpp
+++ b/firmware/stackchan/src/main.cpp
@@ -43,6 +43,11 @@ SemaphoreHandle_t displayMutex; // guards canvas draw + push
 
 volatile bool wsConnected = false;
 volatile bool handshakeSent = false;
+// Set by webSocketEvent(WStype_CONNECTED) (called synchronously from inside
+// webSocket.loop(), i.e. while loop() already holds wsMutex) and consumed by
+// loop() itself, once wsMutex has been released. See sendHandshake() for why
+// the handshake can't be sent directly from the event callback.
+volatile bool needHandshake = false;
 
 M5Canvas canvas(&M5.Display);
 
@@ -110,6 +115,12 @@ void handleEventJson(const uint8_t *payload, size_t len) {
   // other event types (e.g. session_start) are ignored
 }
 
+// IMPORTANT: never call this from inside webSocketEvent() (or anywhere else
+// that may already hold wsMutex). webSocketEvent() is invoked synchronously
+// from within webSocket.loop(), which loop() calls while holding wsMutex;
+// since wsMutex is a plain (non-recursive) mutex, taking it again here would
+// deadlock loop() forever. Callers must already hold wsMutex, or -- as
+// loop() does -- call this only after releasing it.
 void sendHandshake() {
   JsonDocument doc;
   doc["sr"] = SAMPLE_RATE;
@@ -126,12 +137,17 @@ void sendHandshake() {
 }
 
 void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
+  // NOTE: this callback fires synchronously from inside webSocket.loop(),
+  // which loop() calls while holding wsMutex. Never take wsMutex from here
+  // (directly or via a function like sendHandshake()) -- it would deadlock
+  // against loop(). Defer any such work with a flag that loop() polls after
+  // releasing wsMutex (see needHandshake below).
   switch (type) {
     case WStype_CONNECTED:
       wsConnected = true;
       handshakeSent = false;
+      needHandshake = true;
       setStatus("ws connected, handshaking...");
-      sendHandshake();
       break;
     case WStype_DISCONNECTED:
       wsConnected = false;
@@ -227,6 +243,14 @@ void loop() {
   if (xSemaphoreTake(wsMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
     webSocket.loop();
     xSemaphoreGive(wsMutex);
+  }
+
+  // Handled here, after releasing wsMutex, because webSocketEvent() may have
+  // set this from inside the webSocket.loop() call above while wsMutex was
+  // still held -- see the comment on sendHandshake().
+  if (needHandshake) {
+    needHandshake = false;
+    sendHandshake();
   }
 
   delay(2);

--- a/firmware/stackchan/src/main.cpp
+++ b/firmware/stackchan/src/main.cpp
@@ -1,0 +1,233 @@
+// hayamimi stackchan client (M5Stack CoreS3)
+//
+// Captures the CoreS3's built-in mic at 16kHz mono and streams it over a
+// raw WebSocket to hayamimi's /ingest endpoint, then shows the returned
+// subtitle events (partial/final/refine/translation) on the display.
+//
+// Wire protocol (do not change without updating the server -- see
+// ../../scripts/ws_protocol.py and ../../scripts/ws_ingest.py, which are
+// the source of truth):
+//   1. RFC 6455 WS handshake to ws://HAYAMIMI_HOST:HAYAMIMI_PORT/ingest.
+//   2. First frame: one JSON text frame {"sr":16000,"format":"pcm_s16le",
+//      "channels":1}.
+//   3. After that: binary frames of raw little-endian s16 PCM, sent
+//      continuously for the life of the connection (silence included --
+//      that's what lets the server's VAD ever see a pause and finalize).
+//   4. Server replies with JSON text frames: {"type": "partial"/"final"/
+//      "translation"/"refine"/"ready"/"error", "text": ..., ...}.
+//
+// Library choice: links2004/WebSockets (Arduino WebSockets by Links2004).
+// Picked over gilmaimon/ArduinoWebsockets because it ships built-in
+// reconnect handling (setReconnectInterval) which this always-on mic
+// client needs, has a stable long-running maintenance history, and its
+// callback signature (WStype_t, payload, length) cleanly separates text
+// vs. binary frames, matching this protocol's text-then-binary shape.
+#include <M5Unified.h>
+#include <WiFi.h>
+#include <WebSocketsClient.h>
+#include <ArduinoJson.h>
+
+#include "config.h"
+
+namespace {
+
+constexpr uint32_t SAMPLE_RATE = 16000;
+// 100ms per chunk -- matches ws_mic_client.py's CHUNK_S, a size the server
+// side has already been exercised against.
+constexpr size_t CHUNK_SAMPLES = SAMPLE_RATE / 10;
+constexpr size_t CHUNK_BYTES = CHUNK_SAMPLES * sizeof(int16_t);
+
+WebSocketsClient webSocket;
+SemaphoreHandle_t wsMutex;      // guards all webSocket.* calls (loop/send are called from two tasks)
+SemaphoreHandle_t displayMutex; // guards canvas draw + push
+
+volatile bool wsConnected = false;
+volatile bool handshakeSent = false;
+
+M5Canvas canvas(&M5.Display);
+
+String finalText;
+String partialText;
+String statusText = "starting...";
+
+void redraw() {
+  if (xSemaphoreTake(displayMutex, pdMS_TO_TICKS(200)) != pdTRUE) return;
+
+  canvas.fillScreen(TFT_BLACK);
+
+  canvas.setFont(&fonts::lgfxJapanGothic_16);
+  canvas.setTextColor(wsConnected ? TFT_DARKGREEN : TFT_RED);
+  canvas.setCursor(4, 4);
+  canvas.println(statusText);
+
+  canvas.setFont(&fonts::lgfxJapanGothic_24);
+  canvas.setTextColor(TFT_WHITE);
+  canvas.setCursor(4, 30);
+  canvas.println(finalText);
+
+  if (partialText.length() > 0) {
+    canvas.setFont(&fonts::lgfxJapanGothic_20);
+    canvas.setTextColor(TFT_DARKGREY);
+    canvas.setCursor(4, canvas.getCursorY() + 6);
+    canvas.println(partialText);
+  }
+
+  canvas.pushSprite(0, 0);
+  xSemaphoreGive(displayMutex);
+}
+
+void setStatus(const String &s) {
+  statusText = s;
+  redraw();
+}
+
+void handleEventJson(const uint8_t *payload, size_t len) {
+  JsonDocument doc;
+  if (deserializeJson(doc, payload, len)) return; // malformed frame: drop silently
+
+  const char *type = doc["type"] | "";
+  const char *text = doc["text"] | "";
+
+  if (strcmp(type, "final") == 0) {
+    finalText = text;
+    partialText = "";
+    redraw();
+  } else if (strcmp(type, "partial") == 0) {
+    partialText = text;
+    redraw();
+  } else if (strcmp(type, "refine") == 0) {
+    // refine replaces the text of an already-shown final with a
+    // higher-quality re-decode of the same utterance.
+    finalText = text;
+    redraw();
+  } else if (strcmp(type, "translation") == 0) {
+    setStatus(String("[tr] ") + text);
+  } else if (strcmp(type, "error") == 0) {
+    setStatus(String("server: ") + (doc["message"] | ""));
+  } else if (strcmp(type, "ready") == 0) {
+    setStatus("connected");
+  }
+  // other event types (e.g. session_start) are ignored
+}
+
+void sendHandshake() {
+  JsonDocument doc;
+  doc["sr"] = SAMPLE_RATE;
+  doc["format"] = "pcm_s16le";
+  doc["channels"] = 1;
+  char buf[128];
+  size_t n = serializeJson(doc, buf, sizeof(buf));
+
+  if (xSemaphoreTake(wsMutex, portMAX_DELAY) == pdTRUE) {
+    webSocket.sendTXT(buf, n);
+    xSemaphoreGive(wsMutex);
+  }
+  handshakeSent = true;
+}
+
+void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
+  switch (type) {
+    case WStype_CONNECTED:
+      wsConnected = true;
+      handshakeSent = false;
+      setStatus("ws connected, handshaking...");
+      sendHandshake();
+      break;
+    case WStype_DISCONNECTED:
+      wsConnected = false;
+      handshakeSent = false;
+      setStatus("disconnected, reconnecting...");
+      break;
+    case WStype_TEXT:
+      handleEventJson(payload, length);
+      break;
+    case WStype_ERROR:
+      setStatus("ws error");
+      break;
+    default:
+      break;
+  }
+}
+
+void connectWifi() {
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  setStatus(String("wifi: connecting to ") + WIFI_SSID);
+  uint32_t waitStart = millis();
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(250);
+    if (millis() - waitStart > 20000) {
+      // Don't give up -- just let the user see it's still trying.
+      setStatus(String("wifi: still trying (") + WIFI_SSID + ")");
+      waitStart = millis();
+    }
+  }
+  setStatus("wifi connected, opening ws...");
+}
+
+// Runs on core 0: capture one mic chunk, send it if we have an open,
+// handshaked connection. Pinned to its own core so a blocking Mic.record()
+// call never stalls webSocket.loop() (which drives reconnects) on core 1.
+void micTask(void *) {
+  static int16_t buf[CHUNK_SAMPLES];
+  for (;;) {
+    if (!M5.Mic.isEnabled()) {
+      vTaskDelay(pdMS_TO_TICKS(200));
+      continue;
+    }
+    if (M5.Mic.record(buf, CHUNK_SAMPLES, SAMPLE_RATE)) {
+      if (wsConnected && handshakeSent) {
+        if (xSemaphoreTake(wsMutex, pdMS_TO_TICKS(500)) == pdTRUE) {
+          webSocket.sendBIN(reinterpret_cast<uint8_t *>(buf), CHUNK_BYTES);
+          xSemaphoreGive(wsMutex);
+        }
+      }
+    } else {
+      vTaskDelay(pdMS_TO_TICKS(10));
+    }
+  }
+}
+
+} // namespace
+
+void setup() {
+  wsMutex = xSemaphoreCreateMutex();
+  displayMutex = xSemaphoreCreateMutex();
+
+  auto cfg = M5.config();
+  M5.begin(cfg);
+
+  canvas.setColorDepth(8);
+  canvas.createSprite(M5.Display.width(), M5.Display.height());
+  canvas.setTextWrap(true, false);
+  redraw();
+
+  auto micCfg = M5.Mic.config();
+  micCfg.sample_rate = SAMPLE_RATE;
+  micCfg.stereo = false;
+  M5.Mic.config(micCfg);
+  M5.Mic.begin();
+
+  connectWifi();
+
+  webSocket.begin(HAYAMIMI_HOST, HAYAMIMI_PORT, HAYAMIMI_PATH);
+  webSocket.onEvent(webSocketEvent);
+  webSocket.setReconnectInterval(3000);
+
+  xTaskCreatePinnedToCore(micTask, "mic", 8192, nullptr, 2, nullptr, 0);
+}
+
+void loop() {
+  M5.update();
+
+  if (WiFi.status() != WL_CONNECTED) {
+    connectWifi();
+  }
+
+  if (xSemaphoreTake(wsMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    webSocket.loop();
+    xSemaphoreGive(wsMutex);
+  }
+
+  delay(2);
+}

--- a/firmware/stackchan/test_protocol_compat.py
+++ b/firmware/stackchan/test_protocol_compat.py
@@ -1,0 +1,139 @@
+"""Protocol compatibility check for the stackchan firmware's framing.
+
+The firmware itself doesn't run here (no ESP32 hardware in this environment
+-- see README.md's "known limitations" for what still needs a real board).
+What we *can* verify on the host is that the exact frame sequence the
+firmware's main.cpp builds -- one masked WS text frame carrying
+{"sr":16000,"format":"pcm_s16le","channels":1}, followed by masked binary
+frames of 100ms / 3200-sample s16le PCM chunks (see CHUNK_SAMPLES in
+main.cpp) -- is accepted by hayamimi's real ws_ingest.IngestServer and
+lands in its audio_q unchanged. This is scripts/ws_mic_client.py's
+sequence with the chunk size pinned to match the firmware instead of
+CHUNK_S, so any framing drift between the two clients would show up here.
+
+This does not exercise the ASR pipeline (no model load) -- IngestServer is
+used standalone, exactly as realtime_transcribe.py wires it up before
+handing audio_q to the VAD/ASR stage.
+"""
+import base64
+import json
+import os
+import socket
+import sys
+import time
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))          # firmware/stackchan
+FIRMWARE = os.path.dirname(HERE)                           # firmware
+ROOT = os.path.dirname(FIRMWARE)                            # repo root
+SCRIPTS = os.path.join(ROOT, "scripts")
+sys.path.insert(0, SCRIPTS)
+
+from ws_ingest import FLUSH, IngestServer  # noqa: E402
+from ws_protocol import (OP_BINARY, OP_TEXT, build_handshake_request,  # noqa: E402
+                          decode_frame, encode_frame)
+
+SAMPLE_RATE = 16000
+# Mirrors main.cpp: CHUNK_SAMPLES = SAMPLE_RATE / 10 (100ms chunks).
+CHUNK_SAMPLES = SAMPLE_RATE // 10
+CHUNK_BYTES = CHUNK_SAMPLES * 2  # s16le
+
+
+def ws_connect(host: str, port: int, path: str) -> socket.socket:
+    sock = socket.create_connection((host, port), timeout=10)
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    sock.sendall(build_handshake_request(host, port, path, key))
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        data = sock.recv(4096)
+        if not data:
+            raise ConnectionError("server closed during handshake")
+        buf += data
+    status_line = buf.split(b"\r\n", 1)[0]
+    assert b"101" in status_line, f"handshake failed: {status_line!r}"
+    return sock
+
+
+def recv_one_text_frame(sock: socket.socket, timeout: float = 5.0) -> dict:
+    sock.settimeout(timeout)
+    buf = bytearray()
+    while True:
+        data = sock.recv(4096)
+        if not data:
+            raise ConnectionError("server closed while waiting for a reply")
+        buf += data
+        result = decode_frame(bytes(buf))
+        if result is None:
+            continue
+        opcode, payload, consumed = result
+        del buf[:consumed]
+        assert opcode == OP_TEXT
+        return json.loads(payload.decode("utf-8"))
+
+
+def test_firmware_framing_is_accepted_by_ingest_server():
+    # IngestServer doesn't expose its bound port, so pick a free one up
+    # front rather than binding to port 0.
+    import contextlib
+    with contextlib.closing(socket.socket()) as probe:
+        probe.bind(("127.0.0.1", 0))
+        free_port = probe.getsockname()[1]
+
+    ingest = IngestServer("127.0.0.1", free_port, sample_rate=SAMPLE_RATE).start()
+    time.sleep(0.2)  # let the asyncio server actually start listening
+
+    sock = ws_connect("127.0.0.1", free_port, "/ingest")
+
+    # 1. handshake JSON text frame, masked (client->server), exactly what
+    #    main.cpp's sendHandshake() sends.
+    handshake = json.dumps({"sr": SAMPLE_RATE, "format": "pcm_s16le", "channels": 1})
+    sock.sendall(encode_frame(handshake.encode("utf-8"), opcode=OP_TEXT, mask=True))
+
+    reply = recv_one_text_frame(sock)
+    assert reply == {"type": "ready", "sr": SAMPLE_RATE}
+
+    # 2. binary PCM frames, one CHUNK_SAMPLES chunk at a time -- same shape
+    #    main.cpp's micTask()/sendBIN() calls produce.
+    rng = np.random.default_rng(0)
+    n_chunks = 5
+    chunks = [rng.integers(-30000, 30000, size=CHUNK_SAMPLES, dtype=np.int16) for _ in range(n_chunks)]
+    for chunk in chunks:
+        payload = chunk.tobytes()
+        assert len(payload) == CHUNK_BYTES
+        sock.sendall(encode_frame(payload, opcode=OP_BINARY, mask=True))
+
+    # 3. the server decodes each binary frame into audio_q as float32
+    #    mono at the target sample rate (no resampling needed here since
+    #    src_rate == server rate) -- verify every chunk arrived intact and
+    #    in order.
+    deadline = time.time() + 5
+    received = []
+    total_expected = sum(len(c) for c in chunks)
+    total_received = 0
+    while total_received < total_expected and time.time() < deadline:
+        try:
+            item = ingest.audio_q.get(timeout=0.5)
+        except Exception:
+            continue
+        if item is FLUSH:
+            continue
+        received.append(item)
+        total_received += len(item)
+
+    assert total_received == total_expected, (
+        f"expected {total_expected} samples total, got {total_received}"
+    )
+
+    got_f32 = np.concatenate(received) if received else np.array([], dtype=np.float32)
+    # IngestServer's decode_pcm16 -> float32 in [-1, 1]; scale back to
+    # int16 to compare against the chunks we sent.
+    got_i16 = np.clip(np.round(got_f32.astype(np.float64) * 32768.0), -32768, 32767).astype(np.int16)
+
+    sock.close()
+
+    sent_all = np.concatenate([c.astype(np.int64) for c in chunks])
+    # allow the float32 round-trip's quantization error of +-1 LSB
+    assert len(sent_all) == len(got_i16)
+    diff = np.abs(sent_all - got_i16.astype(np.int64))
+    assert diff.max() <= 1, f"PCM round-tripped through the server with drift > 1 LSB: {diff.max()}"


### PR DESCRIPTION
## What

`firmware/stackchan/` — a PlatformIO firmware for M5Stack CoreS3 that streams mic audio to a hayamimi PC over the `/ingest` WebSocket (`--input ws`) and renders the returned subtitles (final / dimmed partial / refine) on the display with Japanese fonts. Dual-task design: I2S mic capture on core 0, WebSocket + WiFi watchdog on core 1, auto-reconnect. WiFi/server settings go in `include/config.h` (gitignored; `config.h.example` provided).

The wire protocol is the deliberately tiny RFC 6455 subset already on main (`scripts/ws_protocol.py`), so no heavy WS stack is needed.

## Verification (Windows-only environment — no physical CoreS3)

- `pio run` (m5stack-cores3): SUCCESS — RAM 16.2%, Flash 26.3%
- Protocol compatibility: `firmware/stackchan/test_protocol_compat.py` (pytest) drives a real `ws_ingest.IngestServer` with the exact frame sequence `main.cpp` produces and verifies the PCM round-trips intact
- Code-review pass found and fixed a real mutex deadlock (handshake inside the WS event callback re-taking `wsMutex`; now deferred via flag to the loop task)

## NOT verified (needs real hardware — contributors welcome)

Mic gain/quality, display behavior, real WiFi drop/reconnect, long-run stability. Listed in the README's Known limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added M5Stack CoreS3 firmware for capturing microphone audio and streaming it to hayamimi.
  * Added on-device subtitle display with support for partial, final, refinement, translation, readiness, and error updates.
  * Added a configuration template for Wi‑Fi and hayamimi connection settings.
  * Added setup, build, flashing, and protocol documentation.

* **Tests**
  * Added compatibility coverage for audio streaming and WebSocket communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->