### PR TITLE
eval: unified FLEURS 5x100 head-to-head benchmark (scripts + results)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -550,7 +550,11 @@ faster-whisper large-v3-turbo を5言語×100本、直接比較した。
 （err: en=WER、他=CER。yueはt2s正規化後。RTF = 処理時間 / 音声長、小さいほど速い。）
 
 - **速度**: hayamimiがturboの約12〜21倍速い（RTF比較: ja 16x, en 11x, zh 13x, ko 18x, yue 20x）。
-  turboはこのCPUでリアルタイム未達（RTF > 0.6）、hayamimiは全言語RTF < 0.08で大幅にリアルタイム内。
+  turboのRTFは0.64〜0.83で、**この短尺クリップ(平均十数秒)のバッチ処理では実時間を下回る**。
+  `docs/COMPARISON.md` の旧実測(実放送クリップ、RTF 1.03〜1.39)と食い違うのは計測条件の差
+  (クリップ長・スレッド数)によるもので、どちらも実測値。なおバッチRTFが1を切っても、
+  Whisper系は発話中の逐次出力(ストリーミング字幕)ができない点は変わらない。
+  hayamimiは全言語RTF < 0.08。
 - **精度**: zh(0.0744 vs 0.0777)のみhayamimiがturboよりわずかに良く、他4言語（ja/en/ko/yue）は
   turboがhayamimiを上回る——ただし上記の言語指定の非対称（turboに正解言語を渡している）を
   差し引く必要がある。差は ja +0.0159, en +0.0443, ko +0.0411, yue +0.0059 (turbo優位)、

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -498,3 +498,77 @@ en/ko はモデルが手元に無く経路が成立しないため、ローカ�
 VAD → プリロール → デコードの実経路に通し、各文の冒頭語（仮名表記も正: 「明日」は
 「あした」と出るのが正常で欠落ではない）が全て残ることを要求する。モデル未配置の環境では
 既存の needs_models 規約でスキップされる。
+## 2026-09-01: FLEURS test 5言語×100本 統一head-to-head (v0.3.1 リリースチャート用)
+
+これまでの `docs/SCORECARD.md`（real-speechセット、言語あたり12〜15本）や
+`docs/EVAL_REAL_ZHKO.md` / `docs/EVAL_REAL_YUE.md`（別々のセット・別々の日付で計測）を
+一本化し、**同一クリップ・同一採点・同一CPU**で hayamimi 本番経路 と
+faster-whisper large-v3-turbo を5言語×100本、直接比較した。
+
+### データ
+
+- [google/fleurs](https://huggingface.co/datasets/google/fleurs) **test** split。
+  `datasets-server` の `/rows` API は本データセットで HTTP 500 を返すため、
+  HF の parquet 自動変換ルート
+  (`https://huggingface.co/api/datasets/google/fleurs/parquet/<config>/test/0.parquet`)
+  を `fsspec` + `pyarrow` で直接読む方式に切り替えた
+  (`scripts/make_fleursset.py`)。5言語とも1シャード (`0.parquet`, 382〜945行) に収まった。
+- 設定: `ja_jp` / `en_us` / `cmn_hans_cn` / `ko_kr` / `yue_hant_hk`。
+- 選定規則: 各言語のparquetテーブルを **FLEURS `id` フィールドで安定ソート**し
+  （同一idが複数recording/speakerに紐づき数件重複するが、同順位はparquet内の元の行順で解決）、
+  先頭から空文字起こし・デコード失敗・非16kHzをスキップしつつ **先頭100本**を採用。
+  埋め込み音声はすでに16kHzモノラルのため再サンプリングなし。
+  除外クリップ: **0件**（5言語とも100/100本を初回取得で確保、デコード失敗なし）。
+- 出力: `testdata/fleurs_bench/<lang>/manifest.json` + `<lang>_NNN.wav`（gitではtestdata配下は非追跡）。
+
+### 採点条件
+
+- `scripts/eval_fleurs_bench.py`。en=WER（jiwer）、他=CER（Levenshtein、NFKC正規化＋
+  句読点/空白除去、`scripts/eval_accuracy.py` の `wer_en`/`cer_ja` をそのまま再利用）。
+  yueはopencc t2s正規化後に比較（既存スコアカードと同じ規約）。
+- **hayamimi**: `asr_engine.RoutedASR(threads=6, preload=False)`、`scripts/eval_engine.py` と
+  同じ本番経路（whisper-tiny LID自動判定 → tier振り分け → デコード → ja句読点）。
+  second-opinion は既定値のOFF（`ja_second_opinion=False`）。言語ブロックごとに
+  `reset_session()` を1回呼び、sticky-LIDのヒステリシスが前言語の残響を持ち込まないようにした
+  （`eval_engine.py` と同一の慣習）。
+- **turbo**: `faster-whisper` `large-v3-turbo`、`device=cpu`、`compute_type=int8`、
+  `beam_size=1`、**`language=<正解言語>` を明示指定**（hayamimiは自動判定なので、turbo側に
+  やや有利な非対称条件 — `docs/COMPARISON.md` に記載済みの規約と同じ）。
+- CPU: Ryzen 5 5600 (6C12T, 6スレッド指定) / Windows 11。sherpa-onnx 1.13.6、
+  faster-whisper 1.2.1。ITN（数字正規化）はSenseVoiceの`use_itn=True`が効く経路で有効。
+
+### 結果
+
+| lang | n | hayamimi err | hayamimi RTF | turbo err | turbo RTF |
+|---|---|---|---|---|---|
+| ja | 100 | 0.0649 | 0.0396 | 0.0490 | 0.6440 |
+| en | 100 | 0.1004 | 0.0732 | 0.0561 | 0.8305 |
+| zh | 100 | 0.0744 | 0.0570 | 0.0777 | 0.7175 |
+| ko | 100 | 0.0757 | 0.0371 | 0.0346 | 0.6685 |
+| yue | 100 | 0.1286 | 0.0374 | 0.1227 | 0.7611 |
+
+（err: en=WER、他=CER。yueはt2s正規化後。RTF = 処理時間 / 音声長、小さいほど速い。）
+
+- **速度**: hayamimiがturboの約12〜21倍速い（RTF比較: ja 16x, en 11x, zh 13x, ko 18x, yue 20x）。
+  turboはこのCPUでリアルタイム未達（RTF > 0.6）、hayamimiは全言語RTF < 0.08で大幅にリアルタイム内。
+- **精度**: zh(0.0744 vs 0.0777)のみhayamimiがturboよりわずかに良く、他4言語（ja/en/ko/yue）は
+  turboがhayamimiを上回る——ただし上記の言語指定の非対称（turboに正解言語を渡している）を
+  差し引く必要がある。差は ja +0.0159, en +0.0443, ko +0.0411, yue +0.0059 (turbo優位)、
+  zh -0.0033 (hayamimi優位、全て絶対値)。
+- **LID**: hayamimiの自動言語判定は500クリップ中498で正解言語のtierに一致。誤判定は
+  yueで2件（`yue_090.wav`→vi判定、`yue_095.wav`→th判定）。それ以外の4言語(400クリップ)は
+  誤判定0件。
+- **除外クリップ**: なし（両エンジンとも5言語×100本、計500クリップを完走）。
+
+### 制約
+
+- **turboに正解言語を渡す非対称条件**（`docs/COMPARISON.md`と同じ規約）。hayamimiは
+  LIDも含めた完全自動判定でこの数字を出している一方、turboはlanguage引数で正解を
+  与えられているため、turbo側の精度はやや有利な条件での測定値。
+- **second-opinion OFF**。本番のオプション機能（ja再デコードの合意ゲート）は既定値のまま
+  無効にして測定した。有効化した場合のja精度は本表に含まれない。
+- **FLEURSはread-aloudの単一話者クリップ**であり、雑音・オーバーラップ・自然発話ではない。
+  実運用条件（マイク入力・雑音・話者交代）ではここでの差がそのまま出るとは限らない。
+- **結果JSONは非追跡**（`testdata/fleurs_bench/results_{hayamimi,turbo}.json`）。再現する場合は
+  `scripts/make_fleursset.py --lang all` → `scripts/eval_fleurs_bench.py --engine ... --lang ...`
+  を参照。

--- a/scripts/eval_fleurs_bench.py
+++ b/scripts/eval_fleurs_bench.py
@@ -1,0 +1,192 @@
+"""Unified FLEURS test-split head-to-head: hayamimi production path vs
+faster-whisper large-v3-turbo, same clips, same scoring, same CPU.
+
+Data: testdata/fleurs_bench/<lang>/ built by scripts/make_fleursset.py
+(5 languages x 100 clips, FLEURS test split).
+
+Two engines, selected with --engine:
+
+  - hayamimi: the real production RoutedASR path (auto LID -> tier routing
+    -> decode -> ja punctuation), exactly like scripts/eval_engine.py.
+    Default settings (second-opinion OFF). asr.reset_session() is called
+    once per language block, same convention as eval_engine.py, so the
+    engine's sticky-LID hysteresis doesn't charge the first clip of a
+    language for "switching away" from a previous language's last clip.
+
+  - turbo: faster-whisper large-v3-turbo, device=cpu, compute_type=int8,
+    beam_size=1, language=<given>. Turbo is handed the correct language
+    directly -- a documented asymmetry vs. hayamimi's auto-LID path, matching
+    the conditions stated in docs/COMPARISON.md.
+
+Scoring: reuses eval_accuracy.wer_en / eval_accuracy.cer_ja exactly as
+eval_engine.py does: en=WER, others=CER (yue additionally t2s-normalized via
+opencc when available), so numbers are comparable in kind with the existing
+scorecard.
+
+Resumable: results are written incrementally to
+testdata/fleurs_bench/results_<engine>.json (a dict keyed by "<lang>/<wav>").
+Re-running skips clips that already have a recorded result. Use --lang and
+--limit/--offset to bound a single invocation's wall time (turbo is the slow
+engine; ~30 clips/call at RTF~1.4 on ~12s clips keeps a call under ~8 min).
+
+Usage:
+    python scripts/eval_fleurs_bench.py --engine hayamimi --lang ja
+    python scripts/eval_fleurs_bench.py --engine turbo --lang ja --offset 0 --limit 30
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import soundfile as sf
+
+from eval_accuracy import cer_ja, wer_en
+from eval_common import load_manifest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BENCH_ROOT = os.path.join(ROOT, "testdata", "fleurs_bench")
+
+LANGS = ["ja", "en", "zh", "ko", "yue"]
+
+try:
+    from opencc import OpenCC
+
+    _t2s = OpenCC("t2s").convert
+except Exception:
+    _t2s = None
+
+
+def score(lang: str, ref: str, hyp: str) -> float:
+    if lang == "en":
+        return wer_en(ref, hyp)
+    r, h = ref, hyp
+    if lang == "yue" and _t2s is not None:
+        r, h = _t2s(r), _t2s(h)
+    return cer_ja(r, h)[0]
+
+
+def results_path(engine: str) -> str:
+    return os.path.join(BENCH_ROOT, f"results_{engine}.json")
+
+
+def load_results(engine: str) -> dict:
+    p = results_path(engine)
+    if os.path.exists(p):
+        with open(p, encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_results(engine: str, results: dict):
+    with open(results_path(engine), "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+def read_clip(mdir, wav_name):
+    samples, sr = sf.read(os.path.join(mdir, wav_name), dtype="float32", always_2d=False)
+    if samples.ndim > 1:
+        samples = samples.mean(axis=1)
+    return samples, sr
+
+
+def run_hayamimi(langs, results):
+    from asr_engine import RoutedASR
+
+    asr = RoutedASR(threads=6, preload=False)
+
+    for lang in langs:
+        mdir = os.path.join(BENCH_ROOT, lang)
+        entries = load_manifest(mdir)
+        pending = [e for e in entries if f"{lang}/{e['wav']}" not in results]
+        if not pending:
+            print(f"[hayamimi/{lang}] all {len(entries)} clips already scored, skipping")
+            continue
+        # Fresh language block -> reset sticky-LID state (see eval_engine.py).
+        asr.reset_session()
+        for e in entries:
+            key = f"{lang}/{e['wav']}"
+            if key in results:
+                continue
+            samples, sr = read_clip(mdir, e["wav"])
+            dur = len(samples) / sr
+            t0 = time.perf_counter()
+            r = asr.transcribe(samples, sr)
+            wall = time.perf_counter() - t0
+            err = score(lang, e["ref"], r["text"])
+            results[key] = {
+                "lang": lang, "wav": e["wav"], "hyp": r["text"], "detected": r["lang"],
+                "tier": r["tier"], "err": err, "rtf": wall / dur if dur > 0 else 0.0, "dur": dur,
+            }
+            print(f"[hayamimi] {key:16} lid={r['lang']:3} tier={r['tier']:4} "
+                  f"err={err:.3f} rtf={results[key]['rtf']:.3f}")
+            save_results("hayamimi", results)
+
+
+def run_turbo(langs, results, offset, limit):
+    from faster_whisper import WhisperModel
+
+    print("Loading faster-whisper large-v3-turbo INT8 (CPU)...")
+    t0 = time.perf_counter()
+    model = WhisperModel("large-v3-turbo", device="cpu", compute_type="int8")
+    print(f"  load: {time.perf_counter() - t0:.2f}s")
+
+    for lang in langs:
+        mdir = os.path.join(BENCH_ROOT, lang)
+        entries = load_manifest(mdir)
+        window = entries[offset:offset + limit] if limit is not None else entries[offset:]
+        for e in window:
+            key = f"{lang}/{e['wav']}"
+            if key in results:
+                continue
+            wav_path = os.path.join(mdir, e["wav"])
+            samples, sr = read_clip(mdir, e["wav"])
+            dur = len(samples) / sr
+            t0 = time.perf_counter()
+            segments, _info = model.transcribe(wav_path, language=lang, beam_size=1)
+            hyp = "".join(seg.text for seg in segments).strip()
+            wall = time.perf_counter() - t0
+            err = score(lang, e["ref"], hyp)
+            results[key] = {
+                "lang": lang, "wav": e["wav"], "hyp": hyp,
+                "err": err, "rtf": wall / dur if dur > 0 else 0.0, "dur": dur,
+            }
+            print(f"[turbo] {key:16} err={err:.3f} rtf={results[key]['rtf']:.3f}")
+            save_results("turbo", results)
+
+
+def print_summary(engine, langs, results):
+    print(f"\n=== {engine} summary ===")
+    for lang in langs:
+        sub = [v for k, v in results.items() if v["lang"] == lang]
+        if not sub:
+            continue
+        err = sum(r["err"] * r["dur"] for r in sub) / sum(r["dur"] for r in sub)
+        rtf = sum(r["rtf"] for r in sub) / len(sub)
+        print(f"| {lang} | n={len(sub)} | mean_err={err:.4f} | mean_rtf={rtf:.4f} |")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", required=True, choices=["hayamimi", "turbo"])
+    ap.add_argument("--lang", default="all", choices=LANGS + ["all"])
+    ap.add_argument("--offset", type=int, default=0, help="turbo only: start index within language's manifest")
+    ap.add_argument("--limit", type=int, default=None, help="turbo only: max clips to process this call")
+    args = ap.parse_args()
+
+    langs = LANGS if args.lang == "all" else [args.lang]
+    results = load_results(args.engine)
+
+    if args.engine == "hayamimi":
+        run_hayamimi(langs, results)
+    else:
+        run_turbo(langs, results, args.offset, args.limit)
+
+    print_summary(args.engine, langs, results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_fleursset.py
+++ b/scripts/make_fleursset.py
@@ -1,0 +1,178 @@
+"""Build the unified FLEURS test-split benchmark set (5 languages x 100 clips).
+
+Data source: google/fleurs, TEST split, via the Hugging Face parquet-conversion
+API (the datasets-server /rows API returns HTTP 500 for this dataset's test
+splits on some configs, so this script bypasses it and reads the auto-
+converted parquet shard directly with fsspec + pyarrow, using column
+projection to keep memory/bandwidth bounded).
+
+    https://huggingface.co/api/datasets/google/fleurs/parquet/<config>/test/0.parquet
+
+Each of the 5 configs used here (ja_jp, en_us, cmn_hans_cn, ko_kr,
+yue_hant_hk) fits in a single shard (0.parquet, 382-945 rows), so no
+multi-shard paging is needed.
+
+Selection rule (documented, deterministic): read the full parquet table's
+`id`, `raw_transcription`, and `audio` columns, sort rows by the FLEURS `id`
+field (stable sort -- ties, which do occur since a handful of ids repeat
+across distinct recordings/speakers in the test split, are broken by the
+row's original position in the parquet file), then take the FIRST 100 rows
+of that sorted order. Rows with empty transcription or that fail to decode
+are skipped and backfilled from the next row in sorted order, so exactly 100
+clips are kept per language whenever the shard has enough usable rows.
+
+Audio in the parquet is already 16kHz mono (verified per-config below); it is
+written out as-is via soundfile, no resampling needed.
+
+Output layout (matches eval_common.load_manifest's expected shape):
+    testdata/fleurs_bench/<lang>/manifest.json  -- [{"wav", "ref", "id"}, ...]
+    testdata/fleurs_bench/<lang>/<lang>_XXX.wav
+
+Idempotent/resumable: if a language's manifest.json already has N_PER_LANG
+entries and every referenced wav file exists on disk, that language is
+skipped entirely (no network access). Use --force to rebuild anyway.
+
+Usage:
+    python scripts/make_fleursset.py --lang ja
+    python scripts/make_fleursset.py --lang all
+"""
+import argparse
+import io
+import json
+import os
+import sys
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUT_ROOT = os.path.join(ROOT, "testdata", "fleurs_bench")
+
+N_PER_LANG = 100
+
+CONFIGS = {
+    "ja": "ja_jp",
+    "en": "en_us",
+    "zh": "cmn_hans_cn",
+    "ko": "ko_kr",
+    "yue": "yue_hant_hk",
+}
+
+PARQUET_URL_TMPL = "https://huggingface.co/api/datasets/google/fleurs/parquet/{config}/test/0.parquet"
+
+
+def lang_dir(lang):
+    return os.path.join(OUT_ROOT, lang)
+
+
+def manifest_path(lang):
+    return os.path.join(lang_dir(lang), "manifest.json")
+
+
+def already_built(lang):
+    mpath = manifest_path(lang)
+    if not os.path.exists(mpath):
+        return False
+    with open(mpath, encoding="utf-8") as f:
+        manifest = json.load(f)
+    if len(manifest) < N_PER_LANG:
+        return False
+    d = lang_dir(lang)
+    return all(os.path.exists(os.path.join(d, e["wav"])) for e in manifest)
+
+
+def fetch_table(config):
+    import urllib.request
+
+    import pyarrow.parquet as pq
+
+    url = PARQUET_URL_TMPL.format(config=config)
+    cache_path = os.path.join(OUT_ROOT, f".cache_{config}.parquet")
+    os.makedirs(OUT_ROOT, exist_ok=True)
+    if not os.path.exists(cache_path):
+        print(f"  downloading {url} -> {cache_path} ...")
+        req = urllib.request.Request(url, headers={"User-Agent": "hayamimi-fleurs-bench/1.0"})
+        # Large shards (e.g. yue_hant_hk, ~800+ rows with embedded audio) can
+        # exceed fsspec's default async-http timeout when streamed via
+        # pyarrow's dataset scanner; a plain blocking urlretrieve-style fetch
+        # to a local file is more robust and also gives us a resumable cache.
+        with urllib.request.urlopen(req, timeout=300) as resp, open(cache_path + ".tmp", "wb") as out:
+            while True:
+                chunk = resp.read(1 << 20)
+                if not chunk:
+                    break
+                out.write(chunk)
+        os.replace(cache_path + ".tmp", cache_path)
+    else:
+        print(f"  reusing cached {cache_path}")
+    tbl = pq.read_table(cache_path, columns=["id", "raw_transcription", "audio"])
+    print(f"  got {tbl.num_rows} rows")
+    return tbl
+
+
+def build_lang(lang, force=False):
+    if not force and already_built(lang):
+        print(f"[{lang}] already built ({N_PER_LANG} clips present), skipping.")
+        return
+
+    config = CONFIGS[lang]
+    os.makedirs(lang_dir(lang), exist_ok=True)
+
+    tbl = fetch_table(config)
+    ids = tbl.column("id").to_pylist()
+    texts = tbl.column("raw_transcription").to_pylist()
+    audio_col = tbl.column("audio").to_pylist()
+
+    # stable sort by id; ties keep original (parquet row) order
+    order = sorted(range(len(ids)), key=lambda i: ids[i])
+
+    import soundfile as sf
+
+    kept = []
+    for i in order:
+        if len(kept) >= N_PER_LANG:
+            break
+        text = (texts[i] or "").strip()
+        if not text:
+            continue
+        audio = audio_col[i]
+        raw_bytes = audio.get("bytes") if audio else None
+        if not raw_bytes:
+            continue
+        try:
+            data, sr = sf.read(io.BytesIO(raw_bytes))
+        except Exception as e:
+            print(f"  [{lang}] id={ids[i]} decode failed: {e}")
+            continue
+        if data.ndim > 1:
+            data = data.mean(axis=1)
+        if sr != 16000:
+            print(f"  [{lang}] id={ids[i]} unexpected sample rate {sr}, skipping")
+            continue
+
+        n = len(kept) + 1
+        wav_name = f"{lang}_{n:03d}.wav"
+        wav_path = os.path.join(lang_dir(lang), wav_name)
+        sf.write(wav_path, data, sr, subtype="PCM_16")
+        kept.append({"wav": wav_name, "ref": text, "id": ids[i]})
+
+    if len(kept) < N_PER_LANG:
+        print(f"WARNING: [{lang}] only found {len(kept)}/{N_PER_LANG} usable clips")
+
+    with open(manifest_path(lang), "w", encoding="utf-8") as f:
+        json.dump(kept, f, ensure_ascii=False, indent=2)
+    print(f"[{lang}] wrote {manifest_path(lang)} with {len(kept)} entries")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lang", required=True, choices=list(CONFIGS.keys()) + ["all"])
+    ap.add_argument("--force", action="store_true", help="rebuild even if already complete")
+    args = ap.parse_args()
+
+    langs = list(CONFIGS.keys()) if args.lang == "all" else [args.lang]
+    for lang in langs:
+        build_lang(lang, force=args.force)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reproducible unified benchmark for the v0.3.1 release chart: FLEURS test split, 5 languages x 100 clips, hayamimi production path (auto LID) vs faster-whisper large-v3-turbo (language given — documented asymmetry), same clips/scoring/CPU. Adds scripts/make_fleursset.py + scripts/eval_fleurs_bench.py (both resumable) and the dated results section in docs/BENCHMARKS.md, including the turbo-RTF reconciliation with COMPARISON.md's older measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified benchmark comparing the production speech-recognition pipeline with faster-whisper across 500 FLEURS audio clips in five languages.
  * Added tooling to build and evaluate a reproducible multilingual test set, with resumable scoring and per-language accuracy and speed summaries.
* **Documentation**
  * Documented benchmark results, limitations, scoring conditions, and dataset details.
  * Results show the production pipeline was approximately 12–21× faster, while faster-whisper generally achieved higher accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->