### PR TITLE
Process safety for embedders: guarded model builds, stop token, loopback WS default

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,6 +78,22 @@ Whisper系・クラウドSTT API・他のローカルモデルとの比較（hay
 外部ライブラリ不要の参照クライアント（wavファイルを実時間ペースで送信）で、
 スマホ/ESP32クライアントを作るときのテンプレートにもなります。
 
+`--input ws`は既定で`127.0.0.1`にバインドするので、エンドポイントは何もしなければ
+localhostからしかアクセスできません。LAN上の他端末を受け付けたいときだけ
+`--ws-host 0.0.0.0`を明示してください（`/ingest`に認証はないので、信頼できる
+ネットワークでのみ使うこと）。バインドしたアドレスは起動時にstderrへ出力されます。
+
+## 他アプリへの組み込み
+
+`scripts/realtime_transcribe.py`の各部品（`RoutedASR`、`build_vad`、`run_stream`）は
+CLI専用ではなくimportして使えます。`RoutedASR(...)`と`build_vad(...)`は、
+モデルパスが見つからない場合にsherpa-onnxのC++層が呼ぶ`exit()`（catchできない）
+の代わりに、catchできる`asr_engine.ModelUnavailable`を送出します。また
+`run_stream(..., stop_event=threading.Eventのインスタンス)`で`threading.Event`型の
+停止トークンを受け付けるので、ホストアプリが自前のスレッドでパイプラインを回している
+場合でも、CLIのプロセスにしか効かない`KeyboardInterrupt`に頼らず
+`stop_event.set()`だけできれいに止められます。
+
 ## 動作環境
 
 Python 3.10以上と、PATHの通ったffmpegが必要です。開発と検証は**Windows 11**で行いました。
@@ -119,7 +135,7 @@ python -m venv .venv
 | `--wav PATH` | マイク入力 | マイクの代わりに16kHzモノラルWAVファイルからのストリーミングをシミュレート |
 | `--no-realtime` | オフ | `--wav`使用時、チャンク間でスリープしない（高速バッチ処理） |
 | `--input {mic,wav,ws}` | mic、`--wav`指定時はwav | 音声入力元。`ws`はネットワーク経由で音声を受け付ける（上記参照） |
-| `--ws-host HOST` | `0.0.0.0` | `--input ws`の`/ingest`エンドポイントのバインドホスト |
+| `--ws-host HOST` | `127.0.0.1` | `--input ws`の`/ingest`エンドポイントのバインドホスト。LANクライアントを受け付けるには`0.0.0.0`を指定 |
 | `--ws-port PORT` | 8766 | `--input ws`の`/ingest`エンドポイントのポート |
 | `--threads N` | 4 | モデルごとの推論スレッド数 |
 | `--no-partial` | オフ | 発話中の速報字幕を無効化 |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ Only one audio-producing client is accepted at a time; `scripts/ws_mic_client.py
 is a dependency-free reference client (streams a wav file at real-time pace)
 that doubles as a template for a phone/ESP32 implementation.
 
+`--input ws` binds `127.0.0.1` by default, so the endpoint is localhost-only
+until you opt in with `--ws-host 0.0.0.0` -- do that only on a network you
+trust, since `/ingest` has no authentication. The bound address is printed
+to stderr on startup either way.
+
+## Embedding in another app
+
+`scripts/realtime_transcribe.py`'s pieces (`RoutedASR`, `build_vad`,
+`run_stream`) are importable, not just CLI-only: `RoutedASR(...)` and
+`build_vad(...)` raise a catchable `asr_engine.ModelUnavailable` instead of
+letting sherpa-onnx's C++ layer call `exit()` on a missing model path, and
+`run_stream(..., stop_event=some_threading_Event)` accepts a
+`threading.Event` cancellation token so a host app running the pipeline on
+its own thread can stop it cleanly (`stop_event.set()`) without relying on
+`KeyboardInterrupt`, which only works for the CLI's own process.
+
 ## Requirements
 
 Python 3.10+ and ffmpeg on PATH. Developed and tested on **Windows 11**;
@@ -128,7 +144,7 @@ All flags are on `scripts/realtime_transcribe.py`:
 | `--wav PATH` | mic input | simulate streaming from a 16kHz mono WAV file instead of the microphone |
 | `--no-realtime` | off | with `--wav`, don't sleep between chunks (fast batch processing) |
 | `--input {mic,wav,ws}` | mic, or wav if `--wav` is given | audio source; `ws` accepts audio over the network (see below) |
-| `--ws-host HOST` | `0.0.0.0` | bind host for `--input ws`'s `/ingest` endpoint |
+| `--ws-host HOST` | `127.0.0.1` | bind host for `--input ws`'s `/ingest` endpoint; pass `0.0.0.0` to accept LAN clients |
 | `--ws-port PORT` | 8766 | port for `--input ws`'s `/ingest` endpoint |
 | `--threads N` | 4 | inference threads per model |
 | `--no-partial` | off | disable in-progress draft subtitles |

--- a/scripts/asr_engine.py
+++ b/scripts/asr_engine.py
@@ -613,12 +613,31 @@ _KEY_FILES = {
     "v3": (V3_MODEL_DIR, "encoder*.onnx"),
     "omni": (OMNI_MODEL_DIR, "model*.onnx"),
     "pja": (PJA_MODEL_DIR, "model*.onnx"),
+    "lid": (WHISPER_TINY_DIR, "tiny-encoder.int8.onnx"),
 }
 
 
 def _model_present(name: str) -> bool:
     d, pat = _KEY_FILES[name]
     return bool(_find(d, pat))
+
+
+def _build_lid_guarded(threads: int):
+    """The single guarded entry point for the whisper-tiny LID model.
+
+    Every native sherpa-onnx construction in this module must be preceded by
+    a _model_present() check: sherpa-onnx's C++ layer calls the process's
+    exit() -- not a catchable Python exception -- when handed an empty or
+    invalid model path (see _KEY_FILES' comment and ModelUnavailable below).
+    _get() already funnels the six _BUILDERS recognizers through exactly
+    that check; the LID model is built eagerly in RoutedASR.__init__
+    (outside _get()'s lazy-load path), so it needs its own guard here rather
+    than silently reaching sherpa_onnx.SpokenLanguageIdentification(...)
+    with a possibly-missing encoder/decoder path.
+    """
+    if not _model_present("lid"):
+        raise ModelUnavailable("lid")
+    return _build_lid(threads)
 
 
 _BUILDERS = {
@@ -687,7 +706,7 @@ class RoutedASR:
         self._pending_lang = None   # candidate new language awaiting confirmation
         self._pending_count = 0
         self.lid_switch_confirm = lid_switch_confirm  # consecutive detections to accept a switch
-        self.lid = _build_lid(threads)
+        self.lid = _build_lid_guarded(threads)
         if warmup:
             # LID + tier-0 pay their one-time kernel/allocation costs here
             # so the first real segment isn't penalized.

--- a/scripts/realtime_transcribe.py
+++ b/scripts/realtime_transcribe.py
@@ -20,7 +20,7 @@ sys.stdout.reconfigure(encoding="utf-8")
 import numpy as np
 import sherpa_onnx
 
-from asr_engine import RoutedASR
+from asr_engine import ModelUnavailable, RoutedASR
 from audio_utils import resample_linear
 
 SAMPLE_RATE = 16000
@@ -61,6 +61,13 @@ def build_vad(min_silence: float = 0.35,
     # The installed sherpa_onnx (1.13.6) SileroVadModelConfig exposes no
     # speech-padding knob (no speech_pad_ms field) alongside threshold, so
     # there is nothing to plumb through for that half of T1.
+    if not os.path.exists(VAD_MODEL):
+        # sherpa-onnx's C++ layer calls the process's exit() -- not a
+        # catchable Python exception -- when handed a missing model path
+        # (see asr_engine._KEY_FILES' comment for the same landmine on the
+        # recognizer side). Check first so an embedding app gets a
+        # catchable ModelUnavailable instead of the whole process dying.
+        raise ModelUnavailable("vad")
     cfg = sherpa_onnx.VadModelConfig(
         silero_vad=sherpa_onnx.SileroVadModelConfig(
             model=VAD_MODEL,
@@ -377,9 +384,9 @@ class TranslationWorker:
 
 
 from asr_engine import (  # shared with the engine's live correction / refine dual-LID confirm
-    ModelUnavailable, REFINE_MIN_REGROUP_S, SV_LANGS, resolve_refine_lang, script_corrected_lang,
+    REFINE_MIN_REGROUP_S, SV_LANGS, resolve_refine_lang, script_corrected_lang,
     sv_lid_tag,
-)
+)  # ModelUnavailable is imported at module top, alongside RoutedASR
 
 GROUP_GAP_S = 2.0   # this much true silence closes an utterance group
 GROUP_MAX_S = 25.0  # refine early rather than outgrow the audio history
@@ -1130,21 +1137,30 @@ def main():
               file=sys.stderr)
 
     print("loading models...", file=sys.stderr)
-    asr = RoutedASR(threads=args.threads,
-                    max_resident=args.max_resident if args.max_resident > 0 else None,
-                    hotwords_file=args.hotwords, replace_file=args.replace,
-                    lid_switch_confirm=max(args.lid_switch_confirm, 1),
-                    dual_confirm=(args.mode != "fast"),
-                    forced_lang=args.lang if args.mode == "single" else None,
-                    ja_second_opinion=args.refine_ja_second_opinion,
-                    **({"agree_threshold": args.refine_agree_threshold}
-                       if args.refine_agree_threshold is not None else {}))
+    try:
+        asr = RoutedASR(threads=args.threads,
+                        max_resident=args.max_resident if args.max_resident > 0 else None,
+                        hotwords_file=args.hotwords, replace_file=args.replace,
+                        lid_switch_confirm=max(args.lid_switch_confirm, 1),
+                        dual_confirm=(args.mode != "fast"),
+                        forced_lang=args.lang if args.mode == "single" else None,
+                        ja_second_opinion=args.refine_ja_second_opinion,
+                        **({"agree_threshold": args.refine_agree_threshold}
+                           if args.refine_agree_threshold is not None else {}))
+        vad = build_vad(args.min_silence, args.max_speech)
+    except ModelUnavailable as exc:
+        # A required model is missing under models/ -- asr_engine and
+        # build_vad() both guard sherpa-onnx's native constructors so this
+        # is a catchable exception, not the process silently exit()ing out
+        # from inside the C++ layer. Fail with a clear message instead.
+        ap.error(f"required model '{exc.name}' not found under models/ -- "
+                 f"run scripts/download_models.py")
+        return
     asr.min_switch_s = max(args.lang_switch_guard, 0.0)
     if server is not None:
         # lets /replacements and /itn_overrides on the subtitle server read
         # and update this engine's live postprocessing dictionaries
         server.asr = asr
-    vad = build_vad(args.min_silence, args.max_speech)
     stats = SessionStats()
     printer = PartialPrinter(enabled=not args.no_partial, server=server)
 

--- a/scripts/realtime_transcribe.py
+++ b/scripts/realtime_transcribe.py
@@ -15,8 +15,6 @@ import threading
 import time
 import wave
 
-sys.stdout.reconfigure(encoding="utf-8")
-
 import numpy as np
 import sherpa_onnx
 
@@ -1007,6 +1005,7 @@ def run_stream(chunks, vad, sample_rate: int, asr: RoutedASR, stats: SessionStat
 
 
 def main():
+    sys.stdout.reconfigure(encoding="utf-8")
     ap = argparse.ArgumentParser()
     ap.add_argument("--wav", help="wav file to simulate streaming from (16kHz mono s16)")
     ap.add_argument("--no-realtime", action="store_true", help="don't sleep between chunks in --wav mode")
@@ -1133,9 +1132,11 @@ def main():
                          "docs/TRANSLATE_M2M.md")
     ap.add_argument("--input", choices=["mic", "wav", "ws"], default=None,
                     help="audio source; default is mic, or wav if --wav is given")
-    ap.add_argument("--ws-host", default="0.0.0.0", metavar="HOST",
-                    help="bind host for --input ws (default 0.0.0.0, so an ESP32/phone "
-                         "on the LAN can reach it; use 127.0.0.1 to restrict to localhost)")
+    ap.add_argument("--ws-host", default="127.0.0.1", metavar="HOST",
+                    help="bind host for --input ws (default 127.0.0.1, localhost-only; "
+                         "pass --ws-host 0.0.0.0 to also accept connections from other "
+                         "devices on the LAN, e.g. a phone or an ESP32 board -- do this "
+                         "only on a network you trust, the /ingest endpoint has no auth)")
     ap.add_argument("--ws-port", type=int, default=8766, metavar="PORT",
                     help="port for the --input ws /ingest endpoint (default 8766)")
     args = ap.parse_args()

--- a/scripts/realtime_transcribe.py
+++ b/scripts/realtime_transcribe.py
@@ -101,7 +101,17 @@ def wav_chunks(samples: np.ndarray, sample_rate: int, realtime: bool):
         pos += WINDOW_SIZE
 
 
-def mic_chunks():
+MIC_QUEUE_TIMEOUT_S = 0.1  # how often the generator wakes up to check stop_event
+
+
+def mic_chunks(stop_event: "threading.Event | None" = None):
+    """Yield mic input frames until `stop_event` is set.
+
+    `q.get()` alone blocks forever with no chunk to hand back control to the
+    caller, so an embedding app has no way to break out short of
+    KeyboardInterrupt. Polling with a bounded timeout lets the generator
+    notice stop_event between callbacks instead.
+    """
     import sounddevice as sd
 
     q: "queue.Queue[np.ndarray]" = queue.Queue()
@@ -111,8 +121,11 @@ def mic_chunks():
 
     with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, dtype="float32",
                          blocksize=WINDOW_SIZE, callback=callback):
-        while True:
-            yield q.get()
+        while stop_event is None or not stop_event.is_set():
+            try:
+                yield q.get(timeout=MIC_QUEUE_TIMEOUT_S)
+            except queue.Empty:
+                continue
 
 
 def ws_chunks(ingest):
@@ -931,13 +944,26 @@ def run_stream(chunks, vad, sample_rate: int, asr: RoutedASR, stats: SessionStat
                printer: PartialPrinter, refiner: "Refiner | None" = None,
                history: AudioHistory | None = None,
                translator_worker: "TranslationWorker | None" = None,
-               speaker_labeler=None):
+               speaker_labeler=None, stop_event: "threading.Event | None" = None):
+    """Drive the VAD -> ASR pipeline over `chunks` until it's exhausted or
+    `stop_event` is set.
+
+    `stop_event` is the cancellation hook for an app embedding this module:
+    the CLI itself still relies on KeyboardInterrupt (unchanged), but a
+    caller running this in a background thread has no SIGINT to send, so it
+    needs a way to ask the loop to stop that doesn't depend on the chunk
+    source unblocking on its own. Checked once per chunk here; mic_chunks()
+    additionally polls it directly since a plain `q.get()` would otherwise
+    block indefinitely with nothing to yield.
+    """
     audio_pos = 0.0
     last_partial = 0.0
     early_lang = None  # LID result computed mid-utterance so finals skip it
     if history is None:
         history = AudioHistory(sample_rate)
     for chunk in chunks:
+        if stop_event is not None and stop_event.is_set():
+            break
         if not isinstance(chunk, np.ndarray):
             # non-ndarray = a "flush now" signal (ws_ingest.FLUSH on client
             # disconnect): finalize whatever the VAD has in progress instead
@@ -1244,6 +1270,14 @@ def main():
             refiner.run_global_recluster()
 
     input_mode = args.input or ("wav" if args.wav else "mic")
+    # The CLI itself still relies on KeyboardInterrupt (unchanged behavior);
+    # stop_event exists for an app embedding this module in a thread it
+    # doesn't control via SIGINT -- it can call stop_event.set() from
+    # anywhere to unwind run_stream cleanly. Set here too, in the except
+    # handler, purely so the two cancellation paths converge on the same
+    # state (run_stream has usually already unwound via the exception by
+    # the time this runs).
+    stop_event = threading.Event()
 
     try:
         if server is not None:
@@ -1254,7 +1288,7 @@ def main():
             samples, sr = read_wave(args.wav)  # resampled to SAMPLE_RATE if needed
             run_stream(wav_chunks(samples, sr, realtime=not args.no_realtime),
                        vad, sr, asr, stats, printer, refiner, history, translator_worker,
-                       speaker_labeler)
+                       speaker_labeler, stop_event=stop_event)
             finish(sr)
         elif input_mode == "ws":
             from ws_ingest import INGEST_PATH, IngestServer
@@ -1264,11 +1298,13 @@ def main():
             print(f"ws ingest: ws://{args.ws_host}:{args.ws_port}{INGEST_PATH}  "
                   f"(JSON handshake, then binary pcm_s16le frames)", file=sys.stderr)
             run_stream(ws_chunks(ingest), vad, SAMPLE_RATE, asr, stats, printer, refiner,
-                       history, translator_worker, speaker_labeler)
+                       history, translator_worker, speaker_labeler, stop_event=stop_event)
         else:
-            run_stream(mic_chunks(), vad, SAMPLE_RATE, asr, stats, printer, refiner, history,
-                       translator_worker, speaker_labeler)
+            run_stream(mic_chunks(stop_event=stop_event), vad, SAMPLE_RATE, asr, stats, printer,
+                       refiner, history, translator_worker, speaker_labeler,
+                       stop_event=stop_event)
     except KeyboardInterrupt:
+        stop_event.set()
         finish(SAMPLE_RATE)
     finally:
         print(f"\n=== session summary: {stats.summary()} ===")

--- a/tests/test_process_safety.py
+++ b/tests/test_process_safety.py
@@ -1,19 +1,31 @@
 """Process-safety regression tests (GitHub issue #30).
 
-sherpa-onnx's C++ layer calls the process's exit() -- not a catchable Python
-exception -- when handed an empty/invalid model path. Every native
-construction in this codebase must be preceded by a file-presence check
-that raises asr_engine.ModelUnavailable instead. These tests prove the
-guard fires (and the native builder is never reached) rather than actually
-letting a bad path hit sherpa-onnx, which would crash the test process
-itself if the guard regressed.
+Two independent landmines an app embedding scripts/asr_engine.py or
+scripts/realtime_transcribe.py could hit:
 
-No ASR/VAD models are loaded here; everything is guard functions and
-monkeypatched builders, so this file is cheap to run.
+  1. sherpa-onnx's C++ layer calls the process's exit() -- not a catchable
+     Python exception -- when handed an empty/invalid model path. Every
+     native construction in this codebase must be preceded by a
+     file-presence check that raises asr_engine.ModelUnavailable instead.
+     These tests prove the guard fires (and the native builder is never
+     reached) rather than actually letting a bad path hit sherpa-onnx,
+     which would crash the test process itself if the guard regressed.
+
+  2. The live capture loop (realtime_transcribe.run_stream / mic_chunks /
+     wav_chunks) had no cancellation mechanism besides KeyboardInterrupt, so
+     an app embedding it on its own thread had no way to stop it cleanly.
+     These tests exercise the threading.Event stop token end to end.
+
+No ASR/VAD models are loaded here; everything is guard functions and stubs,
+so this file is cheap to run.
 """
 import os
 import sys
+import threading
+import time
+import types
 
+import numpy as np
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
@@ -96,3 +108,112 @@ def test_build_vad_raises_not_exits_when_model_missing(tmp_path, monkeypatch):
     with pytest.raises(ModelUnavailable) as exc_info:
         rt.build_vad()
     assert exc_info.value.name == "vad"
+
+
+# --- stop token: run_stream honors a threading.Event ------------------------
+
+class _StubVad:
+    """Just enough of sherpa_onnx.VoiceActivityDetector for run_stream to
+    drive without ever producing a segment -- this test is only about
+    whether the chunk loop notices stop_event, not about VAD/ASR behavior."""
+
+    def accept_waveform(self, chunk):
+        pass
+
+    def empty(self):
+        return True
+
+    def is_speech_detected(self):
+        return False
+
+    def flush(self):
+        pass
+
+
+def test_run_stream_stops_mid_wav_when_stop_event_is_set():
+    """The wav path: stop_event set from another thread must interrupt
+    run_stream before the whole (paced) file has been consumed."""
+    import realtime_transcribe as rt
+
+    sr = 16000
+    samples = np.zeros(int(5.0 * sr), dtype=np.float32)  # 5s, paced playback
+    vad = _StubVad()
+    stats = rt.SessionStats()
+    printer = rt.PartialPrinter(enabled=False)
+    stop_event = threading.Event()
+
+    def run():
+        rt.run_stream(rt.wav_chunks(samples, sr, realtime=True), vad, sr, None,
+                      stats, printer, stop_event=stop_event)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    time.sleep(0.15)
+    stop_event.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive(), "run_stream did not return after stop_event was set"
+    # stopped partway through 5s of paced audio -- nowhere near the full file
+    assert 0.0 < stats.total_audio_s < 5.0
+
+
+def test_run_stream_without_stop_event_runs_to_completion():
+    """Regression guard: omitting stop_event (the CLI's own KeyboardInterrupt
+    path, and every pre-existing caller) must behave exactly as before --
+    the whole chunk source is consumed."""
+    import realtime_transcribe as rt
+
+    sr = 16000
+    samples = np.zeros(int(0.2 * sr), dtype=np.float32)
+    vad = _StubVad()
+    stats = rt.SessionStats()
+    printer = rt.PartialPrinter(enabled=False)
+
+    rt.run_stream(rt.wav_chunks(samples, sr, realtime=False), vad, sr, None, stats, printer)
+
+    # wav_chunks pads its final chunk up to a full WINDOW_SIZE window, so the
+    # consumed total can exceed the raw sample count by less than one window
+    assert stats.total_audio_s >= 0.2
+    assert stats.total_audio_s < 0.2 + rt.WINDOW_SIZE / sr
+
+
+# --- stop token: mic_chunks polls instead of blocking forever ---------------
+
+class _FakeInputStream:
+    """Stand-in for sounddevice.InputStream: never actually calls back with
+    audio, just tracks that it was opened and closed like a context manager
+    should. mic_chunks() must still notice stop_event via its bounded queue
+    timeout instead of blocking on q.get() forever."""
+
+    def __init__(self, *args, callback=None, **kwargs):
+        self.callback = callback
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def test_mic_chunks_notices_stop_event_without_audio(monkeypatch):
+    import realtime_transcribe as rt
+
+    fake_sd = types.SimpleNamespace(InputStream=_FakeInputStream)
+    monkeypatch.setitem(sys.modules, "sounddevice", fake_sd)
+
+    stop_event = threading.Event()
+    gen = rt.mic_chunks(stop_event=stop_event)
+
+    def stopper():
+        time.sleep(0.05)
+        stop_event.set()
+
+    threading.Thread(target=stopper, daemon=True).start()
+
+    start = time.perf_counter()
+    with pytest.raises(StopIteration):
+        while True:
+            next(gen)
+    elapsed = time.perf_counter() - start
+    # bounded by MIC_QUEUE_TIMEOUT_S polling, not an indefinite block
+    assert elapsed < 1.0

--- a/tests/test_process_safety.py
+++ b/tests/test_process_safety.py
@@ -1,0 +1,98 @@
+"""Process-safety regression tests (GitHub issue #30).
+
+sherpa-onnx's C++ layer calls the process's exit() -- not a catchable Python
+exception -- when handed an empty/invalid model path. Every native
+construction in this codebase must be preceded by a file-presence check
+that raises asr_engine.ModelUnavailable instead. These tests prove the
+guard fires (and the native builder is never reached) rather than actually
+letting a bad path hit sherpa-onnx, which would crash the test process
+itself if the guard regressed.
+
+No ASR/VAD models are loaded here; everything is guard functions and
+monkeypatched builders, so this file is cheap to run.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+
+import asr_engine  # noqa: E402
+from asr_engine import ModelUnavailable  # noqa: E402
+
+
+# --- the exit() landmine: RoutedASR construction ----------------------------
+
+def test_routed_asr_init_raises_not_exits_when_lid_missing(tmp_path, monkeypatch):
+    """A missing whisper-tiny LID model must raise ModelUnavailable out of
+    RoutedASR.__init__, not crash the process.
+
+    self.lid = _build_lid_guarded(threads) is the very first native
+    construction __init__ does (docs comment in asr_engine._KEY_FILES);
+    everything before it in __init__ is plain attribute/lock setup, so this
+    exercises the real construction path end to end, not just the guard
+    function in isolation.
+    """
+    empty_dir = tmp_path / "empty_whisper_tiny"
+    empty_dir.mkdir()
+    monkeypatch.setitem(asr_engine._KEY_FILES, "lid",
+                        (str(empty_dir), "tiny-encoder.int8.onnx"))
+    with pytest.raises(ModelUnavailable) as exc_info:
+        asr_engine.RoutedASR(threads=1, warmup=False, preload=False)
+    assert exc_info.value.name == "lid"
+
+
+def test_build_lid_guarded_never_reaches_sherpa_onnx_when_missing(tmp_path, monkeypatch):
+    """Guard function in isolation: when the key file is absent, the real
+    sherpa-onnx builder must never be called at all.
+
+    Calling the real (unguarded) builder with an empty path is exactly the
+    landmine this issue is about -- it would call the process's exit(), not
+    raise -- so this test cannot exercise that path directly without risking
+    killing the test runner. Instead it proves the guard short-circuits
+    BEFORE _build_lid() would ever run.
+    """
+    empty_dir = tmp_path / "empty_whisper_tiny"
+    empty_dir.mkdir()
+    monkeypatch.setitem(asr_engine._KEY_FILES, "lid",
+                        (str(empty_dir), "tiny-encoder.int8.onnx"))
+
+    def boom(threads):
+        pytest.fail("_build_lid() must not be called when the model is "
+                     "missing on disk -- that is the exit() landmine")
+
+    monkeypatch.setattr(asr_engine, "_build_lid", boom)
+    with pytest.raises(ModelUnavailable) as exc_info:
+        asr_engine._build_lid_guarded(threads=1)
+    assert exc_info.value.name == "lid"
+
+
+def test_build_lid_guarded_builds_normally_when_present(monkeypatch):
+    """Sanity check the other direction: presence still reaches the builder
+    and returns whatever it returns (guard is a pure pass-through)."""
+    monkeypatch.setattr(asr_engine, "_model_present", lambda name: True)
+    sentinel = object()
+    monkeypatch.setattr(asr_engine, "_build_lid", lambda threads: sentinel)
+    assert asr_engine._build_lid_guarded(threads=1) is sentinel
+
+
+# --- the exit() landmine: the live capture VAD ------------------------------
+
+def test_build_vad_raises_not_exits_when_model_missing(tmp_path, monkeypatch):
+    """realtime_transcribe.build_vad() must guard the same way as the ASR
+    recognizers: a missing silero_vad.onnx must raise ModelUnavailable
+    before sherpa_onnx.VoiceActivityDetector ever sees the bad path."""
+    import realtime_transcribe as rt
+
+    missing = tmp_path / "no_such_silero_vad.onnx"
+    monkeypatch.setattr(rt, "VAD_MODEL", str(missing))
+
+    def boom(cfg, buffer_size_in_seconds):
+        pytest.fail("sherpa_onnx.VoiceActivityDetector must not be "
+                     "constructed when the VAD model file is missing")
+
+    monkeypatch.setattr(rt.sherpa_onnx, "VoiceActivityDetector", boom)
+    with pytest.raises(ModelUnavailable) as exc_info:
+        rt.build_vad()
+    assert exc_info.value.name == "vad"


### PR DESCRIPTION
Implements #30 (embedding audit package C):

- Funnel ALL sherpa-onnx native builds through guarded entry points — the C++ layer exits the process (not catchable) on missing model paths; the LID build and live VAD build were unguarded. Now they raise ModelUnavailable.
- threading.Event stop token through run_stream/mic_chunks so an embedding app can implement a stop button (Ctrl+C unchanged).
- **Breaking**: --ws-host defaults to 127.0.0.1 instead of 0.0.0.0. LAN exposure (phone Remote) is an explicit opt-in now — documented in --help and both READMEs.
- Moved the import-time sys.stdout.reconfigure side effect into main().

Tests: +7 (guards raise instead of exiting; stop token stops mid-wav); suite 218 passed. Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)