### PR TITLE
demo: AMI attribution + DiarMain composition registration

### DIFF
--- a/demo/CREDITS.md
+++ b/demo/CREDITS.md
@@ -1,5 +1,45 @@
 # Demo video audio credits
 
+## v0.3.0 speaker-diarization video (`hayamimi_v030_diar_demo.mp4`)
+
+The only speech heard in this video is an unmodified 85-second excerpt of a
+real four-person meeting from the **AMI Meeting Corpus**, used under
+**CC BY 4.0**:
+
+> J. Carletta, S. Ashby, S. Bourban, M. Flynn, M. Guillemot, T. Hain,
+> J. Kadlec, V. Karaiskos, W. Kraaij, M. Kronenthal, G. Lathoud, M. Lincoln,
+> A. Lisowska, I. McCowan, W. Post, D. Reidsma and P. Wellner.
+> "The AMI Meeting Corpus: A Pre-Announcement." In *Machine Learning for
+> Multimodal Interaction* (MLMI 2005), LNCS 3869, pp. 28–39. Springer, 2006.
+> Corpus home: https://groups.inf.ed.ac.uk/ami/corpus/ — licensed CC BY 4.0.
+
+Specific material: meeting **IS1008a**, the segment at meeting time
+60.0s–145.0s (the opening round of self-introductions). Cut without
+re-encoding from the 16 kHz mono dev-split copy in `testdata/eval_diar/`;
+see `demo/diar/NOTES.md` for the exact cut and checksums. Original speaker
+identities in the corpus reference are MIO086, FIE038, FIE073 and MIE085;
+the `S1`–`S4` labels on screen are hayamimi's own cluster labels, not the
+corpus's.
+
+Every subtitle line, speaker label and `?` marker shown on screen is
+hayamimi's actual output on that audio, replayed at the real timestamps
+from a timestamped capture of the production pipeline
+(`demo/diar/events.json`, 146 events) without alteration — including the
+mistake at t=38.5s and its correction at t=58.1s. Nothing was retyped,
+re-timed or staged.
+
+### Background music
+
+The instrumental bed under the video is **not licensed from anyone** — it is
+synthesized from scratch by `demo/diar/make_bgm.py` (numpy + scipy: additive
+sine pads over a four-chord diatonic loop in D major, a sine sub-bass and a
+low-passed noise layer; no samples, no external audio, no melody). Output:
+`demo/diar/bgm.wav`. It is an original work of this repository and carries the
+repository's own licence, so the finished video has no third-party music
+rights attached at all.
+
+## v0.1.0 / v0.2.0 videos
+
 The demo video's speech clips are unmodified samples from these datasets
 (all redistribution-compatible, attribution required):
 

--- a/demo/remotion/src/Root.tsx
+++ b/demo/remotion/src/Root.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Composition } from "remotion";
 import { Main } from "./Main";
+import { DiarMain, DIAR_TOTAL_S } from "./DiarMain";
 import {
   FPS,
   INTRO_SECONDS,
@@ -19,13 +20,23 @@ const TOTAL_SECONDS =
 
 export const RemotionRoot: React.FC = () => {
   return (
-    <Composition
-      id="Main"
-      component={Main}
-      durationInFrames={Math.round(TOTAL_SECONDS * FPS)}
-      fps={FPS}
-      width={1920}
-      height={1080}
-    />
+    <>
+      <Composition
+        id="Main"
+        component={Main}
+        durationInFrames={Math.round(TOTAL_SECONDS * FPS)}
+        fps={FPS}
+        width={1920}
+        height={1080}
+      />
+      <Composition
+        id="DiarMain"
+        component={DiarMain}
+        durationInFrames={Math.round(DIAR_TOTAL_S * FPS)}
+        fps={FPS}
+        width={1920}
+        height={1080}
+      />
+    </>
   );
 };


### PR DESCRIPTION
Two tracked-file changes from the v0.3.0 demo-video production that never got committed: the CREDITS.md AMI Meeting Corpus (CC BY 4.0) entry the published video relies on, and Root.tsx registering the DiarMain Remotion composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)