### PR TITLE
README: document --mode presets (missing from the CLI table)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -131,6 +131,7 @@ python -m venv .venv
 | `--transcript PATH` | なし | 清書済みトランスクリプト行をこのファイルに追記 |
 | `--hotwords PATH` | なし | 固有名詞側にデコードを寄せるホットワード一覧（1行1語）。**現状jaルートには効果なし**（ReazonSpeechのbyte-level BPEなtokens.txtはエンコードできず、起動時に失敗数を警告表示）。jaの固有名詞には`--replace`を使ってください |
 | `--replace PATH` | なし | ユーザー辞書。`誤=正`形式、1行1組。全出力に適用 |
+| `--mode {single,balanced,fast}` | `balanced` | 言語切替のプリセット。`balanced`は2つの言語判定器が一致した時だけ切り替える（`docs/LID.md`参照）。`single`は`--lang`で指定した言語に固定し自動切替を行わない。`fast`は判定のたびに即切り替えるv0.2.0以前相当の動作。下の個別フラグはプリセットより優先される |
 | `--lang-switch-guard SEC` | 2.0 | この秒数未満の新言語判定はノイズとみなす：スイッチ確定（`--lid-switch-confirm`参照）には一切カウントされず、空デコード時のomnilingualフォールバックも抑制する（`0`で無効） |
 | `--lid-switch-confirm N` | 2 | セッション言語を実際に切り替えるのに必要な、連続した新言語判定の回数（各判定は`--lang-switch-guard`秒以上）。大きくするほど切り替えが粘る |
 | `--speakers` | オフ | 発話に話者ID（S1, S2, ...）をラベル付け。清書パスでpyannote segmentation-3.0による再分離をかけ直す |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ All flags are on `scripts/realtime_transcribe.py`:
 | `--transcript PATH` | none | append refined transcript lines to this file |
 | `--hotwords PATH` | none | hotword list (one per line) to bias decoding toward proper nouns -- **currently has no effect on the ja tier** (ReazonSpeech's byte-level BPE tokens.txt can't encode them; a startup warning tells you how many failed). Use `--replace` for ja proper nouns instead |
 | `--replace PATH` | none | user dictionary: `wrong=right` per line, applied to all output |
+| `--mode {single,balanced,fast}` | `balanced` | language-switching preset. `balanced` switches only when both language detectors agree (see `docs/LID.md`); `single` pins the language given by `--lang` and never switches; `fast` switches on every detection, matching pre-v0.2.0 behavior. Individual flags below override the preset |
 | `--lang-switch-guard SEC` | 2.0 | treat a new-language detection shorter than this as noise: it can never count toward confirming a switch (see `--lid-switch-confirm`) and it suppresses the omnilingual fallback on an empty decode (`0` disables) |
 | `--lid-switch-confirm N` | 2 | consecutive new-language detections (each >= `--lang-switch-guard` long) required before the session actually switches language; raise for stickier single-language sessions |
 | `--speakers` | off | label utterances with speaker ids (S1, S2, ...); the refine pass re-diarizes each group with pyannote segmentation-3.0 |


### PR DESCRIPTION
The v0.2.0 flagship option never made it into the README CLI tables; two lines, both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)