### PR TITLE
hayamimi_core 0.1.0 release prep: punctuation in refine (#15 phase 2), pub.dev readiness (#16), emulator-driven fixes

### DIFF
--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1409,6 +1409,226 @@ still not timed directly, and no release build and no iOS — so
 `OrtLibrary.processSymbols` on iOS remains unverified. New to this run: the
 punctuated-finals fix above.
 
+## Android emulator verification, run 3 — the punctuation fix confirmed, and two small follow-ups (2026-09-01)
+
+Run 2 ended with a fix for its third defect (the fallback refine going out
+unpunctuated) that had not itself been run on the emulator. This is that
+check, on the same AVD, the same models, and the same 6.26 s three-sentence
+Japanese fixture, plus a fourth pass that reproduces run 2's own control
+(`applyToFinals: false`) on this build. **Verdict: fixed.** On package
+defaults the closing refine over the three-sentence group is now
+`punctuated=true` and carries 。 between the sentences; run 2's behaviour
+is still reachable, exactly, via `JaPunctuation(applyToFinals: false)`. Two
+small new issues turned up alongside the fix, both addressed by this
+change — see below.
+
+Same setup as runs 1 and 2 (emulator `hayamimi_test`,
+`ro.product.cpu.abi=x86_64`, API 35, host Windows 11 26H2 / Ryzen 5 5600,
+Flutter 3.47.1 / Dart 3.13.1, ReazonSpeech ja zipformer int8 with
+`decodingMethod: 'modified_beam_search'` and `numThreads` 2, the fp16
+punctuation model, package-default VAD (0.35 / 12.0) and pre-roll (1.0),
+input through `startDebugWavStream`). Models and the padded wav were
+already on the device from run 1 (328,418 B, byte-identical); nothing was
+pushed again. ONNX Runtime reported itself as 1.27.1, C API 11, unchanged.
+
+The harness ran four passes, twice, in two fresh processes — eight sessions
+in total. **Every text, every `chars`, and every `audio_s` is identical
+between the two processes.** No `ErrorSubtitleEvent`, no `DecodeWorkerDied`,
+no crash.
+
+| tag | `applyToFinals` | `autoRefineEnabled` | explicit `refineNow` | what it shows |
+|---|---|---|---|---|
+| `r1-perseg` | true (default) | true (0.3 / 0.6) | yes | one refine per segment |
+| `r1-closing` | true (default) | false (package default) | no | the closing refine over the group — the fix |
+| `r2-perseg-nofinalpunct` | false | true (0.3 / 0.6) | yes | finals raw, refines still punctuated |
+| `r2-closing-nofinalpunct` | false | false | no | the control: reproduces run 2's `[r3-closing]` |
+
+### The fix confirmed, side by side
+
+Run 2, package defaults, the line this run existed to re-check:
+
+```
+[r3-closing] refine lang= punctuated=false audio_s=6.306 latency_ms=214.19 chars=35 text=東京の天気は晴れです あしたの会議は十時からです 資料は昨日送りました
+```
+
+Run 3, same configuration, same fixture, package defaults:
+
+```
+[r1-closing] final  lang= punctuated=true audio_s=1.762 latency_ms=100.068 chars=11 text=東京の天気は晴れです。
+[r1-closing] final  lang= punctuated=true audio_s=2.4   latency_ms=115.527 chars=14 text=あしたの会議は十時からです。
+[r1-closing] final  lang= punctuated=true audio_s=2.144 latency_ms=100.563 chars=11 text=資料は昨日送りました。
+[r1-closing] refine lang= punctuated=true audio_s=6.306 latency_ms=217.18  chars=38 text=東京の天気は晴れです。 あしたの会議は十時からです。 資料は昨日送りました。
+```
+
+`audio_s=6.306` is still `1.762 + 2.4 + 2.144` (the whole group), and
+`chars=38` is the three punctuated finals (11 + 14 + 11 characters) joined
+with one space each — this is the run before this change's join fix below,
+the shape "New defect 1" describes. The mechanism is exactly run 2's: the
+merged re-decode is still `資料は昨日送りました。` (confirmed again through
+public API alone, `[diag] merged_decode whole_file chars=10`), which strips
+to 10 characters against a fast-joined text that strips to 35, so
+`10 < 0.7 × 35` fires the guard and the text falls back to the joined
+finals — now punctuated, so `isCombinedFastTextPunctuated` reports the
+fallback honestly as `punctuated: true`.
+
+Turning only `applyToFinals` off, on the same build, reproduces run 2's
+line character for character:
+
+```
+[r2-closing-nofinalpunct] refine lang= punctuated=false audio_s=6.306 latency_ms=243.517 chars=35 text=東京の天気は晴れです あしたの会議は十時からです 資料は昨日送りました
+```
+
+`chars=35`, `punctuated=false`, same text as run 2's `[r3-closing]` — the
+flag is the whole difference, and the escape hatch its doc comment promises
+works. Per-segment refines (`r1-perseg` / `r2-perseg-nofinalpunct`) are
+unaffected either way: the group is a single segment there, so the guard
+never fires and both configurations end at the same refine text.
+
+### Timings
+
+**Android emulator x86_64, API 35, host Ryzen 5 5600 — not a phone.** Two
+processes, eight sessions, `modified_beam_search`, `numThreads` 2.
+
+`model_load` events, in ms:
+
+| model | n | median | run 2 median | run 1 median |
+|---|---:|---:|---:|---:|
+| `recognizer` | 8 | **3586.2** | 3883.7 | 3223 |
+| `punct` | 8 | **1317.6** | 1140.2 | 1072 |
+| `vad` | 8 | **37.9** | 32.9 | 33.9 |
+
+Every model's median moved within its own run-to-run spread across the
+three runs and nothing in these commits touches model building, so this
+reads as host-load noise on a shared desktop, same as run 2's recognizer
+jump.
+
+Finals (decode, plus `restore()` when `applyToFinals`), in ms:
+
+| segment `audio_s` | `applyToFinals` | n | median | vs. run 2's final median |
+|---:|---|---:|---:|---:|
+| 1.762 | false | 4 | **61.7** | 61.8 |
+| 2.400 | false | 4 | **77.6** | 80.4 |
+| 2.144 | false | 4 | **68.8** | 71.5 |
+| 1.762 | true (warm) | 2 | **109.5** | — |
+| 2.400 | true | 4 | **115.4** | — |
+| 2.144 | true | 4 | **117.3** | — |
+| 1.762 | true, **cold** (first final of the process) | 2 | **406.4** | — |
+
+`applyToFinals: false` reproduces run 2's final medians within 3 ms, as
+expected — punctuating finals has no effect on a final that stays
+unpunctuated. `applyToFinals: true` costs **+47.7 / +35.0 / +45.8 ms**: a
+final goes from ~62-80 ms to ~110-117 ms warm.
+
+Refines (re-decode + `restore()`), in ms:
+
+| `audio_s` | chars | punctuated | n | median |
+|---:|---:|---|---:|---:|
+| 1.762–2.144 (per-segment) | 11–14 | true | 4 each | 97.8–114.1 |
+| 6.306 (closing, `r1-closing`) | 38 | true (fallback) | 2 | **211.3** |
+| 6.306 (closing, `r2-closing-nofinalpunct`) | 35 | false (fallback) | 2 | **231.2** |
+
+Run 2's equivalent fallback samples were 214.2 / 245.9 ms at `chars=35` —
+consistent. No refine in this run paid a cold-start: with `applyToFinals`
+on, the first final absorbed it, and by the time the `applyToFinals: false`
+passes ran the process was already warm.
+
+**The cold-start moved from the refine path to the fast path.** Run 2 found
+the fp16 punctuation model's first `restore()` in a process costs ~300 ms
+more than every later one, and it landed on that process's first *refine*
+(407.9 / 412.7 ms there). With finals punctuated by default, this run found
+the same cost now lands on the first *final* instead (402.1 / 410.8 ms,
+against a warm 100–119 ms) — same one-time cost, moved onto the first
+caption line a user actually sees, because that is now whichever call
+happens first in a fresh process. Net work was unchanged; only where the
+latency was visible changed. See "New defect 2" (now fixed) below.
+
+### Two follow-ups, and what this change did about them
+
+**New defect 1 — the punctuated fallback kept the space that used to be the
+only separator.** `combineSegmentFastText` (`lib/live/refine_pass.dart`)
+joined every group's fast finals with `join(' ')`, mirroring the desktop
+joiner (`scripts/realtime_transcribe.py`'s `" ".join(...)`) for
+unpunctuated text. That was fine while the space was the only thing
+separating one sentence from the next in a fallback caption; now that every
+sentence already ends in 。, the space is a second, redundant separator, and
+`。 ` is not how Japanese is set — the desktop's own `[refine/ja]` reference
+line for this fixture has no spaces
+(`東京の天気は晴れです。あしたの会議は十時からです。資料は昨日送りました。`).
+Severity was cosmetic but user-visible, and the default path for any group
+of two or more ja segments on this recognizer.
+
+**Fixed in this change:** `combineSegmentFastText` now joins with `''`
+when `isCombinedFastTextPunctuated` says every contributing segment was
+punctuated, and keeps `' '` otherwise (the condition both functions already
+compute). The guard comparison is unaffected — `isRefineTextTooShort`
+compares lengths after `withoutRestoredMarks`, and dropping the redundant
+spaces only makes the fast side slightly shorter, i.e. the guard slightly
+less eager. Run 3's `[r1-closing]` line above (`chars=38`, with spaces) is
+what this branch produced *before* the join fix; after it, the same group
+now emits `東京の天気は晴れです。あしたの会議は十時からです。資料は昨日送りました。`
+with no spaces, matching the desktop reference exactly.
+
+**New defect 2 — the punctuation model's one-time warm-up moved onto the
+fast path.** Described in the cold-start paragraph above: the ~300 ms first
+`restore()` of a process, previously absorbed by the first refine, was now
+paid by the first final — the first caption line a user sees, not a 清書
+pass that arrives seconds later.
+
+**Fixed in this change:** `loadWorkerPunctuator`
+(`lib/live/decode_worker.dart`) now calls `punctuator.restore('あ')` once,
+right after `PunctuatorJa.load(...)` succeeds and before the `model_load`
+`punct`/`done` event is sent, discarding the result. The ~300 ms then lands
+inside the `model_load model=punct` number instead — already ~0.9-1.8 s and
+already understood as startup cost — rather than on the first final or
+refine. Cost: `model_load punct` reports ~300 ms higher; benefit: no
+400 ms spike on the first caption.
+
+### Doc-accuracy: the punctuation cost is higher than the earlier estimate
+
+`ja_punctuation.dart`'s `applyToFinals` doc and the README's punctuation
+section previously said "~25–35 ms per ~11–14 characters", inferred in run
+2 by subtracting two timers (warm refine median minus final median, over
+different audio paths). This run measured it directly instead — same
+audio, same code path, punctuation on vs. off:
+
+| segment | final median, `applyToFinals: false` | final median, `applyToFinals: true` (warm) | difference |
+|---:|---:|---:|---:|
+| 1.762 s (11 chars out) | 61.7 | 109.5 | **+47.8** |
+| 2.400 s (14 chars out) | 77.6 | 115.4 | **+37.7** |
+| 2.144 s (11 chars out) | 68.8 | 117.3 | **+48.5** |
+
+**≈38-49 ms per 11-14 character line**, warm, two intra-op threads, on this
+emulator — not 25-35. `ja_punctuation.dart` and the README have been
+updated to "~40-50 ms per ~11-14 characters" and now say it is a direct A/B
+measurement rather than a subtraction.
+
+### A known small waste, left alone
+
+`decode_worker.dart` punctuates a refine's merged re-decode unconditionally,
+and `live_transcriber.dart`'s shrink guard may then throw that text away
+entirely in favour of `payload.fastText`. On every group refine that hits
+the guard — the default outcome for ≥2 ja segments on this recognizer —
+one `restore()` (~40-50 ms) is spent on text nobody sees; the worker has
+`payload.fastText`/`payload.fastTextPunctuated` in hand already and could
+check `isRefineTextTooShort` before punctuating, skipping the call. **Not
+fixed here** — it costs only time, and the closing refine's measured
+latency did not get worse (211.3 ms punctuated vs. 231.2 ms unpunctuated,
+noise at n=2).
+
+### What remains unverified after run 3
+
+Unchanged from runs 1 and 2: no physical ARM device (everything here is
+emulated x86_64, and the fp16 punctuation model is the figure most likely
+to move on a real phone), `RoutingProfile.jaSenseVoice` still not
+exercised (every pass here went through the plain-session
+`punctuatePlainSession` branch, not the routed `lang == 'ja'` branch of
+`shouldPunctuate`), `restore()` still not timed directly inside the package
+(the ~38-49 ms above is a difference between two configurations, not an
+instrumented number), the real-microphone grouping was not exercised (the
+closing refine ran through `startDebugWavStream`, not a mic, though it is
+the same code path a real `defaultAutoRefineSilenceSeconds = 4.0` pause
+would take), and no release build, no iOS.
+
 ## Next steps for a mobile profile
 
 - Load + accuracy validated on an Android emulator via `sherpa_onnx.dart`

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1,5 +1,11 @@
 # Mobile-Sized ja Model — INT8 Quantization of ReazonSpeech Zipformer
 
+This is an investigation log (model sizing, quantization, and on-device
+measurements), not the package guide. To embed live subtitles in a Flutter
+app, or to read the model-placement/platform-status reference this log's
+measurements feed into, see
+[`mobile/hayamimi_core/README.md`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/README.md).
+
 First step toward a "スマホ搭載プロファイル" (phone-deployable profile): shrink
 the ja-tier model (ReazonSpeech k2 zipformer transducer, `model_type=zipformer`,
 `sherpa-onnx-zipformer-ja-en-reazonspeech-2025-01-17/`) with dynamic INT8

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1222,6 +1222,193 @@ suspicious result in half and retry each half (`_looks_truncated` /
   OrtLibrary.processSymbols` on iOS remains unverified, and the punctuator
   still refuses to load there by default.
 
+## Android emulator verification, run 2 — the segmentation fixes, and a third defect (2026-09-01)
+
+The run above ended with two changes to `hayamimi_core`'s defaults (VAD
+silence, and pre-roll) and no evidence that they worked, because they were
+written after the measurement. This is the re-run that checks them, on the
+same AVD, the same models, and the same 6.26 s three-sentence Japanese
+fixture. **Both defects are fixed.** A third, which the fixes made visible,
+is not — it is described at the end, along with the change this branch makes
+for it.
+
+Same setup as run 1 in every respect (emulator `hayamimi_test`,
+`ro.product.cpu.abi=x86_64`, API 35, host Windows 11 / Ryzen 5 5600, Flutter
+3.47.1 / Dart 3.13.1, ReazonSpeech ja zipformer int8 with
+`decodingMethod: 'modified_beam_search'` and `numThreads` 2, the fp16
+punctuation model, `RoutingProfile.jaOnly`, input through
+`startDebugWavStream`). Nothing was pushed to the device again: the model
+files were already there from run 1, and the padded wav on the device is
+byte-identical (328,418 B) to the one run 1 made. ONNX Runtime reported
+itself as 1.27.1, C API 11, unchanged.
+
+Five passes were run, twice, in two fresh processes — ten sessions in total.
+**Every text and every `audio_s` is identical between the two processes.** No
+`ErrorSubtitleEvent`, no `DecodeWorkerDied`, no crash.
+
+| pass | `prerollSeconds` | `vadSensitivity` | what it is for |
+|---|---|---|---|
+| `r1-defaults` | 1.0 (default) | package default (0.35 / 12.0) | the shipped configuration |
+| `r2-preroll0` | **0** | package default | control: turn pre-roll off only |
+| `r3-closing` | 1.0 | package default | package defaults with no `refineNow()` driver at all |
+| `r1-defaults-2` | 1.0 | package default | repeat of the first, for stability |
+| `old-defaults` | **0** | **0.5 / 5.0** | control: reproduce run 1 on this build |
+
+### The two defects from run 1: fixed
+
+Run 1's output, run 2's output, and the desktop reference, on the same file:
+
+| sentence | desktop reference | run 1 (0.5 s silence, no pre-roll) | run 2 `r1-defaults` |
+|---|---|---|---|
+| 1 | 東京の天気は晴れです。 | 東京の天気は晴れです。 | 東京の天気は晴れです。 |
+| 2 | あしたの会議は十時からです。 | 会議は十時からです。 (`あしたの` lost) | **あしたの会議は十時からです。** |
+| 3 | 資料は昨日送りました。 | 昨日は昨日送りました。 (`資料`→`昨日`) | **資料は昨日送りました。** |
+| segment lengths | 1.8 / 2.4 / 2.1 s | 1.564 / 2.044 / 1.724 s | **1.762 / 2.400 / 2.144 s** |
+
+All three sentences now match the desktop character for character, and the
+segment durations land within 40 ms of the desktop's.
+
+Each fix has its own control, so neither is credited with the other's effect.
+`old-defaults` puts run 1's VAD values back on this build and reproduces run
+1's single merged segment exactly — one 6.134 s segment reading
+`資料は昨日送りました`, the last sentence alone. `r2-preroll0` turns off only
+`prerollSeconds`, on the fixed VAD defaults, and reproduces run 1's texts and
+run 1's `audio_s` values exactly (1.564 / 2.044 / 1.724 s,
+`東京の天気は晴れです。` / `会議は十時からです。` / `昨日は昨日送りました。`).
+
+The pre-roll actually prepended was 0.198 / 0.356 / 0.420 s, not the full
+1.0 s, because `PrerollHistory.withPreroll` clamps at the previous segment's
+end so a segment never reaches back into the one before it. That is the
+documented behaviour, measured.
+
+### The closing refine fires
+
+`r3-closing` runs on the package's true defaults — `autoRefineEnabled` false,
+which is its own default, and no `refineNow()` call anywhere. A refine still
+arrives over all three finals before the awaited future completes, at
+`audio_s=6.306`, which is exactly `1.762 + 2.400 + 2.144`: the whole group.
+Run 1's equivalent measurement was a `refineNow()` after the await that found
+`refineBufferedSeconds=0.0` and did nothing, so the closing-refine change
+does what it was written to do.
+
+### Timings
+
+**Android emulator x86_64, API 35, host Ryzen 5 5600 — not a phone.** The
+AVD's CPU is the desktop's under virtualization. The float16 punctuation
+numbers are the least transferable of all, for the reason run 1 gives: ONNX
+Runtime's CPU provider has no float16 compute path on x86 and casts to
+float32 and back on every operator, which an ARM chip with a float16 vector
+unit does not do. Two processes, ten sessions.
+
+`model_load` events, in ms:
+
+| model | conditions | n | min | max | median | run 1 median |
+|---|---|---:|---:|---:|---:|---:|
+| `recognizer` | ja zipformer int8 (encoder 70.9 MB + decoder + joiner), 2 threads, `modified_beam_search` | 10 | 3390.3 | 4563.3 | **3883.7** | 3223 |
+| `punct` | `punct_bert.fp16.onnx` 181.8 MB, 2 intra-op threads | 10 | 927.4 | 1994.9 | **1140.2** | 1072 |
+| `vad` | `silero_vad.onnx` 0.64 MB | 10 | 21.5 | 41.8 | **32.9** | 33.9 |
+
+The recognizer median moved up ~660 ms against run 1. None of the three
+commits under test touches model building, and the `punct`/`vad` medians are
+flat, so read it as host load on a shared desktop rather than a regression.
+The first load of each model in a fresh process is at the slow end of its
+range.
+
+Finals (decode only, inside the worker), in ms:
+
+| segment `audio_s` | sentence | n | min | median | max |
+|---:|---|---:|---:|---:|---:|
+| 1.762 | 東京の天気は晴れです | 6 | 59.3 | **61.8** | 69.0 |
+| 2.400 | あしたの会議は十時からです | 6 | 74.3 | **80.4** | 91.4 |
+| 2.144 | 資料は昨日送りました | 6 | 66.1 | **71.5** | 85.6 |
+
+Real-time factor ≈ 0.033x, unchanged from run 1. Pre-roll costs 0–9 ms per
+final for 0.2–0.42 s of extra audio, which is inside the noise.
+
+Refines over those same segments, punctuated (re-decode plus `restore()`,
+reported as one number), in ms: **97–114 warm**, and **407.9 / 412.7** for
+the first refine in each of the two processes. That first-refine cost is a
+one-time warm-up inside the fp16 punctuation model, not a per-session one —
+each process ran five sessions and only the first refine paid it.
+
+**`restore()` is still not timed directly.** `latencyMs` covers the
+re-decode and the punctuation together, so subtracting the median final over
+the same audio is the only number available:
+
+| `audio_s` | refine (warm median) | final (median) | difference | output chars |
+|---:|---:|---:|---:|---:|
+| 1.762 | 97.2 | 61.8 | **35.4** | 11 |
+| 2.400 | 114.4 | 80.4 | **34.0** | 14 |
+| 2.144 | 96.6 | 71.5 | **25.1** | 11 |
+
+So roughly **25–35 ms per 11–14 character line**, warm, two intra-op threads
+— consistent with run 1's 26–33 ms per ~10 characters. It remains an
+inference from the difference of two timers.
+
+### The third defect: the fallback refine was unpunctuated
+
+On package defaults, `r3-closing`'s refine came back **unpunctuated**,
+reproduced identically in both processes:
+
+```
+[r3-closing] refine lang= punctuated=false audio_s=6.306 latency_ms=214.19 chars=35 text=東京の天気は晴れです あしたの会議は十時からです 資料は昨日送りました
+```
+
+Three sentences the fast path had recognized correctly, joined with spaces
+and no 。 anywhere.
+
+The mechanism, measured. A refine re-decodes the group's audio as one
+buffer, and this ja transducer keeps only the last utterance of
+multi-utterance audio — run 1 established that on the desktop, and this run
+re-established it on the device through public API alone
+(`LiveTranscriber.runDebugWavRefineTest`: the whole file returns
+`資料は昨日送りました`, 10 characters). So the merged re-decode came back at 10
+characters against a `fastText` of 35, and `10 < 0.7 × 35` fired
+`isRefineTextTooShort`, which replaced the text with the fast finals joined.
+That guard is doing its job — it stopped a caption that would have lost two
+of three sentences. The defect is that nothing had punctuated those finals,
+so the refine went out raw.
+
+It is not confined to the debug path. Punctuation ran in the decode worker,
+before the guard runs on the caller's isolate, so any refine whose group held
+two or more ja segments hit this; with `defaultAutoRefineSilenceSeconds` at
+4.0 s a real microphone session groups several sentences per refine, so it
+was the normal case. The harness only saw punctuated refines in the other
+passes because it forced `autoRefineSilenceSeconds` to 0.3 s, one refine per
+segment. Defect 1's fix is what exposed it: with run 1's single merged
+segment there was one sentence in the group and nothing to fall back to, so
+`old-defaults` still shows `punctuated=true`.
+
+**The desktop pipeline does not have this hole** because its fast finals are
+already punctuated — `RoutedASR.transcribe` runs `punct_ja.py` over ja finals
+— so `scripts/realtime_transcribe.py`'s identical `0.7 × len(fast_joined)`
+fallback yields punctuated text, and its line reads
+`[refine/ja] 東京の天気は晴れです。あしたの会議は十時からです。資料は昨日送りました。`
+
+**What this branch changed.** The decode worker now punctuates
+`finalSegment` results under the same condition it punctuates refines
+(routed `lang == 'ja'`, or a plain session flagged Japanese), so the joined
+fast text is already punctuated and the fallback keeps its marks. The refine
+reports `punctuated: true` only when every final in the group was
+punctuated, and the shrink comparison strips the restored marks off both
+sides rather than only the refine's. Drafts stay unpunctuated. The cost is
+one `restore()` per utterance rather than per refine — 25–35 ms per line at
+the sizes above, on the emulator — which `JaPunctuation(applyToFinals:
+false)` declines, restoring the refine-only behaviour and its unpunctuated
+fallback. `LiveTranscriptEntry`/`FinalSubtitleEvent` now carry `punctuated`
+(wire: `"punctuated"`) so a consumer can see which lines it applied to.
+
+**This fix has not been run on the emulator.** It is covered by the
+package's own tests only; a third run is what would confirm it on a device.
+
+### What remains unverified after run 2
+
+Unchanged from run 1: no physical ARM device (everything is emulated
+x86_64), `RoutingProfile.jaSenseVoice` still not exercised, `restore()`
+still not timed directly, and no release build and no iOS — so
+`OrtLibrary.processSymbols` on iOS remains unverified. New to this run: the
+punctuated-finals fix above.
+
 ## Next steps for a mobile profile
 
 - Load + accuracy validated on an Android emulator via `sherpa_onnx.dart`

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1007,6 +1007,221 @@ this pass — routed drafts share the same `_runDraftDecode`/`_processFrame`
 plumbing already verified for `jaOnly`, so the delta is small, but it's
 worth a follow-up routed-profile wav-stream run).
 
+## Android emulator verification of the decode worker and punctuation (2026-09-01)
+
+Two things had been built for `hayamimi_core` without ever running on
+Android: the persistent decode worker isolate (issue #24) and the Dart
+Japanese punctuation port (issue #15). Both had a specific reason to be
+doubted there. The worker spawns an isolate that loads sherpa-onnx models
+itself, which is a different code path from loading them on the isolate
+that spawned it. The punctuator reaches ONNX Runtime by opening
+`libonnxruntime.so` over `dart:ffi` — the library `sherpa_onnx` already
+ships — and if a second copy of that library ended up in the APK, two ONNX
+Runtimes in one Android process is a known crash
+([sherpa-onnx#3261](https://github.com/k2-fsa/sherpa-onnx/issues/3261)).
+This is the run that settled both, plus what it turned up about
+segmentation that had nothing to do with Android.
+
+### Setup
+
+| | |
+|---|---|
+| Device | **Android emulator x86_64, API level 35** (`ro.product.cpu.abi=x86_64`), AVD `hayamimi_test` |
+| Host | Windows 11 (10.0.26200), AMD Ryzen 5 5600 |
+| Toolchain | Flutter 3.47.1 stable / Dart 3.13.1, Android SDK emulator 37.1.11.0 |
+| App | the package's own `example/` app, debug build, `--target-platform android-x64` |
+| ASR | ReazonSpeech ja zipformer int8 (`encoder`/`decoder`/`joiner-epoch-35-avg-1.int8.onnx` + `tokens.txt`), `numThreads` 2, `decodingMethod: 'modified_beam_search'` passed explicitly to match `scripts/asr_engine.py` rather than measure the package's `greedy_search` default |
+| Punctuation | `quantized_ort/punct_bert.fp16.onnx` (181.8 MB) + `vocab.txt`. The desktop reference uses the fp32 `punct_bert.onnx` (363 MB) |
+| Profile | `RoutingProfile.jaOnly`. `jaSenseVoice` was out of scope |
+| Input | `testdata/multi_sentence_ja.wav` (three ja sentences, 6.26 s, 16 kHz mono) through `startDebugWavStream`, since an emulator has no usable microphone |
+
+Model files cannot be `adb push`ed straight into
+`getApplicationDocumentsDirectory()`
+(`/data/user/0/<pkg>/app_flutter`); they went via `/data/local/tmp` and
+`run-as <pkg> cp`, laid out as `model/`, `vad/silero_vad.onnx`, `punct/`,
+`wav/`.
+
+### What was verified
+
+**The decode worker comes up and stays up on Android.** `Isolate.spawn`
+succeeded, `sherpa_onnx.initBindings()` inside the worker succeeded, and
+every model was built there and reported back over the worker's `SendPort`
+as `model_load` frames — which is the proof, since a failed spawn or a
+failed `initBindings()` would have thrown `DecodeWorkerException` from
+`start()` and no `model_load` frame could have arrived at all. Decode
+results crossed the isolate boundary for the whole run, and the worker was
+shut down and rebuilt three times in one process (three sequential
+`startDebugWavStream` passes) with no crash, no `DecodeWorkerDied`, and no
+`ErrorSubtitleEvent`.
+
+**Punctuation reaches ONNX Runtime through the copy `sherpa_onnx` already
+loads.** The APK contains exactly one `lib/x86_64/libonnxruntime.so`
+(25,000,408 bytes) — no second runtime was added.
+`DynamicLibrary.open('libonnxruntime.so')` resolved, `OrtGetApiBase` was
+found, and the runtime served C API version 11, reporting itself as ONNX
+Runtime **1.27.1** — the same version this repo records from the Windows
+host. That is the Android default branch in `lib/punct/ort_library.dart`
+taken as-is, with no `libraryPath`. The real evidence is the worker
+though: it built the 181.8 MB float16 model through that same path and ran
+`restore()` on its own decode results.
+
+**Refines came back punctuated, and punctuated the way the reference
+punctuates.** `RefineSubtitleEvent.punctuated` was `true` and the text
+carried 。 :
+
+```
+refine punctuated=true audio_s=1.564 text=東京の天気は晴れです。
+refine punctuated=true audio_s=2.044 text=会議は十時からです。
+refine punctuated=true audio_s=1.724 text=昨日は昨日送りました。
+```
+
+A control pass over the same audio with no punctuation model returned
+`punctuated=false` and no 。 , so the marks are the punctuation model's
+output and not something the recognizer produced. Against the desktop
+reference run of the same file, **every 。 the desktop places, this run
+places, at the same sentence ends** — so the Dart `PunctuatorJa` plus the
+float16 model agrees with the Python fp32 reference on this input. What
+differs between the two is upstream of punctuation, in the recognizer's
+input, and is the subject of the next two sections.
+
+### Timings
+
+**Android emulator x86_64, API 35, host Ryzen 5 5600 — not a phone.** The
+AVD's CPU is the desktop's under virtualization. The float16 punctuation
+numbers are the least transferable of all, because ONNX Runtime's CPU
+provider has no float16 compute path on x86 and casts to float32 and back
+on every operator, which an ARM chip with a float16 vector unit does not
+do.
+
+`model_load` events, in ms:
+
+| model | conditions | n | min | max | median |
+|---|---|---:|---:|---:|---:|
+| `recognizer` | ja zipformer int8 (encoder 70.9 MB + decoder + joiner), 2 threads, `modified_beam_search` | 8 | 2929.0 | 3679.1 | 3223 |
+| `punct` | `punct_bert.fp16.onnx` 181.8 MB, 2 intra-op threads | 7 | 855.2 | 1535.5 | 1072 |
+| `vad` | `silero_vad.onnx` 0.64 MB | 8 | 24.8 | 44.5 | 33.9 |
+
+The first load of each in a fresh process is the slow end of its range
+(cold page cache).
+
+Finals (decode only, inside the worker) and refines (re-decode plus
+`restore()`, reported as one number), in ms:
+
+| audio_s | final | refine, punctuated | refine, no punctuation model |
+|---:|---|---|---|
+| 1.564 | 52.6 / 54.4 | 83.1 / 95.8 | — |
+| 1.724 | 54.1 / 57.4 | 80.1 / 81.4 | — |
+| 2.044 | 66.5 / 65.7 | 93.1 / 85.5 | — |
+| 6.134 (merged) | 370.8 / 165.7 / 142.9 / 161.8 / 174.9 | 832.5 (cold) / 539.2 / 485.2 / 217.6 | 184.6 |
+
+Real-time factor on the split segments is roughly 0.03x.
+
+**Punctuation was not timed directly.** `RefineSubtitleEvent.latencyMs`
+covers the re-decode and `restore()` together, so the only way to get a
+number for the punctuation pass alone was to subtract the final over the
+identical samples — same recognizer, same audio:
+
+| audio_s | refine (punctuated) | final (decode only) | difference | output chars |
+|---:|---:|---:|---:|---:|
+| 1.564 | 83.1 | 52.6 | 30.5 | 10 |
+| 2.044 | 93.1 | 66.5 | 26.6 | 9 |
+| 1.724 | 80.1 | 54.1 | 26.0 | 10 |
+| 6.134 | 217.6 | 184.6 (no-punct refine) | 33.0 | 10 |
+
+So roughly **26–33 ms per ~10-character line**, warm, two intra-op threads.
+This is an inference from the difference of two timers, not a measurement.
+For scale, the package README records 66–90 ms mean on the Windows host
+over 55-character inputs; `restore()` scales with sequence length, so the
+two are not in conflict.
+
+### Two segmentation findings, and what this change did about them
+
+The desktop reference run of the same file
+(`scripts/realtime_transcribe.py --wav testdata/multi_sentence_ja.wav
+--no-realtime --mode single --lang ja --threads 4`) produces three
+sentences:
+
+```
+[ja/rz] 東京の天気は晴れです。      (seg=1.8s)
+[ja/rz] あしたの会議は十時からです。 (seg=2.4s)
+[ja/rz] 資料は昨日送りました。      (seg=2.1s)
+```
+
+With the package's defaults at the time, the emulator produced **one**
+segment of 6.134 s and **one** sentence: `資料は昨日送りました`.
+
+**Finding 1: the VAD defaults were sherpa-onnx's, not the desktop's.**
+`VadSensitivity` shipped `minSilenceSeconds = 0.5` and
+`maxSpeechSeconds = 5.0`; the desktop runs 0.35 and 12.0, and its own
+comment records 0.35 s as measured CER-neutral against 0.5 s on real
+broadcast ja while finalizing 150 ms sooner. This file's inter-sentence
+pauses fall in the 0.35–0.5 s band, so the package merged what the desktop
+split. Re-running with `minSilenceSeconds: 0.35` split it into three
+segments of 1.564 / 2.044 / 1.724 s and all three sentences came out,
+reproduced identically across two passes in one process. **The defaults are
+now 0.35 and 12.0.** Also observed on the way: the emitted segment was
+6.134 s under a configured `maxSpeechSeconds` of 5.0, so that value does
+not force a split the way its doc comment claimed — sherpa-onnx treats
+`max_speech_duration` as a nudge, and the doc now says so.
+
+**Finding 2: the Dart final path had no pre-roll.** Even with the VAD
+aligned, two sentences came out slightly wrong: `あしたの会議は十時からです`
+lost `あしたの`, and `資料は昨日送りました` became `昨日は昨日送りました`. The
+emulator's segments were also 0.24–0.38 s shorter than the desktop's on the
+same audio. The reason is that the desktop does not decode the VAD's
+samples as-is: `AudioHistory.with_preroll` prepends up to `PREROLL_S` = 1.0
+s of pre-onset audio to every segment, clamped so it never re-includes the
+previous one, and `tests/test_asr_segment.py` pins that behaviour on this
+very fixture (its docstring records the same `資料は` → `昨日は` failure with
+pre-roll forced to 0). Silero's speech-start detection lags the true onset
+— measured 198 ms behind on this fixture's first sentence — so without
+pre-roll the recogniser is handed audio that begins mid-word. **The package
+now does the same**, in `PrerollHistory`
+(`mobile/hayamimi_core/lib/live/preroll.dart`): a bounded rolling buffer on
+the caller's isolate, a new `prerollSeconds` knob defaulting to 1.0, and
+the extended samples used as the final's audio so `audio_s` and the refine
+buffer both reflect them.
+
+### A third finding that is not ours to fix
+
+**The merge is what destroyed the text, and the truncation is a model
+property.** Verified on the desktop, same int8 model, no VAD at all:
+
+| input | result |
+|---|---|
+| whole 6.26 s file, `modified_beam_search` | `資料は昨日送りました` |
+| whole 6.26 s file, `greedy_search` | `資料は昨日送りました` |
+| 0.0–1.8 s | `東京の天気は晴れです` |
+| 1.8–4.2 s | `〈明日の会議は十時からです` |
+| 4.2 s–end | `資料は昨日送りました` |
+| 0.0–4.2 s (sentences 1+2) | `〈明日の会議は十時からです` |
+
+Given multi-utterance audio this ReazonSpeech transducer keeps only the
+**last** utterance, identically on Windows x86 and Android x86_64. So VAD
+segmentation is load-bearing for correctness here, not an optimisation, and
+a refine over a long group can still lose its leading sentences. The
+package's existing "a merged re-decode must never lose content" guard
+(`isRefineTextTooShort`) catches the case where several good finals refine
+to one sentence, but not the case where a single over-long segment was
+already truncated on the fast path. The desktop's further remedy — split a
+suspicious result in half and retry each half (`_looks_truncated` /
+`_split_retry` in `scripts/asr_engine.py`, v0.3.1) — **is not ported to
+`hayamimi_core` yet.**
+
+### What remains unverified
+
+- **No physical ARM device.** Everything above is emulated x86_64 on a
+  desktop CPU. The float16 punctuation timing in particular should not be
+  extrapolated to a phone.
+- **`RoutingProfile.jaSenseVoice` was not exercised.** Only `jaOnly` was in
+  scope, so the routed decode worker — SenseVoice plus the whisper-tiny
+  language-ID probe in one isolate — is still unrun on Android.
+- **`restore()` was not timed directly**, only inferred (see above). A
+  direct number needs a timer inside the worker's punctuator call site.
+- **No release build, and no iOS.** `libraryPath:
+  OrtLibrary.processSymbols` on iOS remains unverified, and the punctuator
+  still refuses to load there by default.
+
 ## Next steps for a mobile profile
 
 - Load + accuracy validated on an Android emulator via `sherpa_onnx.dart`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -4,7 +4,10 @@ Flutter app (Android + iOS, shared codebase) for prototyping hayamimi's
 speech recognition on phones. The recognition logic itself lives in the
 sibling [`hayamimi_core`](hayamimi_core/) package (path dependency, see
 `pubspec.yaml`) so other apps — e.g. a smart-glasses companion app — can
-embed the same live/remote transcription pipeline without this demo UI. See
+embed the same live/remote transcription pipeline without this demo UI.
+`hayamimi_core` is also published on
+[pub.dev](https://pub.dev/packages/hayamimi_core), so a third-party app can
+depend on it directly instead of a path/git dependency. See
 [`hayamimi_core/README.md`](hayamimi_core/README.md) for the embedding API.
 This app has three screens:
 

--- a/mobile/hayamimi_core/CHANGELOG.md
+++ b/mobile/hayamimi_core/CHANGELOG.md
@@ -13,12 +13,39 @@
   adding a second `libonnxruntime.so` to the app (two in one Android
   process is a known crash, k2-fsa/sherpa-onnx#3261). New dependencies:
   `unorm_dart` (NFKC, which `dart:core` has no equivalent of) and `ffi`.
-  This is phase 1 of
-  [#15](https://github.com/oboroge0/hayamimi/issues/15): it is **not yet
-  wired into `HayamimiLive`**, and the float16 model file it needs
-  (181.8 MB) is not downloadable yet — see "Japanese punctuation
-  restoration" in the README for the platform status and what is still
-  unverified.
+  See "Japanese punctuation restoration" in the README for the platform
+  status and what is still unverified.
+* `LiveTranscriber.start`/`startDebugWavStream` and `HayamimiLive.start`/
+  `startDebugWavStream` take an optional `JaPunctuation`, which turns the
+  punctuation model above on for that session's refine ("清書") output —
+  the second half of
+  [#15](https://github.com/oboroge0/hayamimi/issues/15). Passing nothing
+  keeps the previous behaviour exactly. Only refine results are
+  punctuated: that is where the desktop pipeline punctuates, and a final
+  covers one speech segment while a draft covers part of one still being
+  spoken, so sentence boundaries there would fall wherever the speaker
+  paused. A `RoutingProfile.jaSenseVoice` session punctuates the refines
+  that came back as Japanese and leaves the rest alone; a plain
+  single-model session has no language tag to test, so passing this to one
+  is itself the statement that its model transcribes Japanese (do not pass
+  it to a plain session with a non-Japanese model). The model loads in the
+  decode worker isolate, after the recognizers, and is reported on
+  `modelLoads`/`ModelLoadSubtitleEvent` as `model: "punct"`: `restore()` is
+  a synchronous native call, and running it on the caller's isolate would
+  hand back the pause that moving decoding off it removed. Failing to load
+  it fails `start()` with a message naming the file, rather than starting a
+  session that quietly produces unpunctuated text. `LiveTranscriptEntry`
+  and `RefineSubtitleEvent` gained `punctuated` (and `"punctuated"` in that
+  event's JSON, beside every key that was already there) so a consumer can
+  tell text the punctuation model wrote from text the recognizer produced.
+  The refine pass's "too short, fall back to the fast finals" guard now
+  compares lengths with the restored marks stripped, since they are
+  characters nobody said and would otherwise excuse a truncated re-decode.
+  The float16 model file (181.8 MB) is still not downloadable —
+  `ModelDownloader` has no entry for it — so a host app has to place it and
+  its `vocab.txt` on the device itself. No device or emulator run happened
+  in this change: what a phone's ONNX Runtime does, and what `restore()`
+  costs on an ARM CPU, is still unverified.
 * Initial extraction from `mobile/`'s app-only codebase: on-device live
   transcription (`HayamimiLive`/`LiveTranscriber`), a remote-server client
   (`HayamimiRemote`/`RemoteTranscriber`), a LAN subtitle broadcast server

--- a/mobile/hayamimi_core/CHANGELOG.md
+++ b/mobile/hayamimi_core/CHANGELOG.md
@@ -156,6 +156,63 @@ into a standalone package a third-party Flutter app can embed.
   has to place it and its `vocab.txt` on the device itself; see "Japanese
   punctuation restoration" in the README for the model-placement and
   platform-status details, and "Known limitations" below.
+* **Segmentation and segment audio, after the first Android emulator run.**
+  Running the live pipeline on an Android x86_64 emulator turned up two
+  ways the mobile port produced worse text than the desktop pipeline on the
+  same recording, neither of them an Android or an FFI problem. Both are
+  fixed here, and both change what a caller who passes no configuration
+  gets.
+
+  `VadSensitivity`'s defaults were sherpa-onnx's stock values
+  (`minSilenceSeconds` 0.5, `maxSpeechSeconds` 5.0); they are now the
+  desktop pipeline's tuned ones (**0.35** and **12.0**,
+  `scripts/realtime_transcribe.py`). On a three-sentence Japanese recording
+  whose pauses fall just under half a second, the stock silence default
+  merged all three sentences into one 6.13 s segment and the ja recognizer,
+  handed that segment, returned only the last sentence — two sentences gone,
+  with nothing in the output to say so. At 0.35 s the same audio split into
+  three segments and all three came out. The desktop records 0.35 s as
+  measured no worse for accuracy than 0.5 s while finalizing 150 ms sooner.
+  Segments now finalize on shorter pauses, so a transcript has more lines,
+  each shorter. `maxSpeechSeconds`'s doc also stops calling itself a hard
+  cap that force-closes a segment "even mid-speech": the same run emitted a
+  6.134 s segment from a session configured with 5.0 s.
+  `VadSensitivity(minSilenceSeconds: 0.5, maxSpeechSeconds: 5.0)` restores
+  the previous behaviour.
+
+  Every segment is now decoded together with up to a second of the audio
+  recorded *before* the VAD's detected onset. Silero VAD notices speech
+  slightly late, so its samples can begin partway into the first word:
+  `資料は昨日送りました` came back as `昨日は昨日送りました`, and another
+  sentence lost its `あしたの`. The desktop has prepended pre-onset context
+  since long before this package existed (`AudioHistory` / `PREROLL_S`); the
+  Dart equivalent is `PrerollHistory` (`lib/live/preroll.dart`), a bounded
+  rolling buffer on the caller's isolate, clamped so two consecutive
+  segments never both contain the gap between them. The prepended audio is
+  part of the segment from then on: it is decoded, counted in
+  `LiveTranscriptEntry.audioSeconds` (wire: `audio_s`), and stored in the
+  refine buffer, so a final's reported duration grows by up to a second.
+  New `prerollSeconds` knob on `LiveTranscriber`/`HayamimiLive`
+  (constructor plus runtime setter, default 1.0 s) — the one pacing knob
+  where `0` is valid, meaning "decode exactly what the VAD delimited".
+  `LiveVad.takeSegment` now returns a `LiveSpeechSegment` (samples plus the
+  segment's start position) instead of bare samples, since the samples alone
+  do not say where the audio before them is.
+
+* **`startDebugWavStream` finishes with a refine.** The method exists so a
+  device with no usable microphone can still be shown what a live session
+  produces, and the README points at it as the way to see punctuated refine
+  output — but with default settings it could not produce a refine at all.
+  Auto-refine is off by default, and the method tears the session down in
+  its own `finally`, so a `refineNow()` after the returned future completes
+  found no worker and silently did nothing. It now runs one refine over
+  what its finals buffered (when that is at least half a second of audio)
+  and awaits it before teardown, so one awaited call is enough to see a
+  punctuated refine. `autoRefineEnabled`'s setter also starts its timer for
+  a debug stream rather than only for a microphone session, so turning auto
+  mode on mid-stream works; and the debug path now cancels that timer when
+  it ends, which it never did.
+
 * **Bench and eval utilities.** `BenchRunner` measures offline WAV→RTF for a
   single zipformer-transducer model; `ManifestEvalRunner` batch-decodes a
   manifest of labeled clips (plain or through `RoutingProfile.jaSenseVoice`
@@ -166,14 +223,31 @@ into a standalone package a third-party Flutter app can embed.
 
 ### Known limitations
 
-* The punctuation model has not been run on a device in this release: its
-  wiring was verified on a Windows host (`flutter analyze`/`flutter test`,
-  including the parity test above), but what a phone's ONNX Runtime does,
-  and what `restore()` costs on an ARM CPU, is unverified. It's also
+* The punctuation model has been run on an **Android x86_64 emulator**, not
+  on a phone. The emulator run confirmed the FFI path (`libonnxruntime.so`
+  resolved to the single copy `sherpa_onnx` ships, ONNX Runtime 1.27.1) and
+  that ja refines come back punctuated the way the Python reference
+  punctuates them, but an emulator's CPU is the host PC's under
+  virtualization, and ONNX Runtime has no float16 compute path on x86 —
+  so what `restore()` costs on an ARM CPU is still unverified. It is also
   refused by default on iOS — `sherpa_onnx` links ONNX Runtime as an
   xcframework and it hasn't been confirmed that `OrtGetApiBase` stays
   exported from the app binary, so `PunctuatorJa.load` throws rather than
   guess unless a caller passes `libraryPath: OrtLibrary.processSymbols`.
+* A refine over a long group can come back holding only its last sentence.
+  This is a property of the ReazonSpeech transducer rather than of this
+  package: given the whole 6.26 s multi-sentence test file with no VAD at
+  all, the same int8 model returns the same single sentence on a Windows
+  host under both search algorithms. The tuned VAD defaults above make long
+  groups much rarer, and a refine that comes back much shorter than the
+  finals it replaces falls back to their text — but the desktop pipeline's
+  further remedy, splitting a suspicious result in half and retrying each
+  half (`_looks_truncated`/`_split_retry` in `scripts/asr_engine.py`,
+  v0.3.1), is not ported here yet.
+* `RoutingProfile.jaSenseVoice` has not been run on Android: the emulator
+  verification above used `jaOnly`, so the routed decode worker (SenseVoice
+  plus the whisper-tiny language-ID probe in one isolate) is exercised only
+  by the iOS session and this repo's own tests.
 * This package does not observe the app lifecycle: a host app that wants
   `stop()` on background and `start()` on resume has to wire that up
   itself from its own `WidgetsBindingObserver`.

--- a/mobile/hayamimi_core/CHANGELOG.md
+++ b/mobile/hayamimi_core/CHANGELOG.md
@@ -1,56 +1,43 @@
 ## 0.1.0
 
-* Added `PunctuatorJa`: Japanese punctuation restoration for the mobile
-  pipeline. The desktop pipeline punctuates its refine ("清書") output with
-  `scripts/punct_ja.py`, so desktop captions read as sentences while this
-  package's refine output arrived with no 、 and no 。 at all. `restore()`
-  is a Dart port of that script — the same character-level BERT model, the
-  same thresholds, the same rule-based ？ pass — pinned to the reference
-  implementation by `test/punct/punct_ja_parity_test.dart`, which replays
-  40 FLEURS ja sentences plus 11 edge cases and asserts the two produce
-  identical text. It runs the model through ONNX Runtime's C API over
-  `dart:ffi`, borrowing the runtime `sherpa_onnx` already loads rather than
-  adding a second `libonnxruntime.so` to the app (two in one Android
-  process is a known crash, k2-fsa/sherpa-onnx#3261). New dependencies:
-  `unorm_dart` (NFKC, which `dart:core` has no equivalent of) and `ffi`.
-  See "Japanese punctuation restoration" in the README for the platform
-  status and what is still unverified.
-* `LiveTranscriber.start`/`startDebugWavStream` and `HayamimiLive.start`/
-  `startDebugWavStream` take an optional `JaPunctuation`, which turns the
-  punctuation model above on for that session's refine ("清書") output —
-  the second half of
-  [#15](https://github.com/oboroge0/hayamimi/issues/15). Passing nothing
-  keeps the previous behaviour exactly. Only refine results are
-  punctuated: that is where the desktop pipeline punctuates, and a final
-  covers one speech segment while a draft covers part of one still being
-  spoken, so sentence boundaries there would fall wherever the speaker
-  paused. A `RoutingProfile.jaSenseVoice` session punctuates the refines
-  that came back as Japanese and leaves the rest alone; a plain
-  single-model session has no language tag to test, so passing this to one
-  is itself the statement that its model transcribes Japanese (do not pass
-  it to a plain session with a non-Japanese model). The model loads in the
-  decode worker isolate, after the recognizers, and is reported on
-  `modelLoads`/`ModelLoadSubtitleEvent` as `model: "punct"`: `restore()` is
-  a synchronous native call, and running it on the caller's isolate would
-  hand back the pause that moving decoding off it removed. Failing to load
-  it fails `start()` with a message naming the file, rather than starting a
-  session that quietly produces unpunctuated text. `LiveTranscriptEntry`
-  and `RefineSubtitleEvent` gained `punctuated` (and `"punctuated"` in that
-  event's JSON, beside every key that was already there) so a consumer can
-  tell text the punctuation model wrote from text the recognizer produced.
-  The refine pass's "too short, fall back to the fast finals" guard now
-  compares lengths with the restored marks stripped, since they are
-  characters nobody said and would otherwise excuse a truncated re-decode.
-  The float16 model file (181.8 MB) is still not downloadable —
-  `ModelDownloader` has no entry for it — so a host app has to place it and
-  its `vocab.txt` on the device itself. No device or emulator run happened
-  in this change: what a phone's ONNX Runtime does, and what `restore()`
-  costs on an ARM CPU, is still unverified.
-* Initial extraction from `mobile/`'s app-only codebase: on-device live
-  transcription (`HayamimiLive`/`LiveTranscriber`), a remote-server client
-  (`HayamimiRemote`/`RemoteTranscriber`), a LAN subtitle broadcast server
-  (`SubtitleBroadcastServer`), and offline WAV benchmarking (`BenchRunner`).
-* Every pacing knob that used to be a hardcoded `default*` constant
+First release: `hayamimi_core` extracted out of `mobile/`'s app-only codebase
+into a standalone package a third-party Flutter app can embed.
+
+* **On-device live transcription.** `HayamimiLive` (and the lower-level
+  `LiveTranscriber` it wraps) run mic → Silero VAD → a
+  [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) offline ASR model,
+  emitting a draft ("発話中の暫定字幕") line while a VAD segment is still in
+  progress and a finalized line once it closes. An optional two-pass
+  "refine" (清書) step re-decodes a buffered group of finals for a cleaner
+  transcript, on a silence gap, a buffered-duration ceiling, or a manual
+  `refineNow()` call. Passing `routingProfile: RoutingProfile.jaSenseVoice`
+  switches from the single fixed-language model to per-segment routing
+  between ReazonSpeech (ja) and SenseVoice (en/zh/ko/yue), arbitrated by a
+  whisper-tiny language-ID probe and SenseVoice's own dual-confirmation
+  policy.
+* **Remote client.** `HayamimiRemote` (and `RemoteTranscriber`) stream this
+  device's mic to a hayamimi server running on a PC (`--input ws --serve`)
+  over its `/ingest` WebSocket and surface the subtitle events streamed
+  back, so the PC's full pipeline (multi-language routing, refine,
+  translation) does the actual recognition. `RemoteFinalEvent`/
+  `FinalSubtitleEvent` and `RemoteRefineEvent`/`RefineSubtitleEvent` carry
+  the same `audioSeconds`/`switched`/`latencyMs`/`punctuated` fields the
+  on-device path reports (`latencyMs` was previously parsed for `final` but
+  not `refine`), and `RemoteModelLoadEvent`/`RemoteSessionResetEvent` map
+  onto `ModelLoadSubtitleEvent`/`SessionResetSubtitleEvent` the same way.
+  `model_fallback`/`warning`/`session_summary`/`recluster` frames from the
+  desktop pipeline still fall back to `RemoteUnknownEvent` — this package
+  doesn't have typed events for them yet.
+* **LAN subtitle broadcast server.** `SubtitleBroadcastServer` re-broadcasts
+  either facade's events as SSE plus a transparent overlay page, speaking
+  the same protocol `scripts/subtitle_server.py` does, so an OBS browser
+  source or web client that already works against the desktop app works
+  against an embedding app too. It gained `bindAddress` (still defaults to
+  `InternetAddress.anyIPv4` — the point of this server is LAN reachability)
+  and `allowOrigin` (still defaults to `'*'`) constructor parameters.
+* **Runtime configuration, events, and session reset**
+  ([#29](https://github.com/oboroge0/hayamimi/issues/29)). Every pacing
+  knob that used to be a hardcoded `default*` constant
   (`draftIntervalSeconds`, `draftWindowSeconds`, `minDraftAudioSeconds`,
   `autoRefineSilenceSeconds`, `autoRefineMaxBufferedSeconds`,
   `refineBufferMaxSeconds`) is now a `LiveTranscriber`/`HayamimiLive`
@@ -61,101 +48,144 @@
   threshold/min-silence/min-speech/max-speech knobs, with a runtime
   `setVadSensitivity` that rebuilds and safely swaps the VAD without
   reloading any other model or touching an in-progress segment), and
-  `hotwordsFile`/`hotwordsScore` (sherpa-onnx hotword biasing). See
-  "Runtime configuration and session control" in the README.
-* Added `resetSession()` on `LiveTranscriber`/`HayamimiLive`: clears the
-  refine buffer, draft state, and (for a `RoutingProfile.jaSenseVoice`
-  session) the routed language lock, without reloading any native model —
-  useful for a host app's "start a new conversation" action.
-* Decoding no longer runs on the caller's isolate. Every per-utterance
-  decode used to be a synchronous FFI call made on whichever isolate drove
-  the microphone stream — for a host app, Flutter's UI isolate — so the app
-  stopped painting for the length of each decode, and for much longer
-  during a refine ("清書") pass over a whole buffered group. Each session
-  now spawns one persistent decode worker isolate that owns that session's
-  recognizers (for `RoutingProfile.jaSenseVoice`, all three of them,
-  including the whisper-tiny language identification and the sticky-language
-  state) from first load to last free; requests reach it as messages
-  carrying the audio. What is left on the caller's isolate is microphone
-  capture, one Silero VAD `acceptWaveform` per 32 ms frame, and event
-  dispatch. Decode latency itself is unchanged — the work moved, it did not
-  shrink — and no on-device jank measurement was taken for this change.
-* Because decodes are now answered later rather than inline, the queue in
-  front of the worker follows explicit rules: finals are always queued,
-  never dropped, and emitted in the order their segments closed; drafts are
-  skipped while anything is outstanding and discarded on arrival if their
-  segment has since produced a final; refine passes coalesce, and claim
-  their audio when the request is actually sent rather than when it was
-  asked for (so a segment still decoding when you tap 清書 joins that
-  group). `refineNow()`'s future now completes once that pass's result has
-  been emitted, and a second call while one is still queued awaits the same
-  pass. `resetSession()` now round-trips the clear through the worker and
-  completes on its acknowledgement. `decoding` reports whether *anything*
-  is outstanding, so it emits one `true`/`false` pair per burst rather than
-  one per decode.
-* Added handling for the decode worker isolate dying mid-session: a
-  `LiveTranscriberException` on `LiveTranscriber.errors` (an
-  `ErrorSubtitleEvent` on `HayamimiLive.events`), microphone capture torn
-  down, and the object left ready to `start` again — the same handling a
-  revoked microphone gets. A single decode failing inside the worker is
-  reported the same way but does not stop the session. `stop`/`dispose`
-  wait for the worker's shutdown acknowledgement and kill the isolate if it
-  does not answer; see "Threading / known limitations" in the README for
-  why nothing is freed by force in that case.
-* New exported building blocks for the above, none of which a caller of
-  `HayamimiLive`/`LiveTranscriber` has to touch: `decode_protocol.dart`
-  (the worker message types and their encoding), `decode_scheduler.dart`
-  (`DecodeScheduler`, the pure queue policy), `decode_session.dart`
-  (`DecodeSession`, the caller's-isolate half) and `decode_worker.dart`
-  (`DecodeWorker`/`IsolateDecodeWorker`), and `live_vad.dart` (`LiveVad`,
-  the voice-activity detector a session feeds, plus the
-  Silero-via-sherpa-onnx implementation). `LiveTranscriber`'s constructor
-  gained `decodeWorkerFactory` and `vadFactory` parameters, and
-  `RoutedRecognizerSet.build` a `loadOffIsolate` one — all three exist so a
-  whole session can be exercised without a device, and all three default to
-  production behaviour.
-* `isSegmentWorthDecoding` now takes the segment's `Float32List` samples
-  rather than a `sherpa_onnx.SpeechSegment`, so neither it nor
-  `LiveTranscriber`'s segment handling depends on the FFI-backed package's
-  types any more.
-* `startDebugWavStream` reads its wav file with this package's own
-  pure-Dart PCM16 parser instead of sherpa-onnx's `readWave`. The accepted
-  format is unchanged (16-bit PCM), a wrong channel count is now reported
-  explicitly rather than as a generic read failure, and the debug streaming
-  path no longer touches FFI outside the models themselves.
-* `LiveTranscriptEntry`/`FinalSubtitleEvent`/`RefineSubtitleEvent` gained
-  `audioSeconds` (wire: `audio_s`) — the segment's or refined group's audio
-  duration — and `FinalSubtitleEvent` gained `switched` — whether this
-  segment is why a routed session's language changed. Added
-  `ModelLoadSubtitleEvent` (wire: `model_load`, one per native model's
-  load start/done, surfaced on `HayamimiLive.events` and
-  `LiveTranscriber.modelLoads`) and `SessionResetSubtitleEvent` (wire:
-  `session_reset`, emitted by `resetSession()`). See "Events" in the
-  README for the full JSON shape table.
-* `SubtitleBroadcastServer` gained `bindAddress` (still defaults to
-  `InternetAddress.anyIPv4` — the point of this server is LAN reachability)
-  and `allowOrigin` (still defaults to `'*'`) constructor parameters.
-* `RemoteFinalEvent`/`FinalSubtitleEvent` (via `HayamimiRemote`) now carry
-  `audioSeconds`/`switched` from a remote server the same way the on-device
-  path does; `RemoteRefineEvent`/`RefineSubtitleEvent` gained
-  `audioSeconds`, and `RemoteRefineEvent` also gained `latencyMs` (it was
-  parsed for `final` but never for `refine`). Added `RemoteModelLoadEvent`/
-  `RemoteSessionResetEvent`, mapped onto `ModelLoadSubtitleEvent`/
-  `SessionResetSubtitleEvent` on `HayamimiRemote.events` the same way the
-  on-device versions are. `model_fallback`/`warning`/`session_summary`/
-  `recluster` frames from the desktop pipeline still fall back to
-  `RemoteUnknownEvent` — this package doesn't have typed events for them
-  yet.
-* Fixed a native-handle leak: `LiveTranscriber.start()`/
-  `startDebugWavStream()` now free whatever `_buildNativeState` managed to
-  build (e.g. a good recognizer load followed by a bad VAD model file)
-  before rethrowing, instead of leaking it with `isRunning` still `false`.
-* Fixed `setVadSensitivity()` losing its effect when called while `start()`
-  was still loading: it's now queued and applied once loading finishes,
-  instead of being silently overwritten by the in-progress `start()` call's
-  own sensitivity.
-* Fixed a race where a `setVadSensitivity()` rebuild still in flight when a
-  session was stopped and immediately restarted could land on, and
-  silently replace, the *new* session's freshly built VAD. A monotonically
-  increasing generation counter (`isVadBuildStale`) now detects this and
-  discards the stale build instead of installing it.
+  `hotwordsFile`/`hotwordsScore` (sherpa-onnx hotword biasing). Added
+  `resetSession()`, which clears the refine buffer, draft state, and (for a
+  routed session) the language lock, without reloading any native model —
+  useful for a host app's "start a new conversation" action. New event
+  types: `LiveTranscriptEntry`/`FinalSubtitleEvent`/`RefineSubtitleEvent`
+  gained `audioSeconds` (wire: `audio_s`), `FinalSubtitleEvent` gained
+  `switched` (whether this segment is why a routed session's language
+  changed), and `ModelLoadSubtitleEvent` (wire: `model_load`) /
+  `SessionResetSubtitleEvent` (wire: `session_reset`) were added — see
+  "Runtime configuration and session control" and "Events" in the README
+  for the full parameter and JSON-shape reference. Three bugs surfaced
+  while building this were fixed alongside it: a native-handle leak where
+  `start()`/`startDebugWavStream()` left a partially built native state
+  (e.g. a good recognizer load followed by a bad VAD model file) allocated
+  with `isRunning` still `false` instead of freeing it before rethrowing;
+  `setVadSensitivity()` losing its effect when called while `start()` was
+  still loading, instead of being queued and applied once loading finished;
+  and a race where a `setVadSensitivity()` rebuild still in flight when a
+  session was stopped and immediately restarted could silently replace the
+  *new* session's freshly built VAD, now caught by a monotonically
+  increasing generation counter (`isVadBuildStale`) that discards the stale
+  build.
+* **Decoding off the UI isolate**
+  ([#24](https://github.com/oboroge0/hayamimi/issues/24)). Every sherpa-onnx
+  call is synchronous FFI, so decoding on the isolate driving the
+  microphone stream — for a host app, Flutter's UI isolate — stopped the
+  app painting for the length of each decode, and much longer during a
+  refine pass over a whole buffered group. Each session now spawns one
+  persistent decode worker isolate that owns that session's recognizer
+  handles from first load to last free; requests reach it as messages
+  carrying the audio, and it serves them one at a time, the same
+  single-flight guarantee the old synchronous code got for free. Because
+  results now come back later rather than inline, the queue in front of the
+  worker follows explicit rules: finals are always queued, never dropped,
+  and emitted in the order their segments closed; drafts are skipped while
+  anything is outstanding and discarded on arrival if their segment has
+  since produced a final; refine passes coalesce, and claim their audio
+  when the request is actually sent rather than when it was asked for (so a
+  segment still decoding when you tap 清書 joins that group). `refineNow()`'s
+  future now completes once that pass's result has been emitted, and a
+  second call while one is still queued awaits the same pass;
+  `resetSession()` completes on the worker's acknowledgement; and
+  `decoding` reports whether *anything* is outstanding, so it emits one
+  `true`/`false` pair per burst rather than one per decode. If the decode
+  worker dies mid-session, a `LiveTranscriberException` is emitted on
+  `LiveTranscriber.errors` (an `ErrorSubtitleEvent` on
+  `HayamimiLive.events`), microphone capture is torn down, and the object
+  is left ready to `start` again — the same handling a revoked microphone
+  gets; a single decode failing inside the worker is reported the same way
+  but doesn't stop the session. `stop`/`dispose` wait for the worker's
+  shutdown acknowledgement and kill the isolate if it doesn't answer; see
+  "Threading / known limitations" in the README for why nothing is freed by
+  force in that case. New exported building blocks, none of which a caller
+  of `HayamimiLive`/`LiveTranscriber` has to touch, back this: the wire
+  protocol between the caller's isolate and the worker
+  (`decode_protocol.dart`), the pure queue policy (`decode_scheduler.dart`,
+  `DecodeScheduler`), the caller's-isolate half (`decode_session.dart`,
+  `DecodeSession`), the worker itself (`decode_worker.dart`,
+  `DecodeWorker`/`IsolateDecodeWorker`), and a `LiveVad` interface plus its
+  Silero-via-sherpa-onnx implementation (`live_vad.dart`) — all three exist
+  so a whole session can be exercised without a device, and all default to
+  production behavior via `LiveTranscriber`'s new `decodeWorkerFactory`/
+  `vadFactory` constructor parameters and `RoutedRecognizerSet.build`'s new
+  `loadOffIsolate` one. Two smaller pieces of decode-path plumbing moved
+  off the FFI-backed sherpa-onnx package as part of this: `isSegmentWorthDecoding`
+  now takes the segment's `Float32List` samples rather than a
+  `sherpa_onnx.SpeechSegment`, and `startDebugWavStream` reads its wav file
+  with this package's own pure-Dart PCM16 parser instead of sherpa-onnx's
+  `readWave` (same accepted format — 16-bit PCM — but a wrong channel count
+  is now reported explicitly rather than as a generic read failure).
+* **Japanese punctuation restoration**
+  ([#15](https://github.com/oboroge0/hayamimi/issues/15), refine only). The
+  desktop pipeline punctuates its refine (清書) output with
+  `scripts/punct_ja.py` before anything sees it, so desktop captions read
+  as sentences; this package's refine output previously had no 、 and no
+  。 at all. `PunctuatorJa.restore()` is a Dart port of that script — the
+  same character-level BERT model, the same thresholds, the same
+  rule-based ？ pass — pinned to the reference implementation by
+  `test/punct/punct_ja_parity_test.dart`, which replays 40 FLEURS ja
+  sentences plus 11 edge cases and asserts the two produce identical text.
+  Passing a `JaPunctuation` to `LiveTranscriber.start`/
+  `HayamimiLive.start` (or their `startDebugWavStream` counterparts) turns
+  it on for that session's refine output only — that is where the desktop
+  pipeline punctuates, and the pass with the context for it, since a final
+  covers one speech segment and a draft part of one still being spoken, so
+  sentence boundaries there would fall wherever the speaker paused. A
+  `RoutingProfile.jaSenseVoice` session punctuates the refines that came
+  back as Japanese and leaves the rest alone; a plain single-model session
+  has no language tag to test, so passing this to one is itself the
+  statement that its model transcribes Japanese. `LiveTranscriptEntry` and
+  `RefineSubtitleEvent` gained `punctuated` (and `"punctuated"` in that
+  event's JSON) so a consumer can tell text the punctuation model wrote
+  from text the recognizer produced; the refine pass's "too short, fall
+  back to the fast finals" guard now compares lengths with the restored
+  marks stripped, since they are characters nobody said and would
+  otherwise excuse a truncated re-decode. It runs the model through ONNX
+  Runtime's C API over `dart:ffi`, borrowing the runtime `sherpa_onnx`
+  already loads rather than adding a second `libonnxruntime.so` to the app
+  (two in one Android process is a known crash,
+  [k2-fsa/sherpa-onnx#3261](https://github.com/k2-fsa/sherpa-onnx/issues/3261)),
+  and loads in the decode worker isolate rather than the caller's, for the
+  same reason every other decode moved there. New dependencies: `unorm_dart`
+  (NFKC normalization, which `dart:core` has no equivalent of) and `ffi`.
+  The float16 model file (181.8 MB) is still not downloadable —
+  `ModelDownloader`/`downloadProfile` has no entry for it — so a host app
+  has to place it and its `vocab.txt` on the device itself; see "Japanese
+  punctuation restoration" in the README for the model-placement and
+  platform-status details, and "Known limitations" below.
+* **Bench and eval utilities.** `BenchRunner` measures offline WAV→RTF for a
+  single zipformer-transducer model; `ManifestEvalRunner` batch-decodes a
+  manifest of labeled clips (plain or through `RoutingProfile.jaSenseVoice`
+  routing) for CER/accuracy comparison against the PC pipeline's own
+  manifest runs. Both are debug/dev tools, not part of the embedding
+  surface a host app needs — see the `kDebugMode`-gated call sites in the
+  `mobile/` reference app's Bench tab.
+
+### Known limitations
+
+* The punctuation model has not been run on a device in this release: its
+  wiring was verified on a Windows host (`flutter analyze`/`flutter test`,
+  including the parity test above), but what a phone's ONNX Runtime does,
+  and what `restore()` costs on an ARM CPU, is unverified. It's also
+  refused by default on iOS — `sherpa_onnx` links ONNX Runtime as an
+  xcframework and it hasn't been confirmed that `OrtGetApiBase` stays
+  exported from the app binary, so `PunctuatorJa.load` throws rather than
+  guess unless a caller passes `libraryPath: OrtLibrary.processSymbols`.
+* This package does not observe the app lifecycle: a host app that wants
+  `stop()` on background and `start()` on resume has to wire that up
+  itself from its own `WidgetsBindingObserver`.
+* `textTransform` is an insertion point, not an implementation: CJK
+  inverse-text-normalization (kanji numerals → arabic digits) and user
+  find/replace dictionaries, both present on the desktop pipeline, are not
+  ported to Dart — a host app that wants them supplies its own callback.
+* `FinalSubtitleEvent.speaker` is always empty; there is no on-device
+  speaker diarization yet.
+* `translation` is reserved for wire compatibility with the desktop
+  pipeline's machine translation frames but is never emitted by this
+  package.
+* No on-device frame-timing or jank measurement was taken for the
+  decode-worker migration above — the claim is about where the work runs,
+  not a measured improvement in any particular app.

--- a/mobile/hayamimi_core/CHANGELOG.md
+++ b/mobile/hayamimi_core/CHANGELOG.md
@@ -240,6 +240,15 @@ into a standalone package a third-party Flutter app can embed.
   refine-only behaviour, fallback included. Not yet seen on a device: both
   emulator runs predate this.
 
+  A third emulator run confirmed the fix and found two smaller issues in it,
+  both now fixed: the fallback joined its now-punctuated finals with a
+  space after every 。 (not how Japanese is set), so the join now uses no
+  separator when the whole group is punctuated; and the punctuation
+  model's one-time ~300 ms first-`restore()` cost had moved from a
+  process's first refine onto its first final, so `loadWorkerPunctuator`
+  now pays it during the model's own load phase instead, with a throwaway
+  `restore('あ')`.
+
 * **Bench and eval utilities.** `BenchRunner` measures offline WAV→RTF for a
   single zipformer-transducer model; `ManifestEvalRunner` batch-decodes a
   manifest of labeled clips (plain or through `RoutingProfile.jaSenseVoice`

--- a/mobile/hayamimi_core/CHANGELOG.md
+++ b/mobile/hayamimi_core/CHANGELOG.md
@@ -130,20 +130,19 @@ into a standalone package a third-party Flutter app can embed.
   sentences plus 11 edge cases and asserts the two produce identical text.
   Passing a `JaPunctuation` to `LiveTranscriber.start`/
   `HayamimiLive.start` (or their `startDebugWavStream` counterparts) turns
-  it on for that session's refine output only — that is where the desktop
-  pipeline punctuates, and the pass with the context for it, since a final
-  covers one speech segment and a draft part of one still being spoken, so
-  sentence boundaries there would fall wherever the speaker paused. A
-  `RoutingProfile.jaSenseVoice` session punctuates the refines that came
-  back as Japanese and leaves the rest alone; a plain single-model session
-  has no language tag to test, so passing this to one is itself the
-  statement that its model transcribes Japanese. `LiveTranscriptEntry` and
-  `RefineSubtitleEvent` gained `punctuated` (and `"punctuated"` in that
-  event's JSON) so a consumer can tell text the punctuation model wrote
-  from text the recognizer produced; the refine pass's "too short, fall
-  back to the fast finals" guard now compares lengths with the restored
-  marks stripped, since they are characters nobody said and would
-  otherwise excuse a truncated re-decode. It runs the model through ONNX
+  it on for that session's refine ("清書") output and its finalized lines;
+  drafts stay bare, since a draft covers part of a sentence still being
+  spoken and is re-decoded about once a second. A
+  `RoutingProfile.jaSenseVoice` session punctuates what came back as
+  Japanese and leaves the rest alone; a plain single-model session has no
+  language tag to test, so passing this to one is itself the statement that
+  its model transcribes Japanese. `LiveTranscriptEntry`,
+  `FinalSubtitleEvent` and `RefineSubtitleEvent` carry `punctuated` (and
+  `"punctuated"` in those events' JSON, alongside every key that was
+  already there), so a consumer — including one across the LAN — can tell
+  text the punctuation model wrote from text the recognizer produced;
+  `RemoteFinalEvent` parses the key if a server ever sends it. It runs the
+  model through ONNX
   Runtime's C API over `dart:ffi`, borrowing the runtime `sherpa_onnx`
   already loads rather than adding a second `libonnxruntime.so` to the app
   (two in one Android process is a known crash,
@@ -213,6 +212,34 @@ into a standalone package a third-party Flutter app can embed.
   mode on mid-stream works; and the debug path now cancels that timer when
   it ends, which it never did.
 
+* **The fast line is punctuated too, after the second Android emulator
+  run.** The re-run that confirmed the two segmentation fixes above turned
+  up a third defect, one the fixes had made visible: on package defaults
+  the closing refine came out **unpunctuated**, reading
+  `refine punctuated=false text=東京の天気は晴れです あしたの会議は十時からです
+  資料は昨日送りました` over three sentences the fast path had recognized
+  correctly. A refine re-decodes its whole buffered group as one utterance,
+  this repo's ja transducer keeps only the last utterance of multi-utterance
+  audio, and so `isRefineTextTooShort` correctly rejected the re-decode and
+  emitted the fast finals joined instead — which nothing had punctuated. At
+  `autoRefineSilenceSeconds`' 4.0 s default a microphone session groups
+  several sentences per refine, so that was the normal outcome rather than a
+  corner case, and the guard was losing the punctuation in exactly the case
+  it exists to protect. The desktop pipeline has no such hole because its
+  fast finals are already punctuated, so its identical fallback yields
+  punctuated text.
+
+  Finals are therefore punctuated in the decode worker under the same rule
+  refines are, so the fallback has punctuated text to fall back to; it
+  reports `punctuated: true` only when every final in the group was
+  punctuated, and the shrink comparison now strips the restored marks off
+  both sides rather than only the refine's. The cost is one run of the
+  punctuation model per utterance instead of per refine — about 25–35 ms
+  per 11–14 character line on the emulator, inside a final's `latency_ms`.
+  `JaPunctuation(applyToFinals: false)` declines it and restores the
+  refine-only behaviour, fallback included. Not yet seen on a device: both
+  emulator runs predate this.
+
 * **Bench and eval utilities.** `BenchRunner` measures offline WAV→RTF for a
   single zipformer-transducer model; `ManifestEvalRunner` batch-decodes a
   manifest of labeled clips (plain or through `RoutingProfile.jaSenseVoice`
@@ -229,21 +256,24 @@ into a standalone package a third-party Flutter app can embed.
   that ja refines come back punctuated the way the Python reference
   punctuates them, but an emulator's CPU is the host PC's under
   virtualization, and ONNX Runtime has no float16 compute path on x86 —
-  so what `restore()` costs on an ARM CPU is still unverified. It is also
-  refused by default on iOS — `sherpa_onnx` links ONNX Runtime as an
-  xcframework and it hasn't been confirmed that `OrtGetApiBase` stays
-  exported from the app binary, so `PunctuatorJa.load` throws rather than
-  guess unless a caller passes `libraryPath: OrtLibrary.processSymbols`.
+  so what `restore()` costs on an ARM CPU is still unverified. Both
+  emulator runs predate finals being punctuated, so the fast line's
+  punctuation — and the extra `restore()` per utterance it costs — has
+  been seen only in this package's own tests. It is also refused by default
+  on iOS — `sherpa_onnx` links ONNX Runtime as an xcframework and it hasn't
+  been confirmed that `OrtGetApiBase` stays exported from the app binary, so
+  `PunctuatorJa.load` throws rather than guess unless a caller passes
+  `libraryPath: OrtLibrary.processSymbols`.
 * A refine over a long group can come back holding only its last sentence.
   This is a property of the ReazonSpeech transducer rather than of this
   package: given the whole 6.26 s multi-sentence test file with no VAD at
   all, the same int8 model returns the same single sentence on a Windows
   host under both search algorithms. The tuned VAD defaults above make long
   groups much rarer, and a refine that comes back much shorter than the
-  finals it replaces falls back to their text — but the desktop pipeline's
-  further remedy, splitting a suspicious result in half and retrying each
-  half (`_looks_truncated`/`_split_retry` in `scripts/asr_engine.py`,
-  v0.3.1), is not ported here yet.
+  finals it replaces falls back to their text, punctuation included — but
+  the desktop pipeline's further remedy, splitting a suspicious result in
+  half and retrying each half (`_looks_truncated`/`_split_retry` in
+  `scripts/asr_engine.py`, v0.3.1), is not ported here yet.
 * `RoutingProfile.jaSenseVoice` has not been run on Android: the emulator
   verification above used `jaOnly`, so the routed decode worker (SenseVoice
   plus the whisper-tiny language-ID probe in one isolate) is exercised only

--- a/mobile/hayamimi_core/LICENSE
+++ b/mobile/hayamimi_core/LICENSE
@@ -23,9 +23,7 @@ SOFTWARE.
 ---
 
 This license covers this package's source code only. It bundles no model
-weights; the pretrained models a host app puts on the device are
-third-party artifacts distributed under their own licenses -- see
-THIRD_PARTY_NOTICES.md, shipped alongside this file in the package. In
-particular, the ja->en translation model used by the desktop hayamimi
-pipeline (FuguMT / mojicast-fugumt-ja-en-ct2) is CC BY-SA 4.0
-(share-alike), not MIT.
+weights; the pretrained models a host app puts on the device (ReazonSpeech,
+SenseVoice, whisper-tiny, Silero VAD, and the optional Japanese punctuation
+model) are third-party artifacts distributed under their own licenses --
+see THIRD_PARTY_NOTICES.md, shipped alongside this file in the package.

--- a/mobile/hayamimi_core/README.md
+++ b/mobile/hayamimi_core/README.md
@@ -289,6 +289,7 @@ than silently misbehaving later:
 | `autoRefineSilenceSeconds` | 4.0s | yes | Silence gap that fires an auto-refine, when `autoRefineEnabled` is on. |
 | `autoRefineMaxBufferedSeconds` | 20.0s | yes | Buffered-duration ceiling that fires an auto-refine even without a silence gap. |
 | `refineBufferMaxSeconds` | 60.0s | yes | Hard cap on how much audio the refine buffer holds before it starts dropping the oldest segment. |
+| `prerollSeconds` | 1.0s | yes | How much audio from *before* a speech segment's detected onset is decoded along with it. The only knob here where `0` is a valid value — it means "no pre-roll". |
 
 ```dart
 final live = HayamimiLive(autoRefineSilenceSeconds: 2.0); // shorter pauses trigger refine
@@ -296,10 +297,24 @@ final live = HayamimiLive(autoRefineSilenceSeconds: 2.0); // shorter pauses trig
 live.draftWindowSeconds = 4.0; // shrink the draft window on an older/hotter phone
 ```
 
-These defaults were exercised as-is in the on-device session recorded in
-["Platform status"](#platform-status) below — see
+**Why `prerollSeconds` is there.** Silero VAD notices speech a moment after
+it starts, so the samples it hands over can begin partway into the first
+word — and the recognizer transcribes what it is given. On an Android
+emulator this package returned `昨日は昨日送りました` for `資料は昨日送りました`,
+and lost `あしたの` off the front of another sentence. Pre-roll prepends the
+audio recorded just before the onset, which is what the desktop pipeline
+has always done (`AudioHistory` / `PREROLL_S` in
+`scripts/realtime_transcribe.py`), clamped so two consecutive segments never
+both contain the gap between them. The prepended audio is part of the
+segment from then on: it is what gets decoded, what `audio_s` counts, and
+what the refine buffer stores. Set it to `0` to decode exactly what the VAD
+delimited.
+
+The first six knobs were exercised as-is in the on-device session recorded
+in ["Platform status"](#platform-status) below — see
 [`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md)
-for the full measurement conditions.
+for the full measurement conditions. `prerollSeconds` came later, from the
+Android emulator run described in the same section.
 
 #### Decoding method
 
@@ -321,9 +336,8 @@ at its own defaults, with no way to adjust for a noisy room or a soft
 speaker. `VadSensitivity` exposes its four knobs — `threshold` (speech-
 probability cutoff, higher = less sensitive), `minSilenceSeconds` (how long
 a pause has to last before a segment finalizes), `minSpeechSeconds`
-(shorter blips are discarded before decoding), and `maxSpeechSeconds` (hard
-cap on one segment's length) — each defaulting to sherpa-onnx's own value,
-so `VadSensitivity()` reproduces the unconfigurable behavior exactly:
+(shorter blips are discarded before decoding), and `maxSpeechSeconds`
+(roughly how long one segment may run before the VAD closes it mid-speech):
 
 ```dart
 await live.start(
@@ -335,6 +349,28 @@ await live.start(
 // ...later, mid-session, without restarting:
 await live.setVadSensitivity(VadSensitivity(threshold: 0.4));
 ```
+
+**The defaults are the desktop pipeline's, not sherpa-onnx's.**
+`minSilenceSeconds` is **0.35s** and `maxSpeechSeconds` is **12.0s**,
+matching `scripts/realtime_transcribe.py`; `threshold` (0.5) and
+`minSpeechSeconds` (0.25s) are sherpa-onnx's own, which the desktop leaves
+alone too. This changed because of what sherpa-onnx's stock 0.5s silence
+default did on an Android emulator: on a three-sentence Japanese recording
+whose pauses fall just under half a second, it merged all three sentences
+into one 6.13s segment, and this repo's ja recognizer, handed that segment,
+returned only the last sentence. Two sentences disappeared with nothing in
+the output to say so. At 0.35s the same audio split into three segments and
+all three came out. The desktop's own comment records that 0.35s measured
+no worse for accuracy than 0.5s on real broadcast Japanese while finalizing
+150ms sooner.
+
+`maxSpeechSeconds` is worth reading as a nudge rather than a guarantee: on
+the same run, a session configured with 5.0s emitted a 6.134s segment.
+sherpa-onnx's `max_speech_duration` influences when the VAD force-closes a
+segment; it does not bound what the VAD can hand over, so don't size a
+buffer or a timeout on it. Passing
+`VadSensitivity(minSilenceSeconds: 0.5, maxSpeechSeconds: 5.0)` restores the
+values this package shipped before.
 
 `setVadSensitivity` rebuilds Silero VAD off-isolate (same background-isolate
 technique `start` uses for the initial VAD load — see
@@ -511,7 +547,7 @@ Two pieces of the reference implementation had no Dart equivalent:
 | Platform | Status |
 |---|---|
 | Windows (host, `flutter test`) | **Verified** — parity with the Python reference on 51 recorded cases. |
-| Android | Expected to work: `libonnxruntime.so` is what `sherpa_onnx` loads there. **Not run on a device in this change.** |
+| Android | **Verified on an x86_64 emulator** (API 35): `libonnxruntime.so` resolved to the single copy `sherpa_onnx` ships, `OrtGetApiBase` was found, and the runtime served C API version 11 (ONNX Runtime 1.27.1 — the same version this host records). The 181.8 MB float16 model loaded inside the decode worker and punctuated ja refines. **No physical ARM device.** See ["Measured on an Android emulator"](#measured-on-an-android-emulator). |
 | iOS | **Unverified, and refused by default.** `sherpa_onnx` links ONNX Runtime as an xcframework and it has not been confirmed that `OrtGetApiBase` stays exported from the app binary, so `PunctuatorJa.load` throws rather than guess. Pass `libraryPath: OrtLibrary.processSymbols` to try it. |
 | macOS / Linux | Pass `libraryPath`; nothing puts the library on a desktop host's loader search path. |
 
@@ -854,9 +890,69 @@ and
 | Platform | ASR bench / live mic | Multi-language routing | Remote mode | Japanese punctuation |
 |---|---|---|---|---|
 | **iOS** (real iPhone 15) | **Verified.** Bench RTF 0.013 (ja int8, `modified_beam_search`, single run); Live tab transcribed real mic input end-to-end with no reported heat or UI stutter. | Ran live on-device with real speech switching ja/en; badge-switch accuracy was mixed because the session had multiple people talking in the room, so treat it as "it works," not a clean accuracy number — see `docs/IOS_VERIFY.md` for a cleaner single-speaker retest plan. | **Not attempted** — ruled out of scope by the repo owner for this verification session (the Mac's Wi-Fi IP was outside normal private-LAN ranges); not a known failure. | **Unverified, and refused by default** — see ["Punctuation platform status"](#punctuation-platform-status). |
-| **Android** | **Emulator only.** Load/accuracy validated on an AVD via `sherpa_onnx.dart` (CER 6.19% vs. the PC's 5.50% on the same 15-clip ja set, a +0.69pp gap attributed to onnxruntime kernel differences); RTF from an emulator reflects the *host PC's* CPU under virtualization, not a phone, so it isn't a real-device number. **A real Android device has not been used for this package.** | Validated via manifest batch eval on the emulator only; the live-mic path has not been run on Android at all (only on iOS — see the iOS column). | Not covered by an Android-specific verification pass. | Expected to work (`libonnxruntime.so` is what `sherpa_onnx` loads on Android) but **not run on a device**. |
+| **Android** | **Emulator only.** Load/accuracy validated on an AVD via `sherpa_onnx.dart` (CER 6.19% vs. the PC's 5.50% on the same 15-clip ja set, a +0.69pp gap attributed to onnxruntime kernel differences); RTF from an emulator reflects the *host PC's* CPU under virtualization, not a phone, so it isn't a real-device number. The **decode worker isolate** is verified on an x86_64 emulator (API 35): it spawned, initialized the sherpa-onnx bindings and built every model inside itself, decoded across the isolate boundary for a whole session, and was torn down and rebuilt three times in one process without a crash. **A real Android device has not been used for this package.** | Validated via manifest batch eval on the emulator only; the live-mic path has not been run on Android at all (only on iOS — see the iOS column). `RoutingProfile.jaSenseVoice` was **not exercised** in the emulator run below, which ran `jaOnly`. | Not covered by an Android-specific verification pass. | **Verified on an x86_64 emulator** (API 35): ja refines came back `punctuated: true` with 。 at the same sentence ends as the Python reference, and a control run without a punctuation model gave `punctuated: false`. **Not run on a physical ARM device**; see ["Punctuation platform status"](#punctuation-platform-status). |
 | **Windows** (desktop host) | Not a supported target platform for this package (see `pubspec.yaml`'s `platforms:`) — used only to run this repo's own `flutter analyze`/`flutter test` gates and the punctuation parity test below. | n/a | n/a | **Verified** — parity with the Python reference on 51 recorded cases (`flutter test`). |
 | **macOS / Linux** | Not a supported target platform for this package. | n/a | n/a | Would need an explicit `libraryPath`; not exercised. |
+
+### Measured on an Android emulator
+
+**Android emulator x86_64, API 35, host Ryzen 5 5600 — not a phone.** These
+are emulated x86_64 timings on a desktop CPU, so they say what the code
+does, not what a handset does. The float16 punctuation figures are the
+least transferable of all: ONNX Runtime's CPU provider has no float16
+compute path on x86 and casts to float32 and back on every operator, which
+an ARM chip with a float16 vector unit does not do. Full write-up, including
+how the models were placed and what was and wasn't exercised, in
+[`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md).
+
+| what | conditions | ms |
+|---|---|---|
+| `model_load` `recognizer` | ReazonSpeech ja zipformer int8, 2 threads, `modified_beam_search`, n=8 | 3223 (median) |
+| `model_load` `punct` | `punct_bert.fp16.onnx` (181.8 MB), 2 intra-op threads, n=7 | 1072 (median) |
+| `model_load` `vad` | `silero_vad.onnx` (0.64 MB), n=8 | 33.9 (median) |
+| final, decode only | segments of 1.5–2.0 s | 53–66 |
+| refine, re-decode + punctuation | the same 1.5–2.0 s of audio | 80–96 |
+| refine, re-decode + punctuation | one merged group of 6.13 s | 218–833 |
+
+The first load of each model in a fresh process sits at the slow end of its
+range (cold page cache), and 833 ms is the first refine of a run for the
+same reason. **Punctuation was not timed directly.** A refine's
+`latency_ms` covers the re-decode and the punctuation pass together, so the
+cost quoted for `restore()` on this run — roughly **26–33 ms per ~10
+characters**, warm, two intra-op threads — is a refine minus the final over
+the identical samples. That is an inference from the difference of two
+timers, not a measurement.
+
+### Known limitation: a refine over a long group can lose its leading sentences
+
+A refine ("清書") re-decodes a group of segments as one utterance, and when
+that group is long the result can come back containing only its last
+sentence. On the emulator, a 6.13 s group of three Japanese sentences
+refined to the third sentence alone.
+
+This is a property of the ReazonSpeech transducer, not of this package and
+not of Android. Handed the same 6.26 s file with no VAD at all, on the
+Windows host, the same int8 model returns that same single sentence under
+both `greedy_search` and `modified_beam_search`; split into its three
+sentences, it transcribes all three. Given multi-utterance audio, this
+model keeps the last utterance.
+
+What this package does about it today, and what it doesn't:
+
+- The VAD defaults now split on shorter pauses (see
+  ["VAD sensitivity"](#vad-sensitivity)), so a group is far less likely to
+  contain several sentences in the first place. Segmentation is load-bearing
+  for correctness here, not just for latency.
+- When a refine comes back much shorter than the fast finals it is replacing,
+  the finals' combined text is emitted instead (`isRefineTextTooShort`). That
+  catches the case where a group of several good finals refines to one
+  sentence — but not the case where a single over-long *segment* was already
+  truncated on the fast path, because then there is no better text to fall
+  back to.
+- The desktop pipeline goes further: it splits a suspicious result in half
+  and retries each half (`_looks_truncated` / `_split_retry` in
+  `scripts/asr_engine.py`, v0.3.1). **That is not ported to this package
+  yet.**
 
 ## API reference
 
@@ -888,7 +984,9 @@ browsing it.
   (is-this-segment-worth-decoding),
   `refine_pass.dart` (the two-pass "清書" buffer/merge/due-check logic —
   mirrors the desktop pipeline's `Refiner` with phone-tuned defaults),
-  `draft_pass.dart` (the "発話中の暫定字幕" pacing logic), `vad_sensitivity.dart`
+  `draft_pass.dart` (the "発話中の暫定字幕" pacing logic), `preroll.dart`
+  (`PrerollHistory`, the rolling buffer a segment's pre-onset context comes
+  from), `vad_sensitivity.dart`
   (`VadSensitivity` and the VAD-swap-timing pure function
   `shouldSwapVadNow`), `model_load_event.dart` (`ModelLoadEvent`, what
   `LiveTranscriber.modelLoads` emits), `ja_punctuation.dart`

--- a/mobile/hayamimi_core/README.md
+++ b/mobile/hayamimi_core/README.md
@@ -197,9 +197,11 @@ Notes on the choice:
   (plus the draft pass's own three) is both a constructor parameter and a
   mid-session-settable property now.
 - Punctuation restoration for ja (the desktop pipeline's BERT-char model,
-  ~182 MB as fp16) is **not** part of either profile yet — mobile
-  integration is tracked in
-  [#15](https://github.com/oboroge0/hayamimi/issues/15).
+  181.8 MB as fp16) is wired into the refine pass now — pass a
+  `JaPunctuation` to `start`, see "Japanese punctuation restoration" below
+  — but it is **not** part of either download profile: the model file is
+  still a local build artifact, so a host app has to put it on the device
+  itself.
 
 ## Threading / known limitations
 
@@ -221,6 +223,8 @@ re-decodes a whole buffered group at once (up to 60 s of audio by default).
 | Building the recognizers | the decode worker isolate, which loads them itself |
 | Building the VAD | a short-lived background isolate, which hands the handle back ([`lib/live/native_model_loader.dart`](lib/live/native_model_loader.dart)) |
 | Every decode — per-segment finals, drafts, refine passes, and the whisper-tiny language identification a routed session runs | the decode worker isolate ([`lib/live/decode_worker.dart`](lib/live/decode_worker.dart)) |
+| Building the Japanese punctuation model, when the session asked for one | the decode worker isolate, after the recognizers |
+| Restoring Japanese punctuation into a refine result | the decode worker isolate, right after the decode that produced it |
 | Emitting `entries`/`drafts`/`refineEntries`/`decoding`/`errors`/`modelLoads`/`sessionResets` | the caller's isolate |
 
 Each session owns one decode worker. It is created by `start`, it owns that
@@ -340,18 +344,81 @@ insertion point, not an implementation: CJK inverse-text-normalization
 and user find/replace dictionaries are not ported to Dart yet, so a host app
 that wants them today supplies its own `textTransform`.
 
-## Japanese punctuation restoration (phase 1 of #15)
+## Japanese punctuation restoration
 
 On the desktop pipeline, the refine ("清書") pass hands its text through
 `scripts/punct_ja.py` before anything sees it, so desktop captions read as
 sentences. This package had no equivalent, so its refine output arrived as
 an unbroken run of characters — the same words, no 、 and no 。. Issue
 [#15](https://github.com/oboroge0/hayamimi/issues/15) is about closing that
-gap; this is its first half.
+gap; it is closed now, for a session that asks for it.
 
-**What this adds:** `PunctuatorJa`, a Dart port of that script.
-`restore(String) -> String` inserts 、 and 。 into unpunctuated Japanese, and
-turns a sentence-final 。 into ？ after a recognised question ending.
+**Turning it on.** Pass a `JaPunctuation` to `start` (or
+`startDebugWavStream`, which is how you see it on an emulator):
+
+```dart
+await live.start(
+  modelDir: modelDir,
+  vadModelPath: vadModelPath,
+  punctuation: JaPunctuation(
+    modelPath: '$punctDir/punct_bert.fp16.onnx',
+    vocabPath: '$punctDir/vocab.txt',
+    // On a desktop host, also: libraryPath: '<...>/onnxruntime.dll'.
+    // See "Platform status" below for why Android needs no path here.
+  ),
+);
+```
+
+`null` — the default — leaves it off, which is exactly what a session did
+before the parameter existed.
+
+**What changes when it is on.**
+
+* **Refine events only.** `RefineSubtitleEvent` (and
+  `LiveTranscriber.refineEntries`) come back with 、 and 。 in them, and ？
+  after a recognised question ending. `FinalSubtitleEvent`,
+  `PartialSubtitleEvent` and the `entries`/`drafts` streams carry the
+  recognizer's text unchanged. That is where the desktop pipeline
+  punctuates, and it is the pass with the context for it: a final covers one
+  speech segment and a draft part of one still being spoken, so sentence
+  boundaries there would fall wherever the speaker happened to pause.
+  Punctuating every final would also cost a full model run per utterance, on
+  a phone, for a line the next refine replaces.
+* **Each affected line says so.** `punctuated` on `LiveTranscriptEntry` and
+  on `RefineSubtitleEvent`, and `"punctuated"` in that event's JSON (every
+  key that was already there still is), so a consumer — including one across
+  the LAN — can tell text the punctuation model wrote from text the
+  recognizer produced.
+* **Which refines get it.** A `RoutingProfile.jaSenseVoice` session
+  punctuates the refines that came back as Japanese and leaves the rest
+  alone. A plain single-model session has no language tag to test, so giving
+  it a Japanese punctuation model is itself the statement that its model
+  transcribes Japanese: **do not pass this to a plain session with a
+  non-Japanese model**, which would run a Japanese model over, say, English
+  and produce nonsense rather than nothing.
+* **Where it runs.** In the decode worker isolate, beside the recognizers —
+  loaded after them, and reported on `modelLoads` /
+  `ModelLoadSubtitleEvent` as `model: "punct"` with its measured load time.
+  `restore()` is another synchronous native call, so running it on the
+  caller's isolate would hand back the pause that moving decoding off it
+  removed (see "Threading" above).
+* **Memory, and what a failure does.** The model is 181.8 MB for the life of
+  the session, on top of up to 396 MB of recognizer weights. Failing to load
+  it fails `start()` with a message naming the file, rather than starting a
+  session that quietly produces unpunctuated text: on a phone a missing
+  model file is a configuration mistake, not something to degrade around.
+* **`textTransform` still runs last**, on the punctuated text.
+
+One interaction is worth knowing about. A refine falls back to the fast
+finals' text when the merged re-decode comes back much shorter than they
+were, and that length comparison is made on the text *without* the restored
+marks. They are characters nobody said, and one per clause is enough to lift
+a genuinely truncated re-decode back over the threshold. When that fallback
+does fire, the entry reports `punctuated: false`, because the text that
+survived is the finals', which nothing punctuated.
+
+**Using `PunctuatorJa` directly.** The class stays public, for a caller who
+wants to punctuate something the live pipeline did not produce:
 
 ```dart
 final punctuator = await PunctuatorJa.load(
@@ -363,17 +430,27 @@ punctuator.restore('明日の会議は午後三時から始まります資料の
 punctuator.dispose();   // the session is native; nothing frees it for you
 ```
 
-**What it does not do yet.** It is not wired into `HayamimiLive` or the
-refine pass — that is phase 2, and until then a host app has to call
-`PunctuatorJa` itself (the `textTransform` hook above is one place to do
-it). And the model is not downloadable: `ModelDownloader` has no entry for
-it, because the file this port runs, `punct_bert.fp16.onnx` (181.8 MB), is
-still only a local artifact of `python scripts/quantize_punct.py --variant
-fp16`. Where to host a 182 MB file, and whether to ship the float16 build
-or something smaller, is undecided — see `docs/MOBILE.md`, which records
-that float16 was the only size reduction that did not cost accuracy
-(identical predictions to the full-size model on a 250-sentence FLEURS ja
-check; dynamic and static INT8 both lost recall).
+One instance is one ONNX Runtime session and is not safe to use from more
+than one isolate — which is why the live pipeline keeps its own inside the
+decode worker rather than sharing this one.
+
+**The model is still not downloadable.** `ModelDownloader` has no entry for
+it: `punct_bert.fp16.onnx` (181.8 MB) is a local artifact of `python
+scripts/quantize_punct.py --variant fp16`, and `vocab.txt` comes from the
+model directory `docs/PUNCT_JA.md` describes. Where to host a 182 MB file,
+and whether to ship the float16 build or something smaller, is undecided —
+`docs/MOBILE.md` records that float16 was the only size reduction that did
+not cost accuracy (identical predictions to the full-size model on a
+250-sentence FLEURS ja check; dynamic and static INT8 both lost recall).
+Until that is settled, a host app has to place both files on the device
+itself.
+
+**No device run happened in this change.** The wiring was verified on a
+Windows host with `flutter analyze` and `flutter test`: the session behaviour
+against a stand-in worker, the protocol encoding, and one test that builds
+the punctuator from a real session config and runs it. What that leaves
+unverified is the phone — whether ONNX Runtime resolves as the next section
+expects on Android, and what `restore()` costs on an ARM CPU.
 
 ### How it reaches ONNX Runtime, and why that way
 
@@ -441,8 +518,8 @@ test, `punct_ja_fixture_tokens_test.dart`, checks the token ids from the
 same fixture and needs only the 28 KB `vocab.txt`, so tokenizer drift is
 caught even without the model.
 
-The test prints what it measured while running: **66–71 ms mean
-`restore()`** over the 51 cases (55 characters on average) across three
+The test prints what it measured while running: **66–90 ms mean
+`restore()`** over the 51 cases (55 characters on average) across six
 runs, on this Windows x86 host, ONNX Runtime 1.27.1 from
 `sherpa_onnx_windows`, two intra-op threads. **This says
 nothing about a phone.** ONNX Runtime's CPU provider has no float16 compute
@@ -641,9 +718,9 @@ reason.
 | `partial` | `{"type":"partial","text":...}` | A draft ("発話中の暫定字幕") re-decode fires while a VAD segment is still in progress. |
 | `final` | `{"type":"final","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"switched":...}` | A VAD segment finalized. `audio_s` is the segment's duration in seconds; `switched` is `true` only when this segment is the reason a `RoutingProfile.jaSenseVoice` session's language changed. `speaker` is always empty (no diarization yet). |
 | `translation` | `{"type":"translation","lang":...,"text":...}` | Reserved for wire compatibility with the desktop pipeline's machine translation — not emitted by this package today. |
-| `refine` | `{"type":"refine","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...}` | A refine ("清書") pass completed. `audio_s` is the total duration of the buffered group that was re-decoded. |
+| `refine` | `{"type":"refine","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"punctuated":...}` | A refine ("清書") pass completed. `audio_s` is the total duration of the buffered group that was re-decoded; `punctuated` is `true` when Japanese punctuation was restored into `text` (see "Japanese punctuation restoration"), and `false` from every producer that does not punctuate, remote sessions included. |
 | `error` | `{"type":"error","message":...}` | A session failure not attributable to a call the caller made — e.g. the OS revoking mic access mid-session. |
-| `model_load` | `{"type":"model_load","model":...,"phase":"start"\|"done","ms":...}` | Right before and right after each native model finishes loading (`model` is `"vad"`, `"recognizer"`, or for `RoutingProfile.jaSenseVoice`: `"ja"`/`"sensevoice"`/`"lid"`), including a `setVadSensitivity` rebuild. `ms` is the elapsed build time, only set on `"done"`. |
+| `model_load` | `{"type":"model_load","model":...,"phase":"start"\|"done","ms":...}` | Right before and right after each native model finishes loading (`model` is `"vad"`, `"recognizer"`, for `RoutingProfile.jaSenseVoice`: `"ja"`/`"sensevoice"`/`"lid"`, or `"punct"` for the Japanese punctuation model), including a `setVadSensitivity` rebuild. `ms` is the elapsed build time, only set on `"done"`. |
 | `session_reset` | `{"type":"session_reset"}` | `resetSession()` finished clearing the current conversation's state. |
 
 `HayamimiRemote` speaks the same table — its underlying `RemoteEvent` parser
@@ -680,9 +757,10 @@ from `HayamimiRemote.events` rather than raising an error.
   `draft_pass.dart` (the "発話中の暫定字幕" pacing logic), `vad_sensitivity.dart`
   (`VadSensitivity` and the VAD-swap-timing pure function
   `shouldSwapVadNow`), `model_load_event.dart` (`ModelLoadEvent`, what
-  `LiveTranscriber.modelLoads` emits), and `live_transcript_entry.dart` (one
-  finalized/refine/draft line, including its `audioSeconds`/`switched`
-  fields).
+  `LiveTranscriber.modelLoads` emits), `ja_punctuation.dart`
+  (`JaPunctuation`, the value object `start` takes to turn Japanese
+  punctuation on), and `live_transcript_entry.dart` (one finalized/refine/
+  draft line, including its `audioSeconds`/`switched`/`punctuated` fields).
 - `lib/remote/` — `RemoteTranscriber` (mic → `/ingest` WebSocket
   orchestration, auto-reconnect, debug wav sender) and its pure pieces:
   `remote_event.dart` (JSON→typed event parsing), `remote_handshake.dart`
@@ -694,10 +772,13 @@ from `HayamimiRemote.events` rather than raising an error.
   wire-compatible JSON encoding — see "Events" above), and
   `overlay_html.dart` (the OBS-ready transparent overlay page).
 - `lib/punct/` — Japanese punctuation restoration (see the section above).
-  `punctuator_ja.dart` is the whole public surface (`PunctuatorJa.restore`);
+  A live session runs this inside its decode worker; `PunctuatorJa` is also
+  usable on its own. `punctuator_ja.dart` is the whole public surface
+  (`PunctuatorJa.restore`);
   `punct_ja_tokenizer.dart` (NFKC + character split + vocabulary) and
-  `punct_ja_text.dart` (where a mark goes, and the ？ heuristic) are pure
-  Dart and unit tested without a model; `punct_ort_session.dart` and
+  `punct_ja_text.dart` (where a mark goes, the ？ heuristic, and
+  `withoutRestoredMarks`, which the refine pass's length check strips with)
+  are pure Dart and unit tested without a model; `punct_ort_session.dart` and
   `ort_library.dart` are the only FFI in the package, and
   `ort_bindings.dart` is a trimmed copy of ONNX Runtime's C API bindings
   (see `THIRD_PARTY_NOTICES.md`).

--- a/mobile/hayamimi_core/README.md
+++ b/mobile/hayamimi_core/README.md
@@ -443,28 +443,29 @@ before the parameter existed.
 
 **What changes when it is on.**
 
-* **Refine events only.** `RefineSubtitleEvent` (and
-  `LiveTranscriber.refineEntries`) come back with 、 and 。 in them, and ？
-  after a recognised question ending. `FinalSubtitleEvent`,
-  `PartialSubtitleEvent` and the `entries`/`drafts` streams carry the
-  recognizer's text unchanged. That is where the desktop pipeline
-  punctuates, and it is the pass with the context for it: a final covers one
-  speech segment and a draft part of one still being spoken, so sentence
-  boundaries there would fall wherever the speaker happened to pause.
-  Punctuating every final would also cost a full model run per utterance, on
-  a phone, for a line the next refine replaces.
+* **Refines and finals, not drafts.** `RefineSubtitleEvent` and
+  `FinalSubtitleEvent` (and the `refineEntries`/`entries` streams) come back
+  with 、 and 。 in them, and ？ after a recognised question ending.
+  `PartialSubtitleEvent` and the `drafts` stream carry the recognizer's text
+  unchanged: a draft covers part of a sentence still being spoken and is
+  re-decoded about once a second, so a mark placed in one is a guess about a
+  sentence that has not finished, paid for on a phone, on a line the
+  segment's own final replaces a moment later. See ["Why the fast line is
+  punctuated too"](#why-the-fast-line-is-punctuated-too) for what finals are
+  doing here — the desktop pipeline punctuates its finals as well, and
+  something depends on it.
 * **Each affected line says so.** `punctuated` on `LiveTranscriptEntry` and
-  on `RefineSubtitleEvent`, and `"punctuated"` in that event's JSON (every
-  key that was already there still is), so a consumer — including one across
-  the LAN — can tell text the punctuation model wrote from text the
-  recognizer produced.
-* **Which refines get it.** A `RoutingProfile.jaSenseVoice` session
-  punctuates the refines that came back as Japanese and leaves the rest
-  alone. A plain single-model session has no language tag to test, so giving
-  it a Japanese punctuation model is itself the statement that its model
-  transcribes Japanese: **do not pass this to a plain session with a
-  non-Japanese model**, which would run a Japanese model over, say, English
-  and produce nonsense rather than nothing.
+  on `FinalSubtitleEvent`/`RefineSubtitleEvent`, and `"punctuated"` in those
+  events' JSON (every key that was already there still is), so a consumer —
+  including one across the LAN — can tell text the punctuation model wrote
+  from text the recognizer produced.
+* **Which lines get it.** A `RoutingProfile.jaSenseVoice` session punctuates
+  what came back as Japanese and leaves the rest alone. A plain single-model
+  session has no language tag to test, so giving it a Japanese punctuation
+  model is itself the statement that its model transcribes Japanese: **do
+  not pass this to a plain session with a non-Japanese model**, which would
+  run a Japanese model over, say, English and produce nonsense rather than
+  nothing.
 * **Where it runs.** In the decode worker isolate, beside the recognizers —
   loaded after them, and reported on `modelLoads` /
   `ModelLoadSubtitleEvent` as `model: "punct"` with its measured load time.
@@ -479,13 +480,45 @@ before the parameter existed.
   model file is a configuration mistake, not something to degrade around.
 * **`textTransform` still runs last**, on the punctuated text.
 
-One interaction is worth knowing about. A refine falls back to the fast
-finals' text when the merged re-decode comes back much shorter than they
-were, and that length comparison is made on the text *without* the restored
-marks. They are characters nobody said, and one per clause is enough to lift
-a genuinely truncated re-decode back over the threshold. When that fallback
-does fire, the entry reports `punctuated: false`, because the text that
-survived is the finals', which nothing punctuated.
+#### Why the fast line is punctuated too
+
+A refine does not always emit its own text. It re-decodes the whole buffered
+group as one utterance, and this repo's Japanese recognizer keeps only the
+last utterance of multi-utterance audio (see ["Known limitation: a refine
+over a long group can lose its leading
+sentences"](#known-limitation-a-refine-over-a-long-group-can-lose-its-leading-sentences)),
+so a group of two or more segments usually comes back holding one sentence.
+`isRefineTextTooShort` catches that and emits the fast finals joined
+together instead, which is the whole point of the guard.
+
+While only refines were punctuated, that fallback text was raw, so the
+refine lost its marks in exactly the case the guard exists to protect. An
+Android emulator run on package defaults produced this, over three
+correctly recognized sentences:
+
+```
+refine punctuated=false text=東京の天気は晴れです あしたの会議は十時からです 資料は昨日送りました
+```
+
+With `autoRefineSilenceSeconds` at its 4.0 s default a microphone session
+groups several sentences per refine, so this was the ordinary outcome, not
+a corner case. The desktop pipeline never had the problem because its fast
+finals are already punctuated (`RoutedASR.transcribe` runs `punct_ja.py`
+over ja finals), so its identical fallback yields punctuated text.
+
+So finals are punctuated too. The fallback reports `punctuated: true` when
+every final in the group was punctuated, and the length comparison strips
+the restored marks off both sides before comparing — they are characters
+nobody said, and one per clause is enough to lift a genuinely truncated
+re-decode back over the threshold.
+
+The cost is one run of the punctuation model per utterance rather than per
+refine, on the same isolate the recognizer is on: about **25–35 ms per
+11–14 character line** on the emulator measured below, added to a final's
+`latency_ms`. `JaPunctuation(..., applyToFinals: false)` declines it —
+finals then arrive exactly as the recognizer produced them, refines are
+still punctuated, and a refine that falls back to the finals reports
+`punctuated: false`, since the text that survived is theirs.
 
 **Using `PunctuatorJa` directly.** The class stays public, for a caller who
 wants to punctuate something the live pipeline did not produce:
@@ -547,7 +580,7 @@ Two pieces of the reference implementation had no Dart equivalent:
 | Platform | Status |
 |---|---|
 | Windows (host, `flutter test`) | **Verified** — parity with the Python reference on 51 recorded cases. |
-| Android | **Verified on an x86_64 emulator** (API 35): `libonnxruntime.so` resolved to the single copy `sherpa_onnx` ships, `OrtGetApiBase` was found, and the runtime served C API version 11 (ONNX Runtime 1.27.1 — the same version this host records). The 181.8 MB float16 model loaded inside the decode worker and punctuated ja refines. **No physical ARM device.** See ["Measured on an Android emulator"](#measured-on-an-android-emulator). |
+| Android | **Verified on an x86_64 emulator** (API 35): `libonnxruntime.so` resolved to the single copy `sherpa_onnx` ships, `OrtGetApiBase` was found, and the runtime served C API version 11 (ONNX Runtime 1.27.1 — the same version this host records). The 181.8 MB float16 model loaded inside the decode worker and punctuated ja refines. Both emulator runs predate finals being punctuated, so **the fast line's punctuation has not been seen on a device**, only in this package's tests. **No physical ARM device.** See ["Measured on an Android emulator"](#measured-on-an-android-emulator). |
 | iOS | **Unverified, and refused by default.** `sherpa_onnx` links ONNX Runtime as an xcframework and it has not been confirmed that `OrtGetApiBase` stays exported from the app binary, so `PunctuatorJa.load` throws rather than guess. Pass `libraryPath: OrtLibrary.processSymbols` to try it. |
 | macOS / Linux | Pass `libraryPath`; nothing puts the library on a desktop host's loader search path. |
 
@@ -704,7 +737,7 @@ reason.
 | type | JSON shape | emitted when |
 |---|---|---|
 | `partial` | `{"type":"partial","text":...}` | A draft ("発話中の暫定字幕") re-decode fires while a VAD segment is still in progress. |
-| `final` | `{"type":"final","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"switched":...}` | A VAD segment finalized. `audio_s` is the segment's duration in seconds; `switched` is `true` only when this segment is the reason a `RoutingProfile.jaSenseVoice` session's language changed. `speaker` is always empty (no diarization yet). |
+| `final` | `{"type":"final","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"switched":...,"punctuated":...}` | A VAD segment finalized. `audio_s` is the segment's duration in seconds; `switched` is `true` only when this segment is the reason a `RoutingProfile.jaSenseVoice` session's language changed; `punctuated` is `true` when Japanese punctuation was restored into `text` (see ["Japanese punctuation restoration"](#japanese-punctuation-restoration)), and `false` from every producer that does not punctuate its fast line, remote sessions included. `speaker` is always empty (no diarization yet). |
 | `translation` | `{"type":"translation","lang":...,"text":...}` | Reserved for wire compatibility with the desktop pipeline's machine translation — not emitted by this package today. |
 | `refine` | `{"type":"refine","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"punctuated":...}` | A refine ("清書") pass completed. `audio_s` is the total duration of the buffered group that was re-decoded; `punctuated` is `true` when Japanese punctuation was restored into `text` (see ["Japanese punctuation restoration"](#japanese-punctuation-restoration)), and `false` from every producer that does not punctuate, remote sessions included. |
 | `error` | `{"type":"error","message":...}` | A session failure not attributable to a call the caller made — e.g. the OS revoking mic access mid-session. |
@@ -905,23 +938,31 @@ an ARM chip with a float16 vector unit does not do. Full write-up, including
 how the models were placed and what was and wasn't exercised, in
 [`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md).
 
+These are the **second** emulator run (two processes, ten sessions,
+`modified_beam_search`, `numThreads` 2), on the VAD and pre-roll defaults
+this package ships now:
+
 | what | conditions | ms |
 |---|---|---|
-| `model_load` `recognizer` | ReazonSpeech ja zipformer int8, 2 threads, `modified_beam_search`, n=8 | 3223 (median) |
-| `model_load` `punct` | `punct_bert.fp16.onnx` (181.8 MB), 2 intra-op threads, n=7 | 1072 (median) |
-| `model_load` `vad` | `silero_vad.onnx` (0.64 MB), n=8 | 33.9 (median) |
-| final, decode only | segments of 1.5–2.0 s | 53–66 |
-| refine, re-decode + punctuation | the same 1.5–2.0 s of audio | 80–96 |
-| refine, re-decode + punctuation | one merged group of 6.13 s | 218–833 |
+| `model_load` `recognizer` | ReazonSpeech ja zipformer int8, 2 threads, `modified_beam_search`, n=10 | 3883.7 (median) |
+| `model_load` `punct` | `punct_bert.fp16.onnx` (181.8 MB), 2 intra-op threads, n=10 | 1140.2 (median) |
+| `model_load` `vad` | `silero_vad.onnx` (0.64 MB), n=10 | 32.9 (median) |
+| final, decode only | a 1.762 s / 2.400 s / 2.144 s segment, n=6 each | 61.8 / 80.4 / 71.5 (medians) |
+| refine, re-decode + punctuation | those same segments, warm | 97–114 |
+| refine, re-decode + punctuation | the first refine in a fresh process | 407.9 / 412.7 |
 
 The first load of each model in a fresh process sits at the slow end of its
-range (cold page cache), and 833 ms is the first refine of a run for the
-same reason. **Punctuation was not timed directly.** A refine's
-`latency_ms` covers the re-decode and the punctuation pass together, so the
-cost quoted for `restore()` on this run — roughly **26–33 ms per ~10
-characters**, warm, two intra-op threads — is a refine minus the final over
-the identical samples. That is an inference from the difference of two
-timers, not a measurement.
+range (cold page cache), and the first refine of a process costs ~310 ms
+more than the rest — a one-time warm-up inside the fp16 punctuation model,
+paid once per process and not once per session. The recognizer median moved
+up ~660 ms against the first run while `punct` and `vad` stayed flat, which
+reads as load noise on a shared desktop rather than a change in the code.
+
+**Punctuation was not timed directly.** A `latency_ms` covers the decode and
+the punctuation pass together, so the cost quoted for `restore()` on this
+run — roughly **25–35 ms per 11–14 character line**, warm, two intra-op
+threads — is a refine minus the final over the identical samples. That is an
+inference from the difference of two timers, not a measurement.
 
 ### Known limitation: a refine over a long group can lose its leading sentences
 
@@ -944,11 +985,12 @@ What this package does about it today, and what it doesn't:
   contain several sentences in the first place. Segmentation is load-bearing
   for correctness here, not just for latency.
 - When a refine comes back much shorter than the fast finals it is replacing,
-  the finals' combined text is emitted instead (`isRefineTextTooShort`). That
-  catches the case where a group of several good finals refines to one
-  sentence — but not the case where a single over-long *segment* was already
-  truncated on the fast path, because then there is no better text to fall
-  back to.
+  the finals' combined text is emitted instead (`isRefineTextTooShort`), with
+  their punctuation, since finals are punctuated too (see ["Why the fast line
+  is punctuated too"](#why-the-fast-line-is-punctuated-too)). That catches
+  the case where a group of several good finals refines to one sentence — but
+  not the case where a single over-long *segment* was already truncated on
+  the fast path, because then there is no better text to fall back to.
 - The desktop pipeline goes further: it splits a suspicious result in half
   and retries each half (`_looks_truncated` / `_split_retry` in
   `scripts/asr_engine.py`, v0.3.1). **That is not ported to this package

--- a/mobile/hayamimi_core/README.md
+++ b/mobile/hayamimi_core/README.md
@@ -6,9 +6,9 @@ other Flutter apps — e.g. a smart-glasses companion app — can embed live
 subtitles without pulling in that app's UI.
 
 It gives you three independent pieces, all speaking the same
-[`SubtitleEvent`](lib/server/subtitle_event.dart) wire format (the same
-`partial`/`final`/`translation`/`refine` JSON shape the desktop
-`scripts/subtitle_server.py` and OBS overlay use):
+[`SubtitleEvent`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/server/subtitle_event.dart)
+wire format (the same `partial`/`final`/`translation`/`refine` JSON shape
+the desktop `scripts/subtitle_server.py` and OBS overlay use):
 
 - **`HayamimiLive`** — on-device transcription: mic → Silero VAD → a
   [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) offline ASR model,
@@ -21,24 +21,43 @@ It gives you three independent pieces, all speaking the same
   re-broadcasts either of the above as SSE + a transparent overlay page, so
   OBS or a browser on the same network can subscribe.
 
-Lower-level pieces (`LiveTranscriber`, `RemoteTranscriber`,
-`BenchRunner`, VAD/PCM helpers, ...) are also exported for callers who want
-more control than the two facades above give — see
-[`lib/hayamimi_core.dart`](lib/hayamimi_core.dart) for the full export list.
+Lower-level pieces (`LiveTranscriber`, `RemoteTranscriber`, `BenchRunner`,
+VAD/PCM helpers, ...) are also exported for callers who want more control
+than the two facades above give — see
+[`lib/hayamimi_core.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/hayamimi_core.dart)
+for the full export list.
+
+## Table of contents
+
+- [Installing](#installing)
+- [Embedding guide](#embedding-guide)
+  - [Initialize native bindings](#initialize-native-bindings)
+  - [Platform permissions](#platform-permissions)
+  - [On-device subtitles: HayamimiLive](#on-device-subtitles-hayamimilive)
+  - [Remote subtitles: HayamimiRemote](#remote-subtitles-hayamimiremote)
+  - [Broadcasting to the LAN: SubtitleBroadcastServer](#broadcasting-to-the-lan-subtitlebroadcastserver)
+  - [Runtime configuration and session control](#runtime-configuration-and-session-control)
+  - [Japanese punctuation restoration](#japanese-punctuation-restoration)
+  - [Threading model and error handling](#threading-model-and-error-handling)
+  - [Events](#events)
+- [Model placement guide](#model-placement-guide)
+- [Platform status](#platform-status)
+- [API reference](#api-reference)
+- [Package layout](#package-layout)
+- [Consumers](#consumers)
 
 ## Installing
 
-Not yet published to pub.dev. Depend on it from a path (this repo) or git:
-
 ```yaml
 dependencies:
-  hayamimi_core:
-    path: ../path/to/hayamimi/mobile/hayamimi_core
-  # or:
-  hayamimi_core:
-    git:
-      url: https://github.com/oboroge0/hayamimi.git
-      path: mobile/hayamimi_core
+  hayamimi_core: ^0.1.0
+  # or, to track this repo directly:
+  # hayamimi_core:
+  #   path: ../path/to/hayamimi/mobile/hayamimi_core
+  # hayamimi_core:
+  #   git:
+  #     url: https://github.com/oboroge0/hayamimi.git
+  #     path: mobile/hayamimi_core
 ```
 
 Import it as:
@@ -47,88 +66,178 @@ Import it as:
 import 'package:hayamimi_core/hayamimi_core.dart';
 ```
 
-### Model files
+## Embedding guide
 
-`HayamimiLive` needs sherpa-onnx model files on disk (72-396 MB depending
-on the profile — see "Recommended configurations" below); this package
-doesn't bundle any, but ships a downloader so you don't have to hand-roll
-the fetch/verify/unpack/placement yourself:
+### Initialize native bindings
+
+`sherpa_onnx` (a dependency of this package) keeps its FFI binding table
+per-isolate, so every isolate that touches its native objects has to
+initialize its own copy before doing anything else. Call this once, before
+`runApp`, on your app's main isolate:
 
 ```dart
-import 'package:hayamimi_core/hayamimi_core.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:sherpa_onnx/sherpa_onnx.dart' as sherpa_onnx;
 
-final docsDir = await getApplicationDocumentsDirectory();
-
-await downloadProfile(
-  ModelProfile.jaOnly, // or ModelProfile.jaSenseVoice
-  docsDir.path,
-  onProgress: (event) {
-    // event.phase: skipped/downloading/verifyingDownload/extracting/done
-    // event.bytesReceived / event.totalBytes for a progress bar
-    // (totalBytes is null if the server didn't send Content-Length)
-  },
-);
-
-final live = HayamimiLive();
-await live.start(
-  modelDir: '${docsDir.path}/model',
-  vadModelPath: '${docsDir.path}/vad/silero_vad.onnx',
-  // Only for ModelProfile.jaSenseVoice:
-  // routingProfile: RoutingProfile.jaSenseVoice,
-  // senseVoiceModelDir: '${docsDir.path}/sense_voice',
-  // lidModelDir: '${docsDir.path}/lid',
-);
+void main() {
+  sherpa_onnx.initBindings();
+  runApp(const MyApp());
+}
 ```
 
-`downloadProfile` downloads each asset from the sherpa-onnx GitHub
-releases (`asr-models` tag), verifies its sha256, extracts only the
-`int8` members from the archives that bundle multiple precisions, and
-places everything under `<targetDir>/model`, `/vad`, `/sense_voice`,
-`/lid` — the exact layout `HayamimiLive.start` (and this snippet) expect,
-so nothing needs renaming or resolving by hand. It's idempotent: call it
-again (e.g. on every app start) and it re-verifies what's already on disk
-by checksum and only re-fetches what's missing or corrupt, so it's safe
-to call unconditionally rather than gating it on "is this the first
-launch."
+This package's own background isolates (the decode worker, and the
+short-lived isolate that builds the VAD) call `initBindings()` for
+themselves — you don't need to do that. The one place your isolate is
+still involved is the VAD: it's built off-isolate but then lives and runs
+on your caller's isolate for the rest of the session, so that isolate
+needs bindings initialized before `HayamimiLive.start`/
+`LiveTranscriber.start` builds it. Skipping this call surfaces as a native
+crash or a "failed to lookup symbol" error the first time any sherpa-onnx
+object is touched, not as a friendly Dart exception — see
+[`lib/live/native_model_loader.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/live/native_model_loader.dart)
+for exactly which handles cross this boundary and why doing it this way is
+safe.
 
-See [`lib/setup/model_downloader.dart`](lib/setup/model_downloader.dart)
-for the full manifest (`modelManifest`) — exact asset URLs, sha256s, and
-which files each profile places where — and
-[`example/`](example/)'s `_downloadModels` for a guarded, tap-to-download
-version of the snippet above (it doesn't fetch 396 MB without the user
-asking for it).
-
-<details>
-<summary>Getting the models yourself instead</summary>
-
-If you'd rather manage the files by hand (a CI step, a custom CDN, …),
-`downloadProfile`'s manifest names the exact assets:
-
-- ReazonSpeech ja zipformer transducer (int8): [`sherpa-onnx-zipformer-ja-en-reazonspeech-2025-01-17.tar.bz2`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-ja-en-reazonspeech-2025-01-17.tar.bz2)
-  — extract the `encoder`/`decoder`/`joiner` `.int8.onnx` files (this
-  archive also ships fp32/fp16, which you don't need on a phone) plus
-  `tokens.txt` into one directory. See `resolveZipformerTransducerFiles`
-  in `lib/bench/model_file_resolver.dart` for the filename matching rules
-  if you use a different sherpa-onnx model (exact names aren't required).
-- [`silero_vad.onnx`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx)
-  for VAD, only needed for `HayamimiLive` (not `HayamimiRemote`, which has
-  no ASR of its own).
-- For `RoutingProfile.jaSenseVoice` only: [`sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17.tar.bz2`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17.tar.bz2)
-  (`model.int8.onnx` + `tokens.txt`) and [`sherpa-onnx-whisper-tiny.tar.bz2`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-tiny.tar.bz2)
-  (only its `tiny-encoder.int8.onnx`/`tiny-decoder.int8.onnx` — the LID
-  probe doesn't need `tiny-tokens.txt` or the fp32 files also in that
-  archive).
-
-</details>
+### Platform permissions
 
 `sherpa_onnx` and `record` (both dependencies of this package) need their
 usual platform setup — `RECORD_AUDIO` permission on Android
 (`android/app/src/main/AndroidManifest.xml`), `NSMicrophoneUsageDescription`
-on iOS (`ios/Runner/Info.plist`) — see the `mobile/` app in this repo for a
-working example of both.
+on iOS (`ios/Runner/Info.plist`) — see the
+[`mobile/`](https://github.com/oboroge0/hayamimi/tree/main/mobile) app in
+this repo, or this package's own
+[`example/`](https://github.com/oboroge0/hayamimi/tree/main/mobile/hayamimi_core/example),
+for a working example of both. `HayamimiRemote` needs the same
+`RECORD_AUDIO`/`NSMicrophoneUsageDescription` setup (it streams your mic
+too, just to a PC instead of decoding locally) plus `INTERNET`, which is
+implicit for Android debug builds and should be declared explicitly in
+your release manifest. If you use `SubtitleBroadcastServer`, see
+["iOS local network permission"](#ios-local-network-permission) below —
+it needs one more entitlement beyond the microphone.
 
-### iOS local network permission (SubtitleBroadcastServer only)
+### On-device subtitles: HayamimiLive
+
+See
+[`example/`](https://github.com/oboroge0/hayamimi/tree/main/mobile/hayamimi_core/example)
+for a full, runnable Flutter app built from nothing but this snippet's
+shape (pub.dev's standard `example/` layout) — useful as a copy-pasteable
+starting point, since the fragment below elides error handling and widget
+wiring for brevity. Model files aren't included below either — see
+["Model placement guide"](#model-placement-guide).
+
+```dart
+import 'package:hayamimi_core/hayamimi_core.dart';
+
+final live = HayamimiLive();
+
+live.events.listen((event) {
+  switch (event) {
+    case PartialSubtitleEvent(:final text):
+      print('draft: $text');
+    case FinalSubtitleEvent(:final text, :final lang):
+      print('final [$lang]: $text');
+    case RefineSubtitleEvent(:final text):
+      print('refine (清書): $text');
+    default:
+      break;
+  }
+});
+
+await live.start(
+  modelDir: '/path/to/model',        // encoder/decoder/joiner/tokens.txt
+  vadModelPath: '/path/to/silero_vad.onnx',
+  // Optional multilingual routing: each segment goes to ReazonSpeech (ja)
+  // or SenseVoice (en/zh/ko/yue) instead of one fixed-language model.
+  routingProfile: RoutingProfile.jaSenseVoice,
+  senseVoiceModelDir: '/path/to/sense_voice',
+  lidModelDir: '/path/to/lid',
+);
+
+// ... later, e.g. on a button tap:
+await live.refineNow();   // manual "清書" re-decode pass
+
+// ... when done:
+await live.stop();
+await live.dispose();
+```
+
+#### Text post-processing hook
+
+`HayamimiLive(textTransform: ...)` (or the settable `live.textTransform`
+field, changeable mid-session) lets a host app rewrite each draft/final/
+refine entry's text right where it becomes a `SubtitleEvent` — before it
+reaches `events` and therefore before `SubtitleBroadcastServer` or any other
+consumer sees it. The callback takes `(text, lang)` and returns the text to
+publish; `null` (the default) is a no-op. This is deliberately just an
+insertion point, not an implementation: CJK inverse-text-normalization
+(kanji numerals -> arabic digits, `scripts/itn_cjk.py` on the desktop side)
+and user find/replace dictionaries are not ported to Dart yet, so a host app
+that wants them today supplies its own `textTransform`.
+
+### Remote subtitles: HayamimiRemote
+
+An alternative to `HayamimiLive` for when the recognition should happen on
+a PC instead of the phone — e.g. a low-power device, or when you want the
+desktop pipeline's full multi-language routing/refine/translation stack
+rather than this package's phone-sized subset:
+
+```dart
+import 'package:hayamimi_core/hayamimi_core.dart';
+
+final remote = HayamimiRemote();
+
+remote.events.listen((event) {
+  if (event case FinalSubtitleEvent(:final text, :final lang)) {
+    print('[$lang] $text');
+  }
+});
+
+await remote.connect('ws://192.168.1.10:8766/ingest');
+
+// ... when done:
+await remote.disconnect();
+await remote.dispose();
+```
+
+The server side is `python scripts/realtime_transcribe.py --input ws
+--serve` from the main hayamimi repo — see its own docs for the two ports
+involved (`--serve`'s HTTP/SSE dashboard vs. `--input ws`'s `/ingest`
+WebSocket). `HayamimiRemote` needs no model files and no
+`sherpa_onnx.initBindings()` call of its own — it does no local decoding.
+
+### Broadcasting to the LAN: SubtitleBroadcastServer
+
+Either facade's events can be mirrored out over `SubtitleBroadcastServer`,
+which speaks the exact protocol `scripts/subtitle_server.py` does (so an
+OBS browser source or a browser tab that already works against the desktop
+app works against your embedding app too):
+
+```dart
+final broadcast = SubtitleBroadcastServer();
+await broadcast.start();
+
+live.events.listen(broadcast.broadcast); // events are already SubtitleEvent
+
+// GET http://<lan ip>:8833/         -> transparent overlay page
+// GET http://<lan ip>:8833/events   -> SSE feed of the same events
+```
+
+`SubtitleBroadcastServer({port, bindAddress, allowOrigin})` binds
+[`InternetAddress.anyIPv4`](https://api.dart.dev/dart-io/InternetAddress/anyIPv4-constant.html)
+(`0.0.0.0`, all interfaces) by default, deliberately, rather than loopback:
+the whole point of this class is reachability from *other* devices on the
+LAN — that's what makes it useful for OBS or a browser running on a
+different machine. Pass a narrower `bindAddress` (e.g.
+`InternetAddress.loopbackIPv4`) only if a host app wants to restrict this to
+same-device consumers, which defeats the LAN-broadcast use case this class
+exists for. `allowOrigin` (default `'*'`) controls the `/events` response's
+`Access-Control-Allow-Origin` header, matching the desktop
+`subtitle_server.py`'s permissive default so a browser-based OBS source or a
+web dashboard on a different origin works without extra configuration;
+narrow it if a host app needs to restrict which origins may read its
+transcript.
+
+#### iOS local network permission
 
 `SubtitleBroadcastServer` binds `0.0.0.0` and accepts connections from
 other devices on the LAN. On iOS 14+ that requires the local network
@@ -146,64 +255,300 @@ advertise itself over Bonjour, so clients connect by IP and port (see
 which address to type). Add `NSBonjourServices` only if your own app adds mDNS
 discovery on top.
 
-Android needs nothing extra beyond `INTERNET`, which is implicit for debug
-builds and should be declared in your release manifest.
+Android needs nothing extra beyond `INTERNET` (see
+["Platform permissions"](#platform-permissions) above).
 
-### App lifecycle
+### Runtime configuration and session control
 
-This package does not observe the app lifecycle: the host app owns that
-policy, because only it knows whether a background session is wanted (and
-whether it has arranged the background-audio entitlements to keep one
-alive). The recommended default is to `stop()` on background and `start()`
-again on resume, from your own `WidgetsBindingObserver`.
+The pacing/VAD/decoding defaults below (see
+["Model placement guide"](#model-placement-guide) for the profiles they
+were chosen for) were tuned for a phone, but an embedding app doesn't
+always match that shape — a noisy venue needs a less trigger-happy VAD, a
+lecture-style app might want a longer draft window, and a host that already
+has its own hotword list wants to plug it straight into the recognizer
+instead of post-processing text after the fact. All of this used to be
+hardcoded constants with no way in; issue
+[#29](https://github.com/oboroge0/hayamimi/issues/29) opened it up.
 
-If you don't, the OS may take the microphone away mid-session — on
-backgrounding, or when another app grabs it. When that happens the library
-now emits an error event (`ErrorSubtitleEvent` on `HayamimiLive.events`, a
-`LiveTranscriberException` on `LiveTranscriber.errors`, `RemoteErrorEvent`
-on `HayamimiRemote.events`) and stops the session, so `isRunning` /
-`isConnected` tell the truth instead of reporting a live session that is
-silently receiving nothing.
+#### Pacing knobs
 
-### Recommended configurations (measured)
+The draft ("発話中の暫定字幕") and refine ("清書") passes are each governed by a
+handful of `default*` constants in `lib/live/draft_pass.dart` and
+`lib/live/refine_pass.dart`. All six are now both `LiveTranscriber`/
+`HayamimiLive` constructor parameters and same-named properties that can be
+reassigned mid-session — a setter takes effect from the next due-check or
+buffer write onward, without touching any native model, and an invalid
+(non-positive or non-finite) value throws `ArgumentError` immediately rather
+than silently misbehaving later:
 
-Two supported profiles, both using **int8** model variants. On a real
-iPhone 15, int8 ran at **RTF 0.013** (ja zipformer, `modified_beam_search`)
-— about 4.8x faster than the same int8 files on a desktop x86-64 CPU, and
-faster than fp32 anywhere we measured, so on ARM phones int8 is both the
-smallest *and* the fastest choice; there's no speed reason to carry the
-larger fp16/fp32 files. Full measurements and conditions:
-[`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md),
-"On-device (iPhone 15) verification".
-
-| profile | models on device | disk | languages |
+| knob | default | runtime-settable | what it does |
 |---|---|---|---|
-| ja only (default) | ReazonSpeech zipformer int8 + Silero VAD | ~72 MB | ja |
-| `RoutingProfile.jaSenseVoice` | + SenseVoice small int8 + whisper-tiny int8 (LID probe) | ~396 MB | ja / en / zh / ko / yue |
+| `draftIntervalSeconds` | 1.0s | yes | How often a draft re-decode fires while a VAD segment is still in progress. |
+| `draftWindowSeconds` | 8.0s | yes | Trailing-audio window a draft decode re-processes, so a long utterance doesn't make every draft slower. |
+| `minDraftAudioSeconds` | 0.25s | yes | Minimum accumulated audio before a draft decode is worth running at all. |
+| `autoRefineSilenceSeconds` | 4.0s | yes | Silence gap that fires an auto-refine, when `autoRefineEnabled` is on. |
+| `autoRefineMaxBufferedSeconds` | 20.0s | yes | Buffered-duration ceiling that fires an auto-refine even without a silence gap. |
+| `refineBufferMaxSeconds` | 60.0s | yes | Hard cap on how much audio the refine buffer holds before it starts dropping the oldest segment. |
 
-Notes on the choice:
+```dart
+final live = HayamimiLive(autoRefineSilenceSeconds: 2.0); // shorter pauses trigger refine
+// ...later, mid-session:
+live.draftWindowSeconds = 4.0; // shrink the draft window on an older/hotter phone
+```
 
-- The multilingual profile loads all three models simultaneously (no LRU
-  eviction); 396 MB of weights is a deliberate size-vs-coverage trade-off
-  that assumes a phone with several GB of RAM. Start with ja-only unless
-  you need the language switching.
-- The refine ("清書") defaults shipped in this package are phone-tuned and
-  were exercised as-is in the on-device session: auto-refine fires after
-  **4 s** of silence or **20 s** of buffered speech, with the buffer capped
-  at **60 s** (`defaultAutoRefineSilenceSeconds` /
-  `defaultAutoRefineMaxBufferedSeconds` / `defaultRefineBufferMaxSeconds`
-  in `lib/live/refine_pass.dart`). See "Runtime configuration and session
-  control" below if your app wants different pacing — every one of these
-  (plus the draft pass's own three) is both a constructor parameter and a
-  mid-session-settable property now.
-- Punctuation restoration for ja (the desktop pipeline's BERT-char model,
-  181.8 MB as fp16) is wired into the refine pass now — pass a
-  `JaPunctuation` to `start`, see "Japanese punctuation restoration" below
-  — but it is **not** part of either download profile: the model file is
-  still a local build artifact, so a host app has to put it on the device
-  itself.
+These defaults were exercised as-is in the on-device session recorded in
+["Platform status"](#platform-status) below — see
+[`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md)
+for the full measurement conditions.
 
-## Threading / known limitations
+#### Decoding method
+
+sherpa-onnx's offline recognizer supports more than one search algorithm
+(`'greedy_search'` is fast; `'modified_beam_search'` costs more CPU for
+generally better accuracy). Before this parameter existed, the plain
+(single-model) path was pinned to sherpa-onnx's own `'greedy_search'`
+default and the `RoutingProfile.jaSenseVoice` profile's ja tier was
+hardcoded to `'modified_beam_search'` (matching desktop production) with no
+way to change either. `start`/`startDebugWavStream`'s `decodingMethod`
+parameter overrides whichever of those applies; leave it `null` (the
+default) to keep that existing behavior unchanged. SenseVoice's own decode
+doesn't use this parameter.
+
+#### VAD sensitivity
+
+Silero VAD (the model deciding "is this speech or silence") shipped pinned
+at its own defaults, with no way to adjust for a noisy room or a soft
+speaker. `VadSensitivity` exposes its four knobs — `threshold` (speech-
+probability cutoff, higher = less sensitive), `minSilenceSeconds` (how long
+a pause has to last before a segment finalizes), `minSpeechSeconds`
+(shorter blips are discarded before decoding), and `maxSpeechSeconds` (hard
+cap on one segment's length) — each defaulting to sherpa-onnx's own value,
+so `VadSensitivity()` reproduces the unconfigurable behavior exactly:
+
+```dart
+await live.start(
+  modelDir: modelDir,
+  vadModelPath: vadPath,
+  vadSensitivity: VadSensitivity(threshold: 0.65, minSilenceSeconds: 0.8),
+);
+
+// ...later, mid-session, without restarting:
+await live.setVadSensitivity(VadSensitivity(threshold: 0.4));
+```
+
+`setVadSensitivity` rebuilds Silero VAD off-isolate (same background-isolate
+technique `start` uses for the initial VAD load — see
+["Threading model and error handling"](#threading-model-and-error-handling))
+and swaps it in at the next safe point: never mid-segment, so a speaker's
+in-progress utterance is never silently truncated by the swap. If no
+session is running yet, the value is just remembered for the next `start`.
+Calling it again before an earlier call has finished replaces the pending
+target rather than queueing both, so only the most recently requested
+sensitivity ever actually gets installed.
+
+#### Hotwords
+
+`start`/`startDebugWavStream` also accept `hotwordsFile`/`hotwordsScore`,
+sherpa-onnx's own recognizer-level hotword biasing, applied to the plain
+path and the routed `RoutingProfile.jaSenseVoice` profile's ja tier (not
+SenseVoice). Unlike the pacing knobs and VAD sensitivity, hotwords have no
+runtime setter — they're compiled into the recognizer when it's built, so
+changing them means a fresh `start` (or `stop` + `start`).
+
+#### Starting a new "conversation" without reloading models
+
+Loading `RoutingProfile.jaSenseVoice`'s three models back-to-back is the
+multi-second cost `native_model_loader.dart` moves off the UI isolate — not
+something a host app wants to pay again just because the user tapped "new
+session." `resetSession()` clears everything about the *current*
+conversation instead: the refine buffer, in-progress draft state, and (for
+a routed session) which language it's currently locked to, all without
+touching a single loaded native model. The clear is queued behind whatever
+the decode worker already has, so a segment that was still decoding when
+you called it still lands in the transcript first rather than racing a
+write into the buffers being emptied; the returned future completes once
+the worker has confirmed it cleared its own state. It's a no-op (nothing
+cleared, no event emitted) when no session is running.
+
+```dart
+await live.resetSession(); // fresh conversation, same loaded models
+```
+
+### Japanese punctuation restoration
+
+On the desktop pipeline, the refine ("清書") pass hands its text through
+`scripts/punct_ja.py` before anything sees it, so desktop captions read as
+sentences. This package had no equivalent, so its refine output arrived as
+an unbroken run of characters — the same words, no 、 and no 。. Issue
+[#15](https://github.com/oboroge0/hayamimi/issues/15) is about closing that
+gap; it is closed now, for a session that asks for it. The model files
+this needs are not part of either download profile — see
+["Model placement guide"](#model-placement-guide) for where to get them.
+
+**Turning it on.** Pass a `JaPunctuation` to `start` (or
+`startDebugWavStream`, which is how you see it on an emulator):
+
+```dart
+await live.start(
+  modelDir: modelDir,
+  vadModelPath: vadModelPath,
+  punctuation: JaPunctuation(
+    modelPath: '$punctDir/punct_bert.fp16.onnx',
+    vocabPath: '$punctDir/vocab.txt',
+    // On a desktop host, also: libraryPath: '<...>/onnxruntime.dll'.
+    // See "Punctuation platform status" below for why Android needs no
+    // path here.
+  ),
+);
+```
+
+`null` — the default — leaves it off, which is exactly what a session did
+before the parameter existed.
+
+**What changes when it is on.**
+
+* **Refine events only.** `RefineSubtitleEvent` (and
+  `LiveTranscriber.refineEntries`) come back with 、 and 。 in them, and ？
+  after a recognised question ending. `FinalSubtitleEvent`,
+  `PartialSubtitleEvent` and the `entries`/`drafts` streams carry the
+  recognizer's text unchanged. That is where the desktop pipeline
+  punctuates, and it is the pass with the context for it: a final covers one
+  speech segment and a draft part of one still being spoken, so sentence
+  boundaries there would fall wherever the speaker happened to pause.
+  Punctuating every final would also cost a full model run per utterance, on
+  a phone, for a line the next refine replaces.
+* **Each affected line says so.** `punctuated` on `LiveTranscriptEntry` and
+  on `RefineSubtitleEvent`, and `"punctuated"` in that event's JSON (every
+  key that was already there still is), so a consumer — including one across
+  the LAN — can tell text the punctuation model wrote from text the
+  recognizer produced.
+* **Which refines get it.** A `RoutingProfile.jaSenseVoice` session
+  punctuates the refines that came back as Japanese and leaves the rest
+  alone. A plain single-model session has no language tag to test, so giving
+  it a Japanese punctuation model is itself the statement that its model
+  transcribes Japanese: **do not pass this to a plain session with a
+  non-Japanese model**, which would run a Japanese model over, say, English
+  and produce nonsense rather than nothing.
+* **Where it runs.** In the decode worker isolate, beside the recognizers —
+  loaded after them, and reported on `modelLoads` /
+  `ModelLoadSubtitleEvent` as `model: "punct"` with its measured load time.
+  `restore()` is another synchronous native call, so running it on the
+  caller's isolate would hand back the pause that moving decoding off it
+  removed (see
+  ["Threading model and error handling"](#threading-model-and-error-handling)).
+* **Memory, and what a failure does.** The model is 181.8 MB for the life of
+  the session, on top of up to 396 MB of recognizer weights. Failing to load
+  it fails `start()` with a message naming the file, rather than starting a
+  session that quietly produces unpunctuated text: on a phone a missing
+  model file is a configuration mistake, not something to degrade around.
+* **`textTransform` still runs last**, on the punctuated text.
+
+One interaction is worth knowing about. A refine falls back to the fast
+finals' text when the merged re-decode comes back much shorter than they
+were, and that length comparison is made on the text *without* the restored
+marks. They are characters nobody said, and one per clause is enough to lift
+a genuinely truncated re-decode back over the threshold. When that fallback
+does fire, the entry reports `punctuated: false`, because the text that
+survived is the finals', which nothing punctuated.
+
+**Using `PunctuatorJa` directly.** The class stays public, for a caller who
+wants to punctuate something the live pipeline did not produce:
+
+```dart
+final punctuator = await PunctuatorJa.load(
+  modelPath: '<...>/punct_bert.fp16.onnx',
+  vocabPath: '<...>/vocab.txt',
+);
+punctuator.restore('明日の会議は午後三時から始まります資料の準備をお願いします');
+// -> 明日の会議は午後三時から始まります。資料の準備をお願いします。
+punctuator.dispose();   // the session is native; nothing frees it for you
+```
+
+One instance is one ONNX Runtime session and is not safe to use from more
+than one isolate — which is why the live pipeline keeps its own inside the
+decode worker rather than sharing this one.
+
+#### How it reaches ONNX Runtime, and why that way
+
+The model runs on ONNX Runtime, the inference engine `sherpa_onnx` already
+bundles for speech recognition. The obvious move — adding the `onnxruntime`
+or `flutter_onnxruntime` package — is the wrong one: each ships its own
+`libonnxruntime.so`, and two copies of that library in one Android process
+is a known crash
+([sherpa-onnx#3261](https://github.com/k2-fsa/sherpa-onnx/issues/3261)).
+
+So this package ships no runtime at all. It calls ONNX Runtime's C API
+directly through `dart:ffi` (Dart's foreign-function interface, which lets
+Dart call C functions in a shared library) against the library
+`sherpa_onnx` has already loaded: look up `OrtGetApiBase`, ask it for a
+function table, call through it. That table only ever grows at the end
+across ONNX Runtime releases, so bindings written against an older version
+keep working when `sherpa_onnx` bumps the runtime it bundles — this package
+asks for API version 11 (ONNX Runtime 1.10's) and got 1.27.1 in testing.
+
+The session is created from the model's *file path*, not from bytes, so the
+182 MB never passes through the Dart heap. Every native object it makes —
+environment, session, tensors, the strings ONNX Runtime allocates for graph
+names — is freed explicitly; `dispose()` releases the rest.
+
+Two pieces of the reference implementation had no Dart equivalent:
+
+- **NFKC** (a Unicode normalization that folds full-width ASCII to ASCII and
+  half-width katakana to full-width) is not in `dart:core`. This package
+  depends on [`unorm_dart`](https://pub.dev/packages/unorm_dart) (MIT, no
+  dependencies, Unicode 17.0) for it.
+- **MeCab**, the Japanese morphological analyzer the reference tokenizer
+  runs, has no pure-Dart port worth carrying — and it turns out not to
+  matter: the pipeline splits every morpheme back into single characters a
+  line later, so MeCab's only observable effect is that it drops
+  whitespace. The Dart tokenizer therefore does "NFKC, drop whitespace,
+  split into code points". That is not an assumption:
+  `scripts/make_punct_fixture.py` compares the two on every FLEURS ja
+  sentence and refuses to write its fixture if they ever disagree.
+
+#### Punctuation platform status
+
+| Platform | Status |
+|---|---|
+| Windows (host, `flutter test`) | **Verified** — parity with the Python reference on 51 recorded cases. |
+| Android | Expected to work: `libonnxruntime.so` is what `sherpa_onnx` loads there. **Not run on a device in this change.** |
+| iOS | **Unverified, and refused by default.** `sherpa_onnx` links ONNX Runtime as an xcframework and it has not been confirmed that `OrtGetApiBase` stays exported from the app binary, so `PunctuatorJa.load` throws rather than guess. Pass `libraryPath: OrtLibrary.processSymbols` to try it. |
+| macOS / Linux | Pass `libraryPath`; nothing puts the library on a desktop host's loader search path. |
+
+#### Running the parity test
+
+`test/punct/punct_ja_parity_test.dart` replays
+`test/fixtures/punct_ja_parity.json` — 40 sentences from the FLEURS ja
+benchmark set with their punctuation stripped, plus 11 synthetic edge cases
+— and asserts the Dart output equals the recorded Python output character
+for character. Regenerate the fixture with
+`python scripts/make_punct_fixture.py`.
+
+It needs the float16 model and an ONNX Runtime library, and **skips with a
+reason naming whichever is missing** rather than failing, so a checkout
+without them stays green. On Windows it finds the library by reading the
+resolved path of `sherpa_onnx_windows` out of
+`.dart_tool/package_config.json` and using the `onnxruntime.dll` that
+package ships; elsewhere, point `HAYAMIMI_ORT_LIBRARY` at one. A companion
+test, `punct_ja_fixture_tokens_test.dart`, checks the token ids from the
+same fixture and needs only the 28 KB `vocab.txt`, so tokenizer drift is
+caught even without the model.
+
+The test prints what it measured while running: **66–90 ms mean
+`restore()`** over the 51 cases (55 characters on average) across six
+runs, on this Windows x86 host, ONNX Runtime 1.27.1 from
+`sherpa_onnx_windows`, two intra-op threads. **This says
+nothing about a phone.** ONNX Runtime's CPU provider has no float16 compute
+path on x86, so float16 tensors are cast to float32 and back on every
+operator; an ARM chip with a float16 vector unit is a different machine
+entirely. For scale only: the Python reference (`scripts/punct_ja.py`,
+ONNX Runtime 1.29.0, four intra-op threads, MeCab tokenization inside the
+timed call) averaged 366.3 ms on the same 51 inputs and the same model on
+this host. The two measurements differ in runtime build, thread count and
+what the timed call includes, so the gap has not been attributed to
+anything — it is recorded here, not explained.
+
+### Threading model and error handling
 
 **The problem this section used to describe.** Everything sherpa-onnx does
 is a *synchronous* FFI call — a direct call into a native library that runs
@@ -221,8 +566,8 @@ re-decodes a whole buffered group at once (up to 60 s of audio by default).
 | Microphone capture | the `record` plugin's own platform thread; audio chunks arrive as a stream on the caller's isolate |
 | Silero VAD — one `acceptWaveform` per 32 ms frame | the caller's isolate |
 | Building the recognizers | the decode worker isolate, which loads them itself |
-| Building the VAD | a short-lived background isolate, which hands the handle back ([`lib/live/native_model_loader.dart`](lib/live/native_model_loader.dart)) |
-| Every decode — per-segment finals, drafts, refine passes, and the whisper-tiny language identification a routed session runs | the decode worker isolate ([`lib/live/decode_worker.dart`](lib/live/decode_worker.dart)) |
+| Building the VAD | a short-lived background isolate, which hands the handle back ([`lib/live/native_model_loader.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/live/native_model_loader.dart)) |
+| Every decode — per-segment finals, drafts, refine passes, and the whisper-tiny language identification a routed session runs | the decode worker isolate ([`lib/live/decode_worker.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/live/decode_worker.dart)) |
 | Building the Japanese punctuation model, when the session asked for one | the decode worker isolate, after the recognizers |
 | Restoring Japanese punctuation into a refine result | the decode worker isolate, right after the decode that produced it |
 | Emitting `entries`/`drafts`/`refineEntries`/`decoding`/`errors`/`modelLoads`/`sessionResets` | the caller's isolate |
@@ -268,7 +613,14 @@ per 32 ms frame, and the event dispatch for the streams above. The VAD stays
 put deliberately: it is a small, frequent call, and a message round trip per
 frame would cost more than the call it replaced.
 
-**Other limits worth knowing.**
+**Error handling.** A session reports its own failures rather than throwing
+across an event stream: `HayamimiLive.events` carries an `ErrorSubtitleEvent`,
+`LiveTranscriber.errors` a `LiveTranscriberException`, and
+`HayamimiRemote.events`/`RemoteTranscriber` a `RemoteErrorEvent`/
+`RemoteTranscriberException`, for anything that goes wrong once a session
+is already running. `start`/`connect` themselves still throw synchronously
+for a bad call (a missing model file, an already-connected client) — see
+each method's own doc comment for exactly which exception. Specific cases:
 
 * If the decode worker isolate dies mid-session, the session stops: a
   `LiveTranscriberException` is emitted on `errors` (an `ErrorSubtitleEvent`
@@ -288,418 +640,18 @@ frame would cost more than the call it replaced.
   nothing and cost a spawn and a full model load per invocation. Use
   `startDebugWavStream` to exercise the real pipeline, worker included.
 
-## Minimal example: on-device subtitles
-
-See [`example/`](example/) for a full, runnable Flutter app built from
-nothing but this snippet's shape (pub.dev's standard `example/` layout) —
-useful as a copy-pasteable starting point, since the fragment below elides
-error handling and widget wiring for brevity:
-
-```dart
-import 'package:hayamimi_core/hayamimi_core.dart';
-
-final live = HayamimiLive();
-
-live.events.listen((event) {
-  switch (event) {
-    case PartialSubtitleEvent(:final text):
-      print('draft: $text');
-    case FinalSubtitleEvent(:final text, :final lang):
-      print('final [$lang]: $text');
-    case RefineSubtitleEvent(:final text):
-      print('refine (清書): $text');
-    default:
-      break;
-  }
-});
-
-await live.start(
-  modelDir: '/path/to/model',        // encoder/decoder/joiner/tokens.txt
-  vadModelPath: '/path/to/silero_vad.onnx',
-  // Optional multilingual routing: each segment goes to ReazonSpeech (ja)
-  // or SenseVoice (en/zh/ko/yue) instead of one fixed-language model.
-  routingProfile: RoutingProfile.jaSenseVoice,
-  senseVoiceModelDir: '/path/to/sense_voice',
-  lidModelDir: '/path/to/lid',
-);
-
-// ... later, e.g. on a button tap:
-await live.refineNow();   // manual "清書" re-decode pass
-
-// ... when done:
-await live.stop();
-await live.dispose();
-```
-
-### Text post-processing hook
-
-`HayamimiLive(textTransform: ...)` (or the settable `live.textTransform`
-field, changeable mid-session) lets a host app rewrite each draft/final/
-refine entry's text right where it becomes a `SubtitleEvent` — before it
-reaches `events` and therefore before `SubtitleBroadcastServer` or any other
-consumer sees it. The callback takes `(text, lang)` and returns the text to
-publish; `null` (the default) is a no-op. This is deliberately just an
-insertion point, not an implementation: CJK inverse-text-normalization
-(kanji numerals -> arabic digits, `scripts/itn_cjk.py` on the desktop side)
-and user find/replace dictionaries are not ported to Dart yet, so a host app
-that wants them today supplies its own `textTransform`.
-
-## Japanese punctuation restoration
-
-On the desktop pipeline, the refine ("清書") pass hands its text through
-`scripts/punct_ja.py` before anything sees it, so desktop captions read as
-sentences. This package had no equivalent, so its refine output arrived as
-an unbroken run of characters — the same words, no 、 and no 。. Issue
-[#15](https://github.com/oboroge0/hayamimi/issues/15) is about closing that
-gap; it is closed now, for a session that asks for it.
-
-**Turning it on.** Pass a `JaPunctuation` to `start` (or
-`startDebugWavStream`, which is how you see it on an emulator):
-
-```dart
-await live.start(
-  modelDir: modelDir,
-  vadModelPath: vadModelPath,
-  punctuation: JaPunctuation(
-    modelPath: '$punctDir/punct_bert.fp16.onnx',
-    vocabPath: '$punctDir/vocab.txt',
-    // On a desktop host, also: libraryPath: '<...>/onnxruntime.dll'.
-    // See "Platform status" below for why Android needs no path here.
-  ),
-);
-```
-
-`null` — the default — leaves it off, which is exactly what a session did
-before the parameter existed.
-
-**What changes when it is on.**
-
-* **Refine events only.** `RefineSubtitleEvent` (and
-  `LiveTranscriber.refineEntries`) come back with 、 and 。 in them, and ？
-  after a recognised question ending. `FinalSubtitleEvent`,
-  `PartialSubtitleEvent` and the `entries`/`drafts` streams carry the
-  recognizer's text unchanged. That is where the desktop pipeline
-  punctuates, and it is the pass with the context for it: a final covers one
-  speech segment and a draft part of one still being spoken, so sentence
-  boundaries there would fall wherever the speaker happened to pause.
-  Punctuating every final would also cost a full model run per utterance, on
-  a phone, for a line the next refine replaces.
-* **Each affected line says so.** `punctuated` on `LiveTranscriptEntry` and
-  on `RefineSubtitleEvent`, and `"punctuated"` in that event's JSON (every
-  key that was already there still is), so a consumer — including one across
-  the LAN — can tell text the punctuation model wrote from text the
-  recognizer produced.
-* **Which refines get it.** A `RoutingProfile.jaSenseVoice` session
-  punctuates the refines that came back as Japanese and leaves the rest
-  alone. A plain single-model session has no language tag to test, so giving
-  it a Japanese punctuation model is itself the statement that its model
-  transcribes Japanese: **do not pass this to a plain session with a
-  non-Japanese model**, which would run a Japanese model over, say, English
-  and produce nonsense rather than nothing.
-* **Where it runs.** In the decode worker isolate, beside the recognizers —
-  loaded after them, and reported on `modelLoads` /
-  `ModelLoadSubtitleEvent` as `model: "punct"` with its measured load time.
-  `restore()` is another synchronous native call, so running it on the
-  caller's isolate would hand back the pause that moving decoding off it
-  removed (see "Threading" above).
-* **Memory, and what a failure does.** The model is 181.8 MB for the life of
-  the session, on top of up to 396 MB of recognizer weights. Failing to load
-  it fails `start()` with a message naming the file, rather than starting a
-  session that quietly produces unpunctuated text: on a phone a missing
-  model file is a configuration mistake, not something to degrade around.
-* **`textTransform` still runs last**, on the punctuated text.
-
-One interaction is worth knowing about. A refine falls back to the fast
-finals' text when the merged re-decode comes back much shorter than they
-were, and that length comparison is made on the text *without* the restored
-marks. They are characters nobody said, and one per clause is enough to lift
-a genuinely truncated re-decode back over the threshold. When that fallback
-does fire, the entry reports `punctuated: false`, because the text that
-survived is the finals', which nothing punctuated.
-
-**Using `PunctuatorJa` directly.** The class stays public, for a caller who
-wants to punctuate something the live pipeline did not produce:
-
-```dart
-final punctuator = await PunctuatorJa.load(
-  modelPath: '<...>/punct_bert.fp16.onnx',
-  vocabPath: '<...>/vocab.txt',
-);
-punctuator.restore('明日の会議は午後三時から始まります資料の準備をお願いします');
-// -> 明日の会議は午後三時から始まります。資料の準備をお願いします。
-punctuator.dispose();   // the session is native; nothing frees it for you
-```
-
-One instance is one ONNX Runtime session and is not safe to use from more
-than one isolate — which is why the live pipeline keeps its own inside the
-decode worker rather than sharing this one.
-
-**The model is still not downloadable.** `ModelDownloader` has no entry for
-it: `punct_bert.fp16.onnx` (181.8 MB) is a local artifact of `python
-scripts/quantize_punct.py --variant fp16`, and `vocab.txt` comes from the
-model directory `docs/PUNCT_JA.md` describes. Where to host a 182 MB file,
-and whether to ship the float16 build or something smaller, is undecided —
-`docs/MOBILE.md` records that float16 was the only size reduction that did
-not cost accuracy (identical predictions to the full-size model on a
-250-sentence FLEURS ja check; dynamic and static INT8 both lost recall).
-Until that is settled, a host app has to place both files on the device
-itself.
-
-**No device run happened in this change.** The wiring was verified on a
-Windows host with `flutter analyze` and `flutter test`: the session behaviour
-against a stand-in worker, the protocol encoding, and one test that builds
-the punctuator from a real session config and runs it. What that leaves
-unverified is the phone — whether ONNX Runtime resolves as the next section
-expects on Android, and what `restore()` costs on an ARM CPU.
-
-### How it reaches ONNX Runtime, and why that way
-
-The model runs on ONNX Runtime, the inference engine `sherpa_onnx` already
-bundles for speech recognition. The obvious move — adding the `onnxruntime`
-or `flutter_onnxruntime` package — is the wrong one: each ships its own
-`libonnxruntime.so`, and two copies of that library in one Android process
-is a known crash
-([sherpa-onnx#3261](https://github.com/k2-fsa/sherpa-onnx/issues/3261)).
-
-So this package ships no runtime at all. It calls ONNX Runtime's C API
-directly through `dart:ffi` (Dart's foreign-function interface, which lets
-Dart call C functions in a shared library) against the library
-`sherpa_onnx` has already loaded: look up `OrtGetApiBase`, ask it for a
-function table, call through it. That table only ever grows at the end
-across ONNX Runtime releases, so bindings written against an older version
-keep working when `sherpa_onnx` bumps the runtime it bundles — this package
-asks for API version 11 (ONNX Runtime 1.10's) and got 1.27.1 in testing.
-
-The session is created from the model's *file path*, not from bytes, so the
-182 MB never passes through the Dart heap. Every native object it makes —
-environment, session, tensors, the strings ONNX Runtime allocates for graph
-names — is freed explicitly; `dispose()` releases the rest.
-
-Two pieces of the reference implementation had no Dart equivalent:
-
-- **NFKC** (a Unicode normalization that folds full-width ASCII to ASCII and
-  half-width katakana to full-width) is not in `dart:core`. This package
-  depends on [`unorm_dart`](https://pub.dev/packages/unorm_dart) (MIT, no
-  dependencies, Unicode 17.0) for it.
-- **MeCab**, the Japanese morphological analyzer the reference tokenizer
-  runs, has no pure-Dart port worth carrying — and it turns out not to
-  matter: the pipeline splits every morpheme back into single characters a
-  line later, so MeCab's only observable effect is that it drops
-  whitespace. The Dart tokenizer therefore does "NFKC, drop whitespace,
-  split into code points". That is not an assumption:
-  `scripts/make_punct_fixture.py` compares the two on every FLEURS ja
-  sentence and refuses to write its fixture if they ever disagree.
-
-### Platform status
-
-| Platform | Status |
-|---|---|
-| Windows (host, `flutter test`) | **Verified** — parity with the Python reference on 51 recorded cases. |
-| Android | Expected to work: `libonnxruntime.so` is what `sherpa_onnx` loads there. **Not run on a device in this change.** |
-| iOS | **Unverified, and refused by default.** `sherpa_onnx` links ONNX Runtime as an xcframework and it has not been confirmed that `OrtGetApiBase` stays exported from the app binary, so `PunctuatorJa.load` throws rather than guess. Pass `libraryPath: OrtLibrary.processSymbols` to try it. |
-| macOS / Linux | Pass `libraryPath`; nothing puts the library on a desktop host's loader search path. |
-
-### Running the parity test
-
-`test/punct/punct_ja_parity_test.dart` replays
-`test/fixtures/punct_ja_parity.json` — 40 sentences from the FLEURS ja
-benchmark set with their punctuation stripped, plus 11 synthetic edge cases
-— and asserts the Dart output equals the recorded Python output character
-for character. Regenerate the fixture with
-`python scripts/make_punct_fixture.py`.
-
-It needs the float16 model and an ONNX Runtime library, and **skips with a
-reason naming whichever is missing** rather than failing, so a checkout
-without them stays green. On Windows it finds the library by reading the
-resolved path of `sherpa_onnx_windows` out of
-`.dart_tool/package_config.json` and using the `onnxruntime.dll` that
-package ships; elsewhere, point `HAYAMIMI_ORT_LIBRARY` at one. A companion
-test, `punct_ja_fixture_tokens_test.dart`, checks the token ids from the
-same fixture and needs only the 28 KB `vocab.txt`, so tokenizer drift is
-caught even without the model.
-
-The test prints what it measured while running: **66–90 ms mean
-`restore()`** over the 51 cases (55 characters on average) across six
-runs, on this Windows x86 host, ONNX Runtime 1.27.1 from
-`sherpa_onnx_windows`, two intra-op threads. **This says
-nothing about a phone.** ONNX Runtime's CPU provider has no float16 compute
-path on x86, so float16 tensors are cast to float32 and back on every
-operator; an ARM chip with a float16 vector unit is a different machine
-entirely. For scale only: the Python reference (`scripts/punct_ja.py`,
-ONNX Runtime 1.29.0, four intra-op threads, MeCab tokenization inside the
-timed call) averaged 366.3 ms on the same 51 inputs and the same model on
-this host. The two measurements differ in runtime build, thread count and
-what the timed call includes, so the gap has not been attributed to
-anything — it is recorded here, not explained.
-
-## Runtime configuration and session control
-
-The pacing/VAD/decoding defaults above were chosen for a phone running the
-"Recommended configurations" above, but an embedding app doesn't always
-match that shape — a noisy venue needs a less trigger-happy VAD, a
-lecture-style app might want a longer draft window, and a host that already
-has its own hotword list wants to plug it straight into the recognizer
-instead of post-processing text after the fact. All of this used to be
-hardcoded constants with no way in; issue
-[#29](https://github.com/oboroge0/hayamimi/issues/29) opened it up.
-
-### Pacing knobs
-
-The draft ("発話中の暫定字幕") and refine ("清書") passes are each governed by a
-handful of `default*` constants in `lib/live/draft_pass.dart` and
-`lib/live/refine_pass.dart` (see "Recommended configurations" above for the
-values and why they're phone-tuned). All six are now both `LiveTranscriber`/
-`HayamimiLive` constructor parameters and same-named properties that can be
-reassigned mid-session — a setter takes effect from the next due-check or
-buffer write onward, without touching any native model, and an invalid
-(non-positive or non-finite) value throws `ArgumentError` immediately rather
-than silently misbehaving later:
-
-| knob | default | runtime-settable | what it does |
-|---|---|---|---|
-| `draftIntervalSeconds` | 1.0s | yes | How often a draft re-decode fires while a VAD segment is still in progress. |
-| `draftWindowSeconds` | 8.0s | yes | Trailing-audio window a draft decode re-processes, so a long utterance doesn't make every draft slower. |
-| `minDraftAudioSeconds` | 0.25s | yes | Minimum accumulated audio before a draft decode is worth running at all. |
-| `autoRefineSilenceSeconds` | 4.0s | yes | Silence gap that fires an auto-refine, when `autoRefineEnabled` is on. |
-| `autoRefineMaxBufferedSeconds` | 20.0s | yes | Buffered-duration ceiling that fires an auto-refine even without a silence gap. |
-| `refineBufferMaxSeconds` | 60.0s | yes | Hard cap on how much audio the refine buffer holds before it starts dropping the oldest segment. |
-
-```dart
-final live = HayamimiLive(autoRefineSilenceSeconds: 2.0); // shorter pauses trigger refine
-// ...later, mid-session:
-live.draftWindowSeconds = 4.0; // shrink the draft window on an older/hotter phone
-```
-
-### Decoding method
-
-sherpa-onnx's offline recognizer supports more than one search algorithm
-(`'greedy_search'` is fast; `'modified_beam_search'` costs more CPU for
-generally better accuracy). Before this parameter existed, the plain
-(single-model) path was pinned to sherpa-onnx's own `'greedy_search'`
-default and the `RoutingProfile.jaSenseVoice` profile's ja tier was
-hardcoded to `'modified_beam_search'` (matching desktop production) with no
-way to change either. `start`/`startDebugWavStream`'s `decodingMethod`
-parameter overrides whichever of those applies; leave it `null` (the
-default) to keep that existing behavior unchanged. SenseVoice's own decode
-doesn't use this parameter.
-
-### VAD sensitivity
-
-Silero VAD (the model deciding "is this speech or silence") shipped pinned
-at its own defaults, with no way to adjust for a noisy room or a soft
-speaker. `VadSensitivity` exposes its four knobs — `threshold` (speech-
-probability cutoff, higher = less sensitive), `minSilenceSeconds` (how long
-a pause has to last before a segment finalizes), `minSpeechSeconds`
-(shorter blips are discarded before decoding), and `maxSpeechSeconds` (hard
-cap on one segment's length) — each defaulting to sherpa-onnx's own value,
-so `VadSensitivity()` reproduces the unconfigurable behavior exactly:
-
-```dart
-await live.start(
-  modelDir: modelDir,
-  vadModelPath: vadPath,
-  vadSensitivity: VadSensitivity(threshold: 0.65, minSilenceSeconds: 0.8),
-);
-
-// ...later, mid-session, without restarting:
-await live.setVadSensitivity(VadSensitivity(threshold: 0.4));
-```
-
-`setVadSensitivity` rebuilds Silero VAD off-isolate (same background-isolate
-technique `start` uses for the initial VAD load — see "Threading /
-known limitations") and swaps it in at the next safe point: never
-mid-segment, so a speaker's in-progress utterance is never silently
-truncated by the swap. If no session is running yet, the value is just
-remembered for the next `start`. Calling it again before an earlier call has
-finished replaces the pending target rather than queueing both, so only the
-most recently requested sensitivity ever actually gets installed.
-
-### Hotwords
-
-`start`/`startDebugWavStream` also accept `hotwordsFile`/`hotwordsScore`,
-sherpa-onnx's own recognizer-level hotword biasing, applied to the plain
-path and the routed `RoutingProfile.jaSenseVoice` profile's ja tier (not
-SenseVoice). Unlike the pacing knobs and VAD sensitivity, hotwords have no
-runtime setter — they're compiled into the recognizer when it's built, so
-changing them means a fresh `start` (or `stop` + `start`).
-
-### Starting a new "conversation" without reloading models
-
-Loading `RoutingProfile.jaSenseVoice`'s three models back-to-back is the
-multi-second cost `native_model_loader.dart` moves off the UI isolate — not
-something a host app wants to pay again just because the user tapped "new
-session." `resetSession()` clears everything about the *current*
-conversation instead: the refine buffer, in-progress draft state, and (for
-a routed session) which language it's currently locked to, all without
-touching a single loaded native model. The clear is queued behind whatever
-the decode worker already has, so a segment that was still decoding when
-you called it still lands in the transcript first rather than racing a
-write into the buffers being emptied; the returned future completes once
-the worker has confirmed it cleared its own state. It's a no-op (nothing
-cleared, no event emitted) when no session is running.
-
-```dart
-await live.resetSession(); // fresh conversation, same loaded models
-```
-
-## Minimal example: remote subtitles (PC does the recognition)
-
-```dart
-import 'package:hayamimi_core/hayamimi_core.dart';
-
-final remote = HayamimiRemote();
-
-remote.events.listen((event) {
-  if (event case FinalSubtitleEvent(:final text, :final lang)) {
-    print('[$lang] $text');
-  }
-});
-
-await remote.connect('ws://192.168.1.10:8766/ingest');
-
-// ... when done:
-await remote.disconnect();
-await remote.dispose();
-```
-
-The server side is `python scripts/realtime_transcribe.py --input ws
---serve` from the main hayamimi repo — see its own docs for the two ports
-involved (`--serve`'s HTTP/SSE dashboard vs. `--input ws`'s `/ingest`
-WebSocket).
-
-## Broadcasting to other apps on the LAN
-
-Either facade's events can be mirrored out over `SubtitleBroadcastServer`,
-which speaks the exact protocol `scripts/subtitle_server.py` does (so an
-OBS browser source or a browser tab that already works against the desktop
-app works against your embedding app too):
-
-```dart
-final broadcast = SubtitleBroadcastServer();
-await broadcast.start();
-
-live.events.listen(broadcast.broadcast); // events are already SubtitleEvent
-
-// GET http://<lan ip>:8833/         -> transparent overlay page
-// GET http://<lan ip>:8833/events   -> SSE feed of the same events
-```
-
-`SubtitleBroadcastServer({port, bindAddress, allowOrigin})` binds
-[`InternetAddress.anyIPv4`](https://api.dart.dev/dart-io/InternetAddress/anyIPv4-constant.html)
-(`0.0.0.0`, all interfaces) by default, deliberately, rather than loopback:
-the whole point of this class is reachability from *other* devices on the
-LAN — that's what makes it useful for OBS or a browser running on a
-different machine. Pass a narrower `bindAddress` (e.g.
-`InternetAddress.loopbackIPv4`) only if a host app wants to restrict this to
-same-device consumers, which defeats the LAN-broadcast use case this class
-exists for. `allowOrigin` (default `'*'`) controls the `/events` response's
-`Access-Control-Allow-Origin` header, matching the desktop
-`subtitle_server.py`'s permissive default so a browser-based OBS source or a
-web dashboard on a different origin works without extra configuration;
-narrow it if a host app needs to restrict which origins may read its
-transcript.
-
-## Events
+**App lifecycle.** This package does not observe the app lifecycle: the
+host app owns that policy, because only it knows whether a background
+session is wanted (and whether it has arranged the background-audio
+entitlements to keep one alive). The recommended default is to `stop()` on
+background and `start()` again on resume, from your own
+`WidgetsBindingObserver`. If you don't, the OS may take the microphone away
+mid-session — on backgrounding, or when another app grabs it — and when
+that happens the library emits the error event described above and stops
+the session, so `isRunning`/`isConnected` tell the truth instead of
+reporting a live session that is silently receiving nothing.
+
+### Events
 
 Every `SubtitleEvent` this package emits — from `HayamimiLive.events`,
 `HayamimiRemote.events`, and re-broadcast verbatim by
@@ -718,7 +670,7 @@ reason.
 | `partial` | `{"type":"partial","text":...}` | A draft ("発話中の暫定字幕") re-decode fires while a VAD segment is still in progress. |
 | `final` | `{"type":"final","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"switched":...}` | A VAD segment finalized. `audio_s` is the segment's duration in seconds; `switched` is `true` only when this segment is the reason a `RoutingProfile.jaSenseVoice` session's language changed. `speaker` is always empty (no diarization yet). |
 | `translation` | `{"type":"translation","lang":...,"text":...}` | Reserved for wire compatibility with the desktop pipeline's machine translation — not emitted by this package today. |
-| `refine` | `{"type":"refine","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"punctuated":...}` | A refine ("清書") pass completed. `audio_s` is the total duration of the buffered group that was re-decoded; `punctuated` is `true` when Japanese punctuation was restored into `text` (see "Japanese punctuation restoration"), and `false` from every producer that does not punctuate, remote sessions included. |
+| `refine` | `{"type":"refine","text":...,"lang":...,"speaker":...,"latency_ms":...,"audio_s":...,"punctuated":...}` | A refine ("清書") pass completed. `audio_s` is the total duration of the buffered group that was re-decoded; `punctuated` is `true` when Japanese punctuation was restored into `text` (see ["Japanese punctuation restoration"](#japanese-punctuation-restoration)), and `false` from every producer that does not punctuate, remote sessions included. |
 | `error` | `{"type":"error","message":...}` | A session failure not attributable to a call the caller made — e.g. the OS revoking mic access mid-session. |
 | `model_load` | `{"type":"model_load","model":...,"phase":"start"\|"done","ms":...}` | Right before and right after each native model finishes loading (`model` is `"vad"`, `"recognizer"`, for `RoutingProfile.jaSenseVoice`: `"ja"`/`"sensevoice"`/`"lid"`, or `"punct"` for the Japanese punctuation model), including a `setVadSensitivity` rebuild. `ms` is the elapsed build time, only set on `"done"`. |
 | `session_reset` | `{"type":"session_reset"}` | `resetSession()` finished clearing the current conversation's state. |
@@ -732,6 +684,188 @@ package doesn't have a typed `RemoteEvent` for yet — `model_fallback`,
 `warning`, `session_summary`, `recluster` — which arrive as
 `RemoteUnknownEvent` on `HayamimiRemote.rawEvents` and are silently dropped
 from `HayamimiRemote.events` rather than raising an error.
+
+## Model placement guide
+
+`HayamimiLive` needs sherpa-onnx model files on disk; this package doesn't
+bundle any, but ships a downloader so you don't have to hand-roll the
+fetch/verify/unpack/placement yourself. This section covers both paths:
+letting `downloadProfile` do it, and placing files yourself.
+
+### Recommended configurations (measured)
+
+Two supported profiles, both using **int8** model variants. On a real
+iPhone 15, int8 ran at **RTF 0.013** (ja zipformer, `modified_beam_search`)
+— about 4.8x faster than the same int8 files on a desktop x86-64 CPU, and
+faster than fp32 anywhere we measured, so on ARM phones int8 is both the
+smallest *and* the fastest choice; there's no speed reason to carry the
+larger fp16/fp32 files. Full measurements and conditions:
+[`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md),
+"On-device (iPhone 15) verification".
+
+| profile | models on device | disk | languages |
+|---|---|---|---|
+| `RoutingProfile.jaOnly` (default) | ReazonSpeech zipformer int8 + Silero VAD | ~72 MB | ja |
+| `RoutingProfile.jaSenseVoice` | + SenseVoice small int8 + whisper-tiny int8 (LID probe) | ~396 MB | ja / en / zh / ko / yue |
+
+Notes on the choice:
+
+- The multilingual profile loads all three models simultaneously (no LRU
+  eviction); 396 MB of weights is a deliberate size-vs-coverage trade-off
+  that assumes a phone with several GB of RAM. Start with ja-only unless
+  you need the language switching.
+- The refine ("清書") defaults shipped in this package are phone-tuned —
+  see ["Pacing knobs"](#pacing-knobs) above for the values and how to
+  change them.
+- Punctuation restoration for ja (the desktop pipeline's BERT-char model,
+  181.8 MB as fp16) is wired into the refine pass — see
+  ["Japanese punctuation restoration"](#japanese-punctuation-restoration) —
+  but it is **not** part of either download profile: the model file is
+  still a local build artifact, so a host app has to put it on the device
+  itself (see below).
+
+### Directory layout each profile expects
+
+`downloadProfile`/manual placement both target this layout under one
+`<targetDir>` (e.g. your app's Documents directory) — it's what
+`HayamimiLive.start`/`LiveTranscriber.start` read their `modelDir`/
+`vadModelPath`/`senseVoiceModelDir`/`lidModelDir` arguments from:
+
+| directory | needed by | files |
+|---|---|---|
+| `<targetDir>/model/` | every profile | ReazonSpeech ja zipformer `encoder`/`decoder`/`joiner` (`.int8.onnx`) + `tokens.txt` |
+| `<targetDir>/vad/` | every profile (`HayamimiLive` only — `HayamimiRemote` has no local VAD) | `silero_vad.onnx` |
+| `<targetDir>/sense_voice/` | `RoutingProfile.jaSenseVoice` only | `model.int8.onnx` + `tokens.txt` |
+| `<targetDir>/lid/` | `RoutingProfile.jaSenseVoice` only | `tiny-encoder.int8.onnx` + `tiny-decoder.int8.onnx` |
+| any path you choose, passed to `JaPunctuation` | Japanese punctuation, optional, any profile | `punct_bert.fp16.onnx` (181.8 MB) + `vocab.txt` (28 KB) |
+
+Exact filenames inside `model/`/`sense_voice/`/`lid/` don't have to match
+this table character for character: `resolveZipformerTransducerFiles`/
+`resolveOnnxFile` in
+[`lib/bench/model_file_resolver.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/bench/model_file_resolver.dart)
+match by role substring (`encoder`/`decoder`/`joiner`) and prefer an
+`int8` variant when both it and a full-precision one are present, so
+extracting a sherpa-onnx release archive's own filenames as-is (rather than
+renaming them) is sufficient.
+
+### Automatic download
+
+```dart
+import 'package:hayamimi_core/hayamimi_core.dart';
+import 'package:path_provider/path_provider.dart';
+
+final docsDir = await getApplicationDocumentsDirectory();
+
+await downloadProfile(
+  ModelProfile.jaOnly, // or ModelProfile.jaSenseVoice
+  docsDir.path,
+  onProgress: (event) {
+    // event.phase: skipped/downloading/verifyingDownload/extracting/done
+    // event.bytesReceived / event.totalBytes for a progress bar
+    // (totalBytes is null if the server didn't send Content-Length)
+  },
+);
+
+final live = HayamimiLive();
+await live.start(
+  modelDir: '${docsDir.path}/model',
+  vadModelPath: '${docsDir.path}/vad/silero_vad.onnx',
+  // Only for ModelProfile.jaSenseVoice:
+  // routingProfile: RoutingProfile.jaSenseVoice,
+  // senseVoiceModelDir: '${docsDir.path}/sense_voice',
+  // lidModelDir: '${docsDir.path}/lid',
+);
+```
+
+`downloadProfile` downloads each asset from the sherpa-onnx GitHub
+releases (`asr-models` tag), verifies its sha256, extracts only the
+`int8` members from the archives that bundle multiple precisions, and
+places everything under `<targetDir>/model`, `/vad`, `/sense_voice`,
+`/lid` — the layout in the table above, exactly what this snippet expects,
+so nothing needs renaming or resolving by hand. It's idempotent: call it
+again (e.g. on every app start) and it re-verifies what's already on disk
+by checksum and only re-fetches what's missing or corrupt, so it's safe
+to call unconditionally rather than gating it on "is this the first
+launch."
+
+See
+[`lib/setup/model_downloader.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/setup/model_downloader.dart)
+for the full manifest (`modelManifest`) — exact asset URLs, sha256s, and
+which files each profile places where — and this package's
+[`example/`](https://github.com/oboroge0/hayamimi/tree/main/mobile/hayamimi_core/example)'s
+`_downloadModels` for a guarded, tap-to-download version of the snippet
+above (it doesn't fetch 396 MB without the user asking for it).
+
+### Manual placement
+
+If you'd rather manage the files by hand (a CI step, a custom CDN, …),
+`downloadProfile`'s manifest names the exact assets:
+
+- ReazonSpeech ja zipformer transducer (int8): [`sherpa-onnx-zipformer-ja-en-reazonspeech-2025-01-17.tar.bz2`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-ja-en-reazonspeech-2025-01-17.tar.bz2)
+  — extract the `encoder`/`decoder`/`joiner` `.int8.onnx` files (this
+  archive also ships fp32/fp16, which you don't need on a phone) plus
+  `tokens.txt` into `<targetDir>/model/`.
+- [`silero_vad.onnx`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx)
+  into `<targetDir>/vad/`, only needed for `HayamimiLive` (not
+  `HayamimiRemote`, which has no ASR of its own).
+- For `RoutingProfile.jaSenseVoice` only: [`sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17.tar.bz2`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17.tar.bz2)
+  (`model.int8.onnx` + `tokens.txt`) into `<targetDir>/sense_voice/`, and
+  [`sherpa-onnx-whisper-tiny.tar.bz2`](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-tiny.tar.bz2)
+  (only its `tiny-encoder.int8.onnx`/`tiny-decoder.int8.onnx` — the LID
+  probe doesn't need `tiny-tokens.txt` or the fp32 files also in that
+  archive) into `<targetDir>/lid/`.
+- **Japanese punctuation (optional, any profile):** `punct_bert.fp16.onnx`
+  and its `vocab.txt` are not on the sherpa-onnx release page — they're a
+  local build artifact of `python scripts/quantize_punct.py --variant
+  fp16` in the main hayamimi repo, described in
+  [`docs/PUNCT_JA.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/PUNCT_JA.md).
+  There is no `ModelDownloader` entry for it yet — copy both files to
+  wherever you pass as `JaPunctuation(modelPath: ..., vocabPath: ...)`, no
+  fixed subdirectory required.
+
+### Storage location and licenses
+
+Every path above is written as `<targetDir>/...`; a typical host app uses
+`path_provider`'s `getApplicationDocumentsDirectory()` for `<targetDir>`,
+as the snippets in this guide do — it survives app restarts, isn't
+cleared under storage pressure the way a cache directory can be, and (on
+Android) isn't visible to the user or other apps without their own file
+picker, which matters for multi-hundred-MB files a user didn't explicitly
+save. Avoid a temporary/cache directory for anything `downloadProfile`
+places: the whole point of its checksum-based idempotency is that the
+files stay put between launches.
+
+Every model file above is a third-party artifact with its own license —
+this package's own code is MIT (`LICENSE`), but bundling or redistributing
+model weights is a separate question. See
+[`THIRD_PARTY_NOTICES.md`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/THIRD_PARTY_NOTICES.md)
+in this package for the publisher, license, and source of every model
+`downloadProfile`/manual placement can put on a device, including the
+Japanese punctuation model.
+
+## Platform status
+
+What has actually been run where, as of this release — not a claim about
+what *should* work elsewhere. Full write-ups:
+[`docs/MOBILE.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/MOBILE.md)
+and
+[`docs/IOS_VERIFY.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/IOS_VERIFY.md).
+
+| Platform | ASR bench / live mic | Multi-language routing | Remote mode | Japanese punctuation |
+|---|---|---|---|---|
+| **iOS** (real iPhone 15) | **Verified.** Bench RTF 0.013 (ja int8, `modified_beam_search`, single run); Live tab transcribed real mic input end-to-end with no reported heat or UI stutter. | Ran live on-device with real speech switching ja/en; badge-switch accuracy was mixed because the session had multiple people talking in the room, so treat it as "it works," not a clean accuracy number — see `docs/IOS_VERIFY.md` for a cleaner single-speaker retest plan. | **Not attempted** — ruled out of scope by the repo owner for this verification session (the Mac's Wi-Fi IP was outside normal private-LAN ranges); not a known failure. | **Unverified, and refused by default** — see ["Punctuation platform status"](#punctuation-platform-status). |
+| **Android** | **Emulator only.** Load/accuracy validated on an AVD via `sherpa_onnx.dart` (CER 6.19% vs. the PC's 5.50% on the same 15-clip ja set, a +0.69pp gap attributed to onnxruntime kernel differences); RTF from an emulator reflects the *host PC's* CPU under virtualization, not a phone, so it isn't a real-device number. **A real Android device has not been used for this package.** | Validated via manifest batch eval on the emulator only; the live-mic path has not been run on Android at all (only on iOS — see the iOS column). | Not covered by an Android-specific verification pass. | Expected to work (`libonnxruntime.so` is what `sherpa_onnx` loads on Android) but **not run on a device**. |
+| **Windows** (desktop host) | Not a supported target platform for this package (see `pubspec.yaml`'s `platforms:`) — used only to run this repo's own `flutter analyze`/`flutter test` gates and the punctuation parity test below. | n/a | n/a | **Verified** — parity with the Python reference on 51 recorded cases (`flutter test`). |
+| **macOS / Linux** | Not a supported target platform for this package. | n/a | n/a | Would need an explicit `libraryPath`; not exercised. |
+
+## API reference
+
+Once published, pub.dev generates a full dartdoc API reference from this
+package's doc comments at
+[pub.dev/documentation/hayamimi_core/latest/](https://pub.dev/documentation/hayamimi_core/latest/)
+— [`lib/hayamimi_core.dart`](https://github.com/oboroge0/hayamimi/blob/main/mobile/hayamimi_core/lib/hayamimi_core.dart)
+is the export list it's generated from, and a good starting point for
+browsing it.
 
 ## Package layout
 
@@ -769,12 +903,13 @@ from `HayamimiRemote.events` rather than raising an error.
 - `lib/server/` — `SubtitleBroadcastServer` (the `dart:io` `HttpServer`),
   `subtitle_event.dart` (the `SubtitleEvent` hierarchy: partial/final/
   translation/refine/error/model_load/session_reset, all with
-  wire-compatible JSON encoding — see "Events" above), and
+  wire-compatible JSON encoding — see ["Events"](#events) above), and
   `overlay_html.dart` (the OBS-ready transparent overlay page).
-- `lib/punct/` — Japanese punctuation restoration (see the section above).
-  A live session runs this inside its decode worker; `PunctuatorJa` is also
-  usable on its own. `punctuator_ja.dart` is the whole public surface
-  (`PunctuatorJa.restore`);
+- `lib/punct/` — Japanese punctuation restoration (see
+  ["Japanese punctuation restoration"](#japanese-punctuation-restoration)
+  above). A live session runs this inside its decode worker; `PunctuatorJa`
+  is also usable on its own. `punctuator_ja.dart` is the whole public
+  surface (`PunctuatorJa.restore`);
   `punct_ja_tokenizer.dart` (NFKC + character split + vocabulary) and
   `punct_ja_text.dart` (where a mark goes, the ？ heuristic, and
   `withoutRestoredMarks`, which the refine pass's length check strips with)
@@ -803,12 +938,13 @@ from `HayamimiRemote.events` rather than raising an error.
 
 ## Consumers
 
-- [`example/`](example/) — a minimal, runnable Flutter app built from
-  nothing but this package's public API (`hayamimi_core.dart`'s export
-  list): one dependency, one `HayamimiLive` instance, a draft line + a
-  language-tagged transcript list. Start here if you're embedding this
-  package into your own app.
-- `mobile/` in this repo — the reference app: three tabs (Bench/Live/
-  Remote) built directly on this package, useful as a fuller worked example
-  than the snippets above (permission handling, error states, debug-only
-  no-mic test paths, etc).
+- [`example/`](https://github.com/oboroge0/hayamimi/tree/main/mobile/hayamimi_core/example)
+  — a minimal, runnable Flutter app built from nothing but this package's
+  public API (`hayamimi_core.dart`'s export list): one dependency, one
+  `HayamimiLive` instance, a draft line + a language-tagged transcript
+  list. Start here if you're embedding this package into your own app.
+- [`mobile/`](https://github.com/oboroge0/hayamimi/tree/main/mobile) in
+  this repo — the reference app: three tabs (Bench/Live/Remote) built
+  directly on this package, useful as a fuller worked example than the
+  snippets above (permission handling, error states, debug-only no-mic
+  test paths, etc).

--- a/mobile/hayamimi_core/README.md
+++ b/mobile/hayamimi_core/README.md
@@ -513,9 +513,11 @@ nobody said, and one per clause is enough to lift a genuinely truncated
 re-decode back over the threshold.
 
 The cost is one run of the punctuation model per utterance rather than per
-refine, on the same isolate the recognizer is on: about **25–35 ms per
-11–14 character line** on the emulator measured below, added to a final's
-`latency_ms`. `JaPunctuation(..., applyToFinals: false)` declines it —
+refine, on the same isolate the recognizer is on: about **40–50 ms per
+11–14 character line** on the emulator measured below — a direct A/B on the
+same audio with the flag on and off, not a subtraction between two timers —
+added to a final's `latency_ms`. `JaPunctuation(..., applyToFinals: false)`
+declines it —
 finals then arrive exactly as the recognizer produced them, refines are
 still punctuated, and a refine that falls back to the finals reports
 `punctuated: false`, since the text that survived is theirs.
@@ -940,7 +942,8 @@ how the models were placed and what was and wasn't exercised, in
 
 These are the **second** emulator run (two processes, ten sessions,
 `modified_beam_search`, `numThreads` 2), on the VAD and pre-roll defaults
-this package ships now:
+this package ships now, plus two rows from the **third** run (below) where
+noted:
 
 | what | conditions | ms |
 |---|---|---|
@@ -950,19 +953,34 @@ this package ships now:
 | final, decode only | a 1.762 s / 2.400 s / 2.144 s segment, n=6 each | 61.8 / 80.4 / 71.5 (medians) |
 | refine, re-decode + punctuation | those same segments, warm | 97–114 |
 | refine, re-decode + punctuation | the first refine in a fresh process | 407.9 / 412.7 |
+| final, decode + punctuation (run 3, `applyToFinals: true`, warm) | those same three segments | 109.5 / 115.4 / 117.3 (medians) |
+| final, decode + punctuation (run 3, first final in a fresh process) | the cold-start now lands on the first final, not the first refine | 402.1 / 410.8 |
 
 The first load of each model in a fresh process sits at the slow end of its
-range (cold page cache), and the first refine of a process costs ~310 ms
-more than the rest — a one-time warm-up inside the fp16 punctuation model,
-paid once per process and not once per session. The recognizer median moved
-up ~660 ms against the first run while `punct` and `vad` stayed flat, which
-reads as load noise on a shared desktop rather than a change in the code.
+range (cold page cache), and the first punctuation-model run of a process
+costs ~300-310 ms more than the rest — a one-time warm-up inside the fp16
+model, paid once per process and not once per session. Run 2 saw that cost
+on the first *refine* (407.9 / 412.7); run 3, with finals punctuated by
+default, saw it move to the first *final* instead (402.1 / 410.8) — same
+mechanism, different first caller. This package now pays it during the
+punctuation model's own load phase (`loadWorkerPunctuator`), so neither
+path should see it going forward. The recognizer median moved up ~660 ms
+against run 1 while `punct` and `vad` stayed flat, which reads as load
+noise on a shared desktop rather than a change in the code.
 
-**Punctuation was not timed directly.** A `latency_ms` covers the decode and
-the punctuation pass together, so the cost quoted for `restore()` on this
-run — roughly **25–35 ms per 11–14 character line**, warm, two intra-op
-threads — is a refine minus the final over the identical samples. That is an
-inference from the difference of two timers, not a measurement.
+**Run 3 measured the punctuation cost directly**, decoding the same audio
+with `applyToFinals` on and off instead of subtracting two timers: finals
+went from 61.7/77.6/68.8 ms to 109.5/115.4/117.3 ms, i.e. **+38 to +49 ms
+per 11–14 character line** (warm, two intra-op threads) — the run-2 figure
+just below, "25–35 ms", was an inference from a different subtraction and
+reads low against this direct measurement.
+
+Run 2's own paragraph, kept for the record: **punctuation was not timed
+directly.** A `latency_ms` covers the decode and the punctuation pass
+together, so the cost quoted for `restore()` on that run — roughly
+**25–35 ms per 11–14 character line**, warm, two intra-op threads — was a
+refine minus the final over the identical samples. That was an inference
+from the difference of two timers, not a measurement.
 
 ### Known limitation: a refine over a long group can lose its leading sentences
 

--- a/mobile/hayamimi_core/THIRD_PARTY_NOTICES.md
+++ b/mobile/hayamimi_core/THIRD_PARTY_NOTICES.md
@@ -1,84 +1,53 @@
 # Third-Party Notices
 
-hayamimi (早耳)'s own source code is MIT-licensed (see `LICENSE`). It ships no
-model weights in this repository -- `scripts/download_models.py` fetches
-pretrained models from their original publishers into `models/` (git-ignored).
-Those models carry their own licenses, listed below. **Read the "Translation
-models" row carefully before redistributing anything that bundles model
-weights** -- one of them is share-alike, not permissive.
+`hayamimi_core`'s own source code is MIT-licensed (see `LICENSE`). It ships
+no model weights: a host app places pretrained models on the device itself
+(automatically via `downloadProfile`, or by hand — see the README's "Model
+placement guide"). Those models, and this package's Dart dependencies,
+carry their own licenses, listed below.
 
-## ASR / VAD / speaker models
+This file covers `hayamimi_core` only — the mobile Flutter package. The
+desktop hayamimi pipeline (`scripts/`) has a wider model catalog (zh, EU
+languages, translation, speaker diarization) with its own
+`THIRD_PARTY_NOTICES.md` at the repository root; none of those extra
+models or Python dependencies are used by this package.
 
-| Model (dir under `models/`) | Publisher | License | Source |
+## ASR / VAD models
+
+Placed under `<targetDir>/model`, `/vad`, `/sense_voice`, `/lid` by
+`downloadProfile`, or manually — see the README's "Model placement guide"
+for exact files and directories.
+
+| Model | Needed by | Publisher | License | Source |
+|---|---|---|---|---|
+| ReazonSpeech k2 Zipformer (ja ASR) | every profile | Reazon Human Interaction Lab | Apache-2.0 | [reazon-research/reazonspeech-k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2), packaged by [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
+| Silero VAD | every profile (`HayamimiLive` only) | Silero Team | MIT | [snakers4/silero-vad](https://github.com/snakers4/silero-vad), packaged by k2-fsa/sherpa-onnx |
+| SenseVoice small (en/zh/ko/yue ASR) | `RoutingProfile.jaSenseVoice` only | Alibaba / FunAudioLLM | Apache-2.0 (code) + FunASR Model Open Source License Agreement (official weights; permits commercial use with attribution) | [FunAudioLLM/SenseVoice](https://github.com/FunAudioLLM/SenseVoice), packaged by k2-fsa/sherpa-onnx |
+| whisper-tiny (spoken-language ID probe) | `RoutingProfile.jaSenseVoice` only | OpenAI | MIT | [openai/whisper](https://github.com/openai/whisper), ONNX export packaged by k2-fsa/sherpa-onnx |
+
+## Japanese punctuation model
+
+Optional, and not placed by `downloadProfile` — see the README's "Japanese
+punctuation restoration" and "Model placement guide" for why and where to
+get it.
+
+| Model | Publisher | License | Source |
 |---|---|---|---|
-| `sherpa-onnx-zipformer-ja-en-reazonspeech-2025-01-17` (ReazonSpeech k2 Zipformer, ja) | Reazon Human Interaction Lab | Apache-2.0 | [reazon-research/reazonspeech-k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2), packaged by [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
-| `sherpa-onnx-paraformer-zh-int8-2025-10-07` (Paraformer-zh, zh) | Alibaba DAMO Academy / FunASR | Apache-2.0 | [FunASR](https://github.com/modelscope/FunASR) / ModelScope, packaged by k2-fsa/sherpa-onnx |
-| `sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17` (SenseVoice small, ko/yue) | Alibaba / FunAudioLLM | Apache-2.0 (code) + FunASR Model Open Source License Agreement (official weights; permits commercial use with attribution) | [FunAudioLLM/SenseVoice](https://github.com/FunAudioLLM/SenseVoice), packaged by k2-fsa/sherpa-onnx |
-| `sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8` (Parakeet TDT 0.6B v3, en + 24 EU langs) | NVIDIA | CC-BY-4.0 | [nvidia/parakeet-tdt-0.6b-v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3), packaged by k2-fsa/sherpa-onnx |
-| `omnilingual-300m-ctc-int8` (Meta Omnilingual ASR 300M CTC, ~1600-language fallback) | Meta AI | Apache-2.0 | [facebook/omniASR-CTC-300M](https://huggingface.co/facebook/omniASR-CTC-300M) / [facebookresearch/omnilingual-asr](https://github.com/facebookresearch/omnilingual-asr), ONNX export packaged by k2-fsa/sherpa-onnx |
-| `sherpa-onnx-whisper-tiny` (spoken-language ID) | OpenAI | MIT | [openai/whisper](https://github.com/openai/whisper), ONNX export packaged by k2-fsa/sherpa-onnx |
-| `silero_vad.onnx` (voice activity detection) | Silero Team | MIT | [snakers4/silero-vad](https://github.com/snakers4/silero-vad), packaged by k2-fsa/sherpa-onnx |
-| `campplus_sv.onnx` (CAM++ speaker embedding, `--speakers`) | Alibaba DAMO Academy / 3D-Speaker | Apache-2.0 | [modelscope/3D-Speaker](https://github.com/modelscope/3D-Speaker), packaged by k2-fsa/sherpa-onnx |
+| `mojicast-punct-onnx` (`punct_bert.fp16.onnx` + `vocab.txt`) | Base models: Tohoku NLP + bobfromjapan; ONNX export: Mojicast (ishiki-emo) | Apache-2.0 | [tohoku-nlp/bert-base-japanese-char-v3](https://huggingface.co/tohoku-nlp/bert-base-japanese-char-v3), [bobfromjapan/bert_japanese_punctuation](https://huggingface.co/bobfromjapan/bert_japanese_punctuation), export: [ishiki-emo/mojicast-punct-onnx](https://huggingface.co/ishiki-emo/mojicast-punct-onnx) |
 
-## Text models
-
-| Model (dir under `models/`) | Publisher | License | Source |
-|---|---|---|---|
-| `mojicast-punct-onnx` (Japanese punctuation restoration) | Base models: Tohoku NLP + bobfromjapan; ONNX export: Mojicast (ishiki-emo) | Apache-2.0 | [tohoku-nlp/bert-base-japanese-char-v3](https://huggingface.co/tohoku-nlp/bert-base-japanese-char-v3), [bobfromjapan/bert_japanese_punctuation](https://huggingface.co/bobfromjapan/bert_japanese_punctuation), export: [ishiki-emo/mojicast-punct-onnx](https://huggingface.co/ishiki-emo/mojicast-punct-onnx) |
-| `mojicast-m2m100-ct2` (M2M-100 418M, ja->zh/ko translation) | Meta AI (base model); CTranslate2 conversion: Mojicast (ishiki-emo) | MIT | [facebook/m2m100_418M](https://huggingface.co/facebook/m2m100_418M), conversion: [ishiki-emo/mojicast-m2m100-ct2](https://huggingface.co/ishiki-emo/mojicast-m2m100-ct2) |
-| `mojicast-fugumt-ja-en-ct2` (FuguMT, ja->en translation) | staka (base model); CTranslate2 conversion: Mojicast (ishiki-emo) | **CC BY-SA 4.0 (share-alike)** | [staka/fugumt-ja-en](https://huggingface.co/staka/fugumt-ja-en), conversion: [ishiki-emo/mojicast-fugumt-ja-en-ct2](https://huggingface.co/ishiki-emo/mojicast-fugumt-ja-en-ct2) |
-
-> **CC BY-SA 4.0 flag:** `mojicast-fugumt-ja-en-ct2` (used for `--translate en`)
-> is the one non-permissive model in this list. If you redistribute this
-> model's weights (not just its runtime output), you must keep attribution to
-> staka's Fugu Machine Translator and to the Mojicast conversion, and any
-> redistribution of the weights themselves must remain under CC BY-SA 4.0.
-> hayamimi's own code and the other models are unaffected -- this only
-> applies if you re-host/re-bundle this specific model file. Live subtitle
-> *output* text is not itself claimed to be encumbered by this notice; if
-> your use case is sensitive to this, use `--translate zh,ko` (M2M-100, MIT)
-> or skip `en` translation.
-
-## Eval-only baseline models (not used by the runtime pipeline)
-
-These are downloaded only if you run `scripts/download_models.py` without
-`--minimal` and are referenced solely by `scripts/eval_accuracy.py` /
-`scripts/make_realset_zhko.py` as comparison baselines during accuracy
-evaluation -- `asr_engine.py`'s routing does not use them.
-
-| Model (dir under `models/`) | Publisher | License | Source |
-|---|---|---|---|
-| `sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8` | NVIDIA NeMo (trained on ReazonSpeech data) | CC-BY-4.0 | packaged by k2-fsa/sherpa-onnx (`asr-models` release) |
-| `sherpa-onnx-zipformer-korean-2024-06-24` | k2-fsa / Zipformer (Korean) | Apache-2.0 | [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
-
-## Python runtime dependencies
+## Dart package dependencies
 
 | Package | License | Notes |
 |---|---|---|
-| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Apache-2.0 | ONNX Runtime-based inference for all ASR/VAD/speaker models above |
-| [onnxruntime](https://github.com/microsoft/onnxruntime) | MIT | used transitively by sherpa-onnx and `punct_ja.py` |
-| [ctranslate2](https://github.com/OpenNMT/CTranslate2) | MIT | translation model inference |
-| [sentencepiece](https://github.com/google/sentencepiece) | Apache-2.0 | tokenization for translation models |
-| [numpy](https://numpy.org/) | BSD-3-Clause | |
-| [soundfile](https://github.com/bastibe/python-soundfile) | BSD-3-Clause | |
-| [sounddevice](https://github.com/spatialaudio/python-sounddevice) | MIT | microphone capture |
-| [fugashi](https://github.com/polm/fugashi) | MIT (MeCab itself is BSD/GPL/LGPL tri-license) | Japanese tokenization for punctuation restoration |
-| [unidic-lite](https://github.com/polm/unidic-lite) | MIT (dictionary data: BSD-modified, per UniDic) | dictionary for fugashi |
-| [kiwipiepy](https://github.com/bab2min/kiwipiepy) | **LGPL-2.1-or-later** | Korean tokenizer, used only to fix SenseVoice's spacing on `ko` output; optional at runtime (falls through silently if not installed) -- kept as an **optional/dev extra**, not a hard runtime dependency, to avoid LGPL obligations on the core install |
-| [psutil](https://github.com/giampaolo/psutil) | BSD-3-Clause | memory diagnostics |
+| [sherpa_onnx](https://pub.dev/packages/sherpa_onnx) | Apache-2.0 | ONNX Runtime-based inference for the ASR/VAD models above |
+| [onnxruntime](https://github.com/microsoft/onnxruntime) | MIT | The inference engine itself, bundled by `sherpa_onnx`. This package's own Japanese punctuation code (`lib/punct/`) calls the same already-loaded copy through `dart:ffi` rather than shipping a second one — see the README's "How it reaches ONNX Runtime, and why that way." |
+| [record](https://pub.dev/packages/record) | BSD-3-Clause (per the package's own `LICENSE` file) | Microphone capture for `HayamimiLive`/`HayamimiRemote` |
+| [archive](https://pub.dev/packages/archive) | MIT (Copyright (c) 2013-2021 Brendan Duncan) | `.tar.bz2` extraction inside `downloadProfile` |
+| [crypto](https://pub.dev/packages/crypto) | BSD-3-Clause (Copyright 2015, the Dart project authors) | sha256 verification inside `downloadProfile` |
+| [ffi](https://pub.dev/packages/ffi) | BSD-3-Clause (Copyright 2019, the Dart project authors) | Native memory allocation and C string conversion for the ONNX Runtime C API calls in `lib/punct/` |
+| [unorm_dart](https://pub.dev/packages/unorm_dart) | MIT (Copyright (c) 2018 Yasuhiro Shimizu) | NFKC Unicode normalization, which `dart:core` has no equivalent of and which the punctuation tokenizer needs to match the Python reference |
 
-### Dev / eval-only dependencies (`requirements-dev.txt`)
-
-| Package | License |
-|---|---|
-| [faster-whisper](https://github.com/SYSTRAN/faster-whisper) | MIT |
-| [jiwer](https://github.com/jitsi/jiwer) | Apache-2.0 |
-| [edge-tts](https://github.com/rany2/edge-tts) | LGPL-3.0 |
-| [yt-dlp](https://github.com/yt-dlp/yt-dlp) | Unlicense |
-| [pytest](https://github.com/pytest-dev/pytest) | MIT |
-| [OpenCC](https://github.com/BYVoid/OpenCC) | Apache-2.0 |
-
-## Vendored source (`hayamimi_core`)
+## Vendored source (`lib/punct/ort_bindings.dart`)
 
 `lib/punct/ort_bindings.dart` is not original work. It is derived from the
 ffigen-generated ONNX Runtime bindings in
@@ -91,16 +60,9 @@ Copyright (c) Microsoft Corporation).
 
 Only the Dart binding declarations were taken; none of that package's native
 code, build files, or higher-level API was copied, and the package is not a
-dependency. The copy was trimmed to the ~27 C API members hayamimi calls
-and one parameter's type was corrected for Windows — both changes are
+dependency. The copy was trimmed to the ~27 C API members hayamimi_core
+calls and one parameter's type was corrected for Windows — both changes are
 documented in the file's own header.
-
-## Dart dependencies added for punctuation restoration
-
-| Package | License | Notes |
-|---|---|---|
-| [unorm_dart](https://pub.dev/packages/unorm_dart) | MIT (Copyright (c) 2018 Yasuhiro Shimizu) | NFKC Unicode normalization, which `dart:core` has no equivalent of and which the punctuation tokenizer needs to match the Python reference |
-| [ffi](https://pub.dev/packages/ffi) | BSD-3-Clause (Copyright 2019, the Dart project authors) | native memory allocation and C string conversion for the ONNX Runtime C API calls |
 
 ## Test fixture data
 
@@ -113,12 +75,10 @@ repeated inside the file itself.
 
 ## Design inspiration
 
-Several integration choices in this project (the FuguMT/M2M-100 CTranslate2
-conversions, the punctuation model export, and beam-size/repetition-control
-settings noted in `docs/TRANSLATE.md` and `docs/TRANSLATE_M2M.md`) are drawn
-from or reuse artifacts published by the [Mojicast](https://github.com/ishiki-emo/mojicast)
-project (MIT-licensed offline captioning app) by ishiki-emo. Credit and thanks
-to that project -- see the README credits section.
+The Japanese punctuation model's export (`mojicast-punct-onnx`, above) is
+published by the [Mojicast](https://github.com/ishiki-emo/mojicast) project
+(MIT-licensed offline captioning app) by ishiki-emo. Credit and thanks to
+that project.
 
 ## TODO verify
 

--- a/mobile/hayamimi_core/lib/bench/bench_runner.dart
+++ b/mobile/hayamimi_core/lib/bench/bench_runner.dart
@@ -6,6 +6,8 @@ import 'bench_result.dart';
 import 'model_file_resolver.dart';
 import 'model_kind.dart';
 
+/// Thrown by [BenchRunner] when a model/wav file is missing or can't be
+/// read, or a decode itself fails.
 class BenchRunException implements Exception {
   BenchRunException(this.message);
   final String message;

--- a/mobile/hayamimi_core/lib/bench/manifest_eval_runner.dart
+++ b/mobile/hayamimi_core/lib/bench/manifest_eval_runner.dart
@@ -99,11 +99,11 @@ class ManifestEvalRunner {
     return results;
   }
 
-  /// Decodes every entry in [manifestPath] through [RoutingProfile
-  /// .jaSenseVoice] routing (ReazonSpeech ja + SenseVoice en/zh/ko/yue,
-  /// arbitrated per clip by the dual-LID policy in `../routing/`), so a
-  /// multilingual manifest's language-routing accuracy and CER can be
-  /// compared against the PC pipeline's `docs/SCORECARD.md`.
+  /// Decodes every entry in [manifestPath] through
+  /// `RoutingProfile.jaSenseVoice` routing (ReazonSpeech ja + SenseVoice
+  /// en/zh/ko/yue, arbitrated per clip by the dual-LID policy in
+  /// `../routing/`), so a multilingual manifest's language-routing accuracy
+  /// and CER can be compared against the PC pipeline's `docs/SCORECARD.md`.
   ///
   /// Each entry is treated as its own isolated "session" (bootstrap: no
   /// prior language) since manifest clips are independent recordings, not

--- a/mobile/hayamimi_core/lib/bench/model_file_resolver.dart
+++ b/mobile/hayamimi_core/lib/bench/model_file_resolver.dart
@@ -20,6 +20,8 @@ class ResolvedModelFiles {
   final String tokens;
 }
 
+/// Thrown by [resolveOnnxFile]/[resolveZipformerTransducerFiles] when a
+/// model directory doesn't contain the file a role needs.
 class ModelFileResolutionException implements Exception {
   ModelFileResolutionException(this.message);
   final String message;

--- a/mobile/hayamimi_core/lib/hayamimi_core.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_core.dart
@@ -32,6 +32,7 @@ export 'live/live_transcriber.dart';
 export 'live/live_vad.dart';
 export 'live/model_load_event.dart';
 export 'live/pcm_frame_buffer.dart' show pcm16BytesToFloat32, PcmFrameBuffer;
+export 'live/preroll.dart';
 export 'live/refine_pass.dart';
 export 'live/speech_segment_filter.dart' show isSegmentWorthDecoding;
 export 'live/vad_sensitivity.dart';

--- a/mobile/hayamimi_core/lib/hayamimi_core.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_core.dart
@@ -27,6 +27,7 @@ export 'live/decode_scheduler.dart';
 export 'live/decode_session.dart';
 export 'live/decode_worker.dart';
 export 'live/draft_pass.dart';
+export 'live/ja_punctuation.dart';
 export 'live/live_transcriber.dart';
 export 'live/live_vad.dart';
 export 'live/model_load_event.dart';

--- a/mobile/hayamimi_core/lib/hayamimi_live.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_live.dart
@@ -69,6 +69,7 @@ class HayamimiLive {
           latencyMs: entry.latencyMs,
           audioSeconds: entry.audioSeconds,
           switched: entry.switched,
+          punctuated: entry.punctuated,
         ),
       );
     });
@@ -247,14 +248,15 @@ class HayamimiLive {
   /// -- forwarded through unchanged.
   ///
   /// [punctuation] turns on Japanese punctuation restoration: refine
-  /// ("清書") results then arrive with 、 and 。 in them instead of as an
-  /// unbroken run of characters, and their [RefineSubtitleEvent] says so
-  /// through `punctuated` (also `"punctuated"` in `toJson`, so a LAN
-  /// consumer can see it too). Nothing else changes -- [FinalSubtitleEvent]
-  /// and [PartialSubtitleEvent] carry the recognizer's text as before. The
-  /// model is loaded in the decode worker and costs 181.8 MB of memory for
-  /// the session; failing to load it fails this call. [textTransform], if
-  /// set, still runs last, on the punctuated text.
+  /// ("清書") results and finalized lines then arrive with 、 and 。 in
+  /// them instead of as an unbroken run of characters, and their
+  /// [RefineSubtitleEvent]/[FinalSubtitleEvent] say so through `punctuated`
+  /// (also `"punctuated"` in `toJson`, so a LAN consumer can see it too).
+  /// [PartialSubtitleEvent] still carries the recognizer's text as before,
+  /// and `JaPunctuation.applyToFinals: false` puts [FinalSubtitleEvent] back
+  /// that way too. The model is loaded in the decode worker and costs
+  /// 181.8 MB of memory for the session; failing to load it fails this call.
+  /// [textTransform], if set, still runs last, on the punctuated text.
   Future<void> start({
     required String modelDir,
     required String vadModelPath,

--- a/mobile/hayamimi_core/lib/hayamimi_live.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_live.dart
@@ -319,9 +319,16 @@ class HayamimiLive {
   ///
   /// Exists so this facade can be exercised end to end without a real
   /// microphone -- e.g. on an Android emulator, which has none. Awaits
-  /// until the whole file has been fed through and any in-progress segment
-  /// has been flushed and decoded. See [start] for [decodingMethod]/
-  /// [vadSensitivity]/[hotwordsFile]/[hotwordsScore]/[punctuation].
+  /// until the whole file has been fed through, any in-progress segment has
+  /// been flushed and decoded, and one closing refine ("清書") pass over
+  /// what those finals buffered has been emitted as a [RefineSubtitleEvent]
+  /// -- so a punctuated refine is visible from a single awaited call. The
+  /// session is torn down before this future completes, so [refineNow]
+  /// afterwards has nothing left to refine; see
+  /// [LiveTranscriber.startDebugWavStream] for the full behavior, including
+  /// how [autoRefineEnabled] applies here too. See [start] for
+  /// [decodingMethod]/[vadSensitivity]/[hotwordsFile]/[hotwordsScore]/
+  /// [punctuation].
   Future<void> startDebugWavStream({
     required String modelDir,
     required String vadModelPath,

--- a/mobile/hayamimi_core/lib/hayamimi_live.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_live.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'bench/model_kind.dart';
 import 'live/draft_pass.dart';
+import 'live/ja_punctuation.dart';
 import 'live/live_transcriber.dart';
 import 'live/refine_pass.dart';
 import 'live/vad_sensitivity.dart';
@@ -76,6 +77,7 @@ class HayamimiLive {
           lang: entryLang,
           latencyMs: entry.latencyMs,
           audioSeconds: entry.audioSeconds,
+          punctuated: entry.punctuated,
         ),
       );
     });
@@ -122,7 +124,9 @@ class HayamimiLive {
   /// the text to actually publish.
   ///
   /// Settable at any time, including mid-session: the next entry to arrive
-  /// picks up the new transform. `null` (the default) is a no-op. This is
+  /// picks up the new transform. It runs last, after Japanese punctuation
+  /// restoration if the session has it on, so a refine's text reaches it
+  /// with 、 and 。 already in place. `null` (the default) is a no-op. This is
   /// deliberately just an insertion point -- e.g. for CJK ITN
   /// (`scripts/itn_cjk.py` on the desktop side) or a user find/replace
   /// dictionary -- and does not itself implement any postprocessing.
@@ -227,6 +231,16 @@ class HayamimiLive {
   /// See [LiveTranscriber.start] for what [decodingMethod]/
   /// [vadSensitivity]/[hotwordsFile]/[hotwordsScore] do and their defaults
   /// -- forwarded through unchanged.
+  ///
+  /// [punctuation] turns on Japanese punctuation restoration: refine
+  /// ("清書") results then arrive with 、 and 。 in them instead of as an
+  /// unbroken run of characters, and their [RefineSubtitleEvent] says so
+  /// through `punctuated` (also `"punctuated"` in `toJson`, so a LAN
+  /// consumer can see it too). Nothing else changes -- [FinalSubtitleEvent]
+  /// and [PartialSubtitleEvent] carry the recognizer's text as before. The
+  /// model is loaded in the decode worker and costs 181.8 MB of memory for
+  /// the session; failing to load it fails this call. [textTransform], if
+  /// set, still runs last, on the punctuated text.
   Future<void> start({
     required String modelDir,
     required String vadModelPath,
@@ -238,6 +252,7 @@ class HayamimiLive {
     VadSensitivity? vadSensitivity,
     String? hotwordsFile,
     double hotwordsScore = 1.5,
+    JaPunctuation? punctuation,
   }) {
     return _transcriber.start(
       modelKind: modelKind,
@@ -250,6 +265,7 @@ class HayamimiLive {
       vadSensitivity: vadSensitivity,
       hotwordsFile: hotwordsFile,
       hotwordsScore: hotwordsScore,
+      punctuation: punctuation,
     );
   }
 
@@ -291,7 +307,7 @@ class HayamimiLive {
   /// microphone -- e.g. on an Android emulator, which has none. Awaits
   /// until the whole file has been fed through and any in-progress segment
   /// has been flushed and decoded. See [start] for [decodingMethod]/
-  /// [vadSensitivity]/[hotwordsFile]/[hotwordsScore].
+  /// [vadSensitivity]/[hotwordsFile]/[hotwordsScore]/[punctuation].
   Future<void> startDebugWavStream({
     required String modelDir,
     required String vadModelPath,
@@ -305,6 +321,7 @@ class HayamimiLive {
     VadSensitivity? vadSensitivity,
     String? hotwordsFile,
     double hotwordsScore = 1.5,
+    JaPunctuation? punctuation,
   }) {
     return _transcriber.startDebugWavStream(
       modelKind: modelKind,
@@ -319,6 +336,7 @@ class HayamimiLive {
       vadSensitivity: vadSensitivity,
       hotwordsFile: hotwordsFile,
       hotwordsScore: hotwordsScore,
+      punctuation: punctuation,
     );
   }
 

--- a/mobile/hayamimi_core/lib/hayamimi_live.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_live.dart
@@ -4,6 +4,7 @@ import 'bench/model_kind.dart';
 import 'live/draft_pass.dart';
 import 'live/ja_punctuation.dart';
 import 'live/live_transcriber.dart';
+import 'live/preroll.dart';
 import 'live/refine_pass.dart';
 import 'live/vad_sensitivity.dart';
 import 'routing/routing_profile.dart';
@@ -30,8 +31,8 @@ import 'server/subtitle_event.dart';
 /// await live.dispose();
 /// ```
 class HayamimiLive {
-  /// If [transcriber] is omitted, the six pacing-knob parameters
-  /// ([draftIntervalSeconds] through [refineBufferMaxSeconds]) seed the
+  /// If [transcriber] is omitted, the seven pacing-knob parameters
+  /// ([draftIntervalSeconds] through [prerollSeconds]) seed the
   /// [LiveTranscriber] this facade creates for itself -- see that class's
   /// constructor for what each one does and its `default*` constant
   /// (`draft_pass.dart`/`refine_pass.dart`) for the value a caller who
@@ -47,6 +48,7 @@ class HayamimiLive {
     double autoRefineSilenceSeconds = defaultAutoRefineSilenceSeconds,
     double autoRefineMaxBufferedSeconds = defaultAutoRefineMaxBufferedSeconds,
     double refineBufferMaxSeconds = defaultRefineBufferMaxSeconds,
+    double prerollSeconds = defaultPrerollSeconds,
   }) : _transcriber =
            transcriber ??
            LiveTranscriber(
@@ -56,6 +58,7 @@ class HayamimiLive {
              autoRefineSilenceSeconds: autoRefineSilenceSeconds,
              autoRefineMaxBufferedSeconds: autoRefineMaxBufferedSeconds,
              refineBufferMaxSeconds: refineBufferMaxSeconds,
+             prerollSeconds: prerollSeconds,
            ) {
     _entriesSubscription = _transcriber.entries.listen((entry) {
       final entryLang = entry.lang ?? lang;
@@ -223,6 +226,15 @@ class HayamimiLive {
   double get refineBufferMaxSeconds => _transcriber.refineBufferMaxSeconds;
   set refineBufferMaxSeconds(double value) =>
       _transcriber.refineBufferMaxSeconds = value;
+
+  /// How much audio from before a speech segment's detected onset is
+  /// prepended to it before decoding, in seconds. Silero VAD notices speech
+  /// slightly late, so without this the first word of an utterance can be
+  /// clipped and transcribed wrong. See [LiveTranscriber.prerollSeconds] --
+  /// same default, same runtime-settable behavior, and `0` (unlike the
+  /// other knobs) is a valid value meaning "no pre-roll".
+  double get prerollSeconds => _transcriber.prerollSeconds;
+  set prerollSeconds(double value) => _transcriber.prerollSeconds = value;
 
   /// Starts capturing mic audio and transcribing it.
   ///

--- a/mobile/hayamimi_core/lib/hayamimi_live.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_live.dart
@@ -172,6 +172,8 @@ class HayamimiLive {
   /// transition, not one per decode; see [LiveTranscriber.decoding].
   Stream<bool> get decoding => _decodingController.stream;
 
+  /// Whether a session is currently active: `start`/`startDebugWavStream`
+  /// has completed and `stop` hasn't been called since.
   bool get isRunning => _transcriber.isRunning;
 
   /// Total audio currently buffered for the next refine pass, in seconds.

--- a/mobile/hayamimi_core/lib/hayamimi_remote.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_remote.dart
@@ -92,6 +92,7 @@ class HayamimiRemote {
         :final latencyMs,
         :final audioSeconds,
         :final switched,
+        :final punctuated,
       ) =>
         FinalSubtitleEvent(
           text: text,
@@ -100,6 +101,7 @@ class HayamimiRemote {
           latencyMs: latencyMs,
           audioSeconds: audioSeconds,
           switched: switched,
+          punctuated: punctuated,
         ),
       RemoteTranslationEvent(:final lang, :final text) =>
         TranslationSubtitleEvent(lang: lang, text: text),

--- a/mobile/hayamimi_core/lib/hayamimi_remote.dart
+++ b/mobile/hayamimi_core/lib/hayamimi_remote.dart
@@ -30,6 +30,9 @@ import 'server/subtitle_event.dart';
 /// await remote.dispose();
 /// ```
 class HayamimiRemote {
+  /// Creates a client with no active connection. Pass [transcriber] only
+  /// to inject a fake [RemoteTranscriber] in tests; a real host app should
+  /// leave it unset.
   HayamimiRemote({RemoteTranscriber? transcriber})
     : _transcriber = transcriber ?? RemoteTranscriber() {
     _rawSubscription = _transcriber.events.listen(_onRawEvent);
@@ -49,9 +52,15 @@ class HayamimiRemote {
   /// [events] drops. Most callers want [events] instead.
   Stream<RemoteEvent> get rawEvents => _transcriber.events;
 
+  /// Fires whenever [state] changes, e.g. connecting -> connected, or a
+  /// dropped socket -> reconnecting.
   Stream<RemoteConnectionState> get connectionState =>
       _transcriber.connectionState;
+
+  /// This client's current connection lifecycle state.
   RemoteConnectionState get state => _transcriber.state;
+
+  /// Shorthand for `state == RemoteConnectionState.connected`.
   bool get isConnected => _transcriber.isConnected;
 
   /// Connects to [url] (e.g. `ws://192.168.1.10:8766/ingest`), sends the

--- a/mobile/hayamimi_core/lib/live/decode_protocol.dart
+++ b/mobile/hayamimi_core/lib/live/decode_protocol.dart
@@ -23,6 +23,8 @@ library;
 import 'dart:isolate';
 import 'dart:typed_data';
 
+import 'ja_punctuation.dart';
+
 /// A failure raised while starting, or by, the decode worker.
 ///
 /// `LiveTranscriber` re-wraps this as a `LiveTranscriberException` carrying
@@ -59,7 +61,8 @@ enum DecodeRequestKind {
   shutdown,
 }
 
-/// Everything the worker needs to build its recognizer(s) itself.
+/// Everything the worker needs to build its recognizer(s) — and, when the
+/// session asks for it, its Japanese punctuation model — itself.
 ///
 /// The worker loads the models rather than being handed them: the objects
 /// it builds never leave that isolate, so there is no pointer handoff to
@@ -76,7 +79,16 @@ class DecodeWorkerConfig {
     this.hotwordsScore = 1.5,
     this.numThreads = 2,
     this.sampleRate = 16000,
-  });
+    this.punctModelPath,
+    this.punctVocabPath,
+    this.punctLibraryPath,
+    this.punctNumThreads = defaultPunctNumThreads,
+    this.punctuatePlainSession = true,
+  }) : assert(
+         (punctModelPath == null) == (punctVocabPath == null),
+         'Japanese punctuation needs both punctModelPath and punctVocabPath, '
+         'or neither.',
+       );
 
   /// Build the three-model `RoutedRecognizerSet` (ReazonSpeech ja +
   /// SenseVoice + whisper-tiny LID) rather than one plain recognizer —
@@ -97,6 +109,65 @@ class DecodeWorkerConfig {
   final int numThreads;
   final int sampleRate;
 
+  /// The Japanese punctuation model to load, or `null` to load none — in
+  /// which case the worker behaves exactly as it did before punctuation
+  /// existed. Set together with [punctVocabPath]; setting one without the
+  /// other is a configuration error the worker reports as a build failure.
+  ///
+  /// See `JaPunctuation`, the value object `LiveTranscriber.start` takes,
+  /// for what these files are.
+  final String? punctModelPath;
+
+  /// The punctuation model's `vocab.txt`. See [punctModelPath].
+  final String? punctVocabPath;
+
+  /// Where ONNX Runtime comes from for the punctuation model; `null` uses
+  /// `OrtLibrary`'s per-platform default (the copy `sherpa_onnx` already
+  /// loaded, on Android). Threaded through so a desktop host — and the
+  /// tests — can name a library the loader would not otherwise find.
+  final String? punctLibraryPath;
+
+  /// Intra-op threads for the punctuation model. See
+  /// [defaultPunctNumThreads].
+  final int punctNumThreads;
+
+  /// Whether a **plain** (non-[routed]) session's refine results are
+  /// Japanese, and so should be punctuated.
+  ///
+  /// A routed session decides per result, from the language the routing
+  /// resolved ([DecodeWorkerResult.lang] `== 'ja'`). A plain session has one
+  /// model, one language, and no language tag to test — so it says here,
+  /// once, whether that language is Japanese. Defaults to `true`, because a
+  /// caller who configured a Japanese punctuation model for a single-model
+  /// session has already said what language it transcribes. **A plain
+  /// session whose model is not Japanese must not pass punctuation paths at
+  /// all**: punctuating, say, English with this model produces nonsense
+  /// rather than nothing.
+  ///
+  /// Ignored when [punctModelPath] is `null` or when [routed] is true.
+  final bool punctuatePlainSession;
+
+  /// Whether this session loads a punctuation model at all.
+  bool get hasPunctuation => punctModelPath != null && punctVocabPath != null;
+
+  /// Whether a refine result that came back as [lang] should have Japanese
+  /// punctuation restored into it.
+  ///
+  /// Kept here, as a pure function of the config and one result's language,
+  /// so the rule can be read and tested on its own rather than inferred
+  /// from the worker's decode loop. `lang` is `null` for a plain session,
+  /// which is why [punctuatePlainSession] exists.
+  ///
+  /// Only refine results are punctuated, so the worker checks the request
+  /// kind before calling this — see `decode_worker.dart` for why finals and
+  /// drafts are left alone.
+  bool shouldPunctuateRefine({String? lang}) {
+    if (!hasPunctuation) {
+      return false;
+    }
+    return routed ? lang == 'ja' : punctuatePlainSession;
+  }
+
   List<Object?> toMessage() => <Object?>[
     routed,
     modelDir,
@@ -107,6 +178,11 @@ class DecodeWorkerConfig {
     hotwordsScore,
     numThreads,
     sampleRate,
+    punctModelPath,
+    punctVocabPath,
+    punctLibraryPath,
+    punctNumThreads,
+    punctuatePlainSession,
   ];
 
   static DecodeWorkerConfig fromMessage(Object? message) {
@@ -121,6 +197,11 @@ class DecodeWorkerConfig {
       hotwordsScore: m[6]! as double,
       numThreads: m[7]! as int,
       sampleRate: m[8]! as int,
+      punctModelPath: m[9] as String?,
+      punctVocabPath: m[10] as String?,
+      punctLibraryPath: m[11] as String?,
+      punctNumThreads: m[12]! as int,
+      punctuatePlainSession: m[13]! as bool,
     );
   }
 }
@@ -227,6 +308,7 @@ sealed class DecodeWorkerMessage {
           lang: m[5] as String?,
           switched: m[6]! as bool,
           latencyMs: m[7]! as double,
+          punctuated: m[8]! as bool,
         );
       case 'failure':
         return DecodeWorkerFailure(
@@ -298,6 +380,7 @@ class DecodeWorkerResult extends DecodeWorkerMessage {
     this.segmentId = 0,
     this.lang,
     this.switched = false,
+    this.punctuated = false,
   });
 
   /// Echoes [DecodeWorkerCommand.id].
@@ -318,11 +401,19 @@ class DecodeWorkerResult extends DecodeWorkerMessage {
   /// Whether this segment is what made a routed session change language.
   final bool switched;
 
-  /// Wall-clock milliseconds the decode itself took inside the worker.
-  /// Deliberately excludes the message round trip, so it stays the same
-  /// quantity `LiveTranscriptEntry.latencyMs` reported when decoding
-  /// happened in-process.
+  /// Wall-clock milliseconds the work took inside the worker: the decode,
+  /// plus punctuation restoration when [punctuated] is true. Deliberately
+  /// excludes the message round trip, so for an unpunctuated result it
+  /// stays the same quantity `LiveTranscriptEntry.latencyMs` reported when
+  /// decoding happened in-process.
   final double latencyMs;
+
+  /// Whether Japanese punctuation was restored into [text] — i.e. the
+  /// punctuation model ran on this result. Only refine results are ever
+  /// punctuated, and only when the session was started with a punctuation
+  /// model that applies to this result's language (see
+  /// [DecodeWorkerConfig.shouldPunctuateRefine]).
+  final bool punctuated;
 
   @override
   List<Object?> toMessage() => <Object?>[
@@ -334,6 +425,7 @@ class DecodeWorkerResult extends DecodeWorkerMessage {
     lang,
     switched,
     latencyMs,
+    punctuated,
   ];
 }
 

--- a/mobile/hayamimi_core/lib/live/decode_protocol.dart
+++ b/mobile/hayamimi_core/lib/live/decode_protocol.dart
@@ -84,6 +84,7 @@ class DecodeWorkerConfig {
     this.punctLibraryPath,
     this.punctNumThreads = defaultPunctNumThreads,
     this.punctuatePlainSession = true,
+    this.punctuateFinals = true,
   }) : assert(
          (punctModelPath == null) == (punctVocabPath == null),
          'Japanese punctuation needs both punctModelPath and punctVocabPath, '
@@ -147,23 +148,45 @@ class DecodeWorkerConfig {
   /// Ignored when [punctModelPath] is `null` or when [routed] is true.
   final bool punctuatePlainSession;
 
+  /// Whether [DecodeRequestKind.finalSegment] results are punctuated too,
+  /// and not only [DecodeRequestKind.refine] ones. Defaults to `true`; see
+  /// `JaPunctuation.applyToFinals`, the caller-facing switch this carries,
+  /// for why a punctuated fast line is what keeps a refine's fallback
+  /// punctuated.
+  ///
+  /// Ignored when [punctModelPath] is `null`.
+  final bool punctuateFinals;
+
   /// Whether this session loads a punctuation model at all.
   bool get hasPunctuation => punctModelPath != null && punctVocabPath != null;
 
-  /// Whether a refine result that came back as [lang] should have Japanese
+  /// Whether a [kind] result that came back as [lang] should have Japanese
   /// punctuation restored into it.
   ///
-  /// Kept here, as a pure function of the config and one result's language,
-  /// so the rule can be read and tested on its own rather than inferred
-  /// from the worker's decode loop. `lang` is `null` for a plain session,
-  /// which is why [punctuatePlainSession] exists.
+  /// Kept here, as a pure function of the config, one request's kind and one
+  /// result's language, so the rule can be read and tested on its own rather
+  /// than inferred from the worker's decode loop. `lang` is `null` for a
+  /// plain session, which is why [punctuatePlainSession] exists.
   ///
-  /// Only refine results are punctuated, so the worker checks the request
-  /// kind before calling this — see `decode_worker.dart` for why finals and
-  /// drafts are left alone.
-  bool shouldPunctuateRefine({String? lang}) {
+  /// Refines always qualify; finals do when [punctuateFinals] is set; drafts
+  /// never do — see `decode_worker.dart` for why a line that is re-decoded
+  /// every second is left alone. The two control kinds carry no text and
+  /// never reach this.
+  bool shouldPunctuate({required DecodeRequestKind kind, String? lang}) {
     if (!hasPunctuation) {
       return false;
+    }
+    switch (kind) {
+      case DecodeRequestKind.refine:
+        break;
+      case DecodeRequestKind.finalSegment:
+        if (!punctuateFinals) {
+          return false;
+        }
+      case DecodeRequestKind.draft:
+      case DecodeRequestKind.resetSession:
+      case DecodeRequestKind.shutdown:
+        return false;
     }
     return routed ? lang == 'ja' : punctuatePlainSession;
   }
@@ -183,6 +206,7 @@ class DecodeWorkerConfig {
     punctLibraryPath,
     punctNumThreads,
     punctuatePlainSession,
+    punctuateFinals,
   ];
 
   static DecodeWorkerConfig fromMessage(Object? message) {
@@ -202,6 +226,7 @@ class DecodeWorkerConfig {
       punctLibraryPath: m[11] as String?,
       punctNumThreads: m[12]! as int,
       punctuatePlainSession: m[13]! as bool,
+      punctuateFinals: m[14]! as bool,
     );
   }
 }
@@ -409,10 +434,10 @@ class DecodeWorkerResult extends DecodeWorkerMessage {
   final double latencyMs;
 
   /// Whether Japanese punctuation was restored into [text] — i.e. the
-  /// punctuation model ran on this result. Only refine results are ever
-  /// punctuated, and only when the session was started with a punctuation
-  /// model that applies to this result's language (see
-  /// [DecodeWorkerConfig.shouldPunctuateRefine]).
+  /// punctuation model ran on this result. Refines and finals can be
+  /// punctuated, drafts never are, and only when the session was started
+  /// with a punctuation model that applies to this result's language (see
+  /// [DecodeWorkerConfig.shouldPunctuate]).
   final bool punctuated;
 
   @override

--- a/mobile/hayamimi_core/lib/live/decode_session.dart
+++ b/mobile/hayamimi_core/lib/live/decode_session.dart
@@ -26,7 +26,11 @@ import 'decode_worker.dart';
 /// the user tapped 清書 is included in the group instead of being pushed
 /// into the next one.
 class RefineRequestPayload {
-  const RefineRequestPayload({required this.samples, required this.fastText});
+  const RefineRequestPayload({
+    required this.samples,
+    required this.fastText,
+    this.fastTextPunctuated = false,
+  });
 
   /// The buffered segments' audio, joined.
   final Float32List samples;
@@ -34,6 +38,12 @@ class RefineRequestPayload {
   /// Those segments' fast finals, joined — the fallback if the merged
   /// re-decode comes back suspiciously short.
   final String fastText;
+
+  /// Whether [fastText] is punctuated throughout, because every final that
+  /// went into it was (see `isCombinedFastTextPunctuated`). A refine that
+  /// falls back to [fastText] reports this as its own `punctuated`, and the
+  /// shrink comparison strips [fastText]'s marks when it is set.
+  final bool fastTextPunctuated;
 }
 
 sealed class _Pending {

--- a/mobile/hayamimi_core/lib/live/decode_worker.dart
+++ b/mobile/hayamimi_core/lib/live/decode_worker.dart
@@ -18,9 +18,27 @@
 /// to justify. The worker calls `sherpa_onnx.initBindings()` itself, as
 /// every isolate that touches the FFI bindings must.
 ///
+/// The Japanese punctuation model lives here for the same reason. Its
+/// `restore()` is another synchronous native call, tens of milliseconds per
+/// refine on the Windows x86 host the parity test runs on (see the README's
+/// punctuation section for the measurement and its conditions; no phone was
+/// measured), so running it on the caller's isolate would hand back the
+/// pause that moving decoding here removed.
+///
+/// Only refine ("清書") results are punctuated. That is where the desktop
+/// pipeline punctuates, and it is the pass with the context to do it well:
+/// a refine re-decodes a whole buffered group, while a final covers one
+/// speech segment and a draft covers part of one still being spoken, so
+/// sentence boundaries there fall wherever the speaker paused. Punctuating
+/// every final would also add a full model run to every utterance, on a
+/// phone, for a line the next refine replaces. Finals and drafts therefore
+/// come back exactly as the recognizer produced them, with
+/// [DecodeWorkerResult.punctuated] false.
+///
 /// Ownership, stated once: from `initBindings` to the [DecodeRequestKind.shutdown]
 /// ack, exactly one isolate — this one — creates, uses and frees the
-/// recognizer handles. The caller's isolate never holds a pointer to them.
+/// recognizer handles and the punctuation session. The caller's isolate
+/// never holds a pointer to them.
 library;
 
 import 'dart:async';
@@ -30,6 +48,7 @@ import 'dart:isolate';
 import 'package:sherpa_onnx/sherpa_onnx.dart' as sherpa_onnx;
 
 import '../bench/model_file_resolver.dart';
+import '../punct/punctuator_ja.dart';
 import '../routing/routed_recognizer.dart';
 import 'decode_protocol.dart';
 
@@ -307,6 +326,19 @@ Future<void> decodeWorkerMain(List<Object?> bootstrap) async {
 
   sherpa_onnx.OfflineRecognizer? recognizer;
   RoutedRecognizerSet? routed;
+  PunctuatorJa? punctuator;
+
+  // The punctuation model loads *after* the recognizers, so a build that
+  // gets that far has native handles to release before reporting the
+  // failure -- the caller is told the session did not start, and nothing
+  // may be left allocated in an isolate that is about to exit.
+  void reportBuildFailure(String message) {
+    recognizer?.free();
+    routed?.free();
+    toMain.send(DecodeWorkerBuildFailed(message).toMessage());
+    commands.close();
+  }
+
   try {
     if (config.routed) {
       final senseVoiceModelDir = config.senseVoiceModelDir;
@@ -340,17 +372,23 @@ Future<void> decodeWorkerMain(List<Object?> bootstrap) async {
     } else {
       recognizer = await _buildPlainRecognizer(config, toMain);
     }
+    punctuator = await loadWorkerPunctuator(
+      config,
+      onModelLoad: (event) => toMain.send(event.toMessage()),
+    );
   } on RoutedRecognizerException catch (e) {
-    toMain.send(DecodeWorkerBuildFailed(e.message).toMessage());
-    commands.close();
+    reportBuildFailure(e.message);
     return;
   } on ModelFileResolutionException catch (e) {
-    toMain.send(DecodeWorkerBuildFailed(e.message).toMessage());
-    commands.close();
+    reportBuildFailure(e.message);
+    return;
+  } on DecodeWorkerException catch (e) {
+    // What loadWorkerPunctuator throws: its message already names the
+    // punctuation model, so it travels as-is.
+    reportBuildFailure(e.message);
     return;
   } catch (e) {
-    toMain.send(DecodeWorkerBuildFailed('$e').toMessage());
-    commands.close();
+    reportBuildFailure('$e');
     return;
   }
   toMain.send(const DecodeWorkerReady().toMessage());
@@ -360,6 +398,7 @@ Future<void> decodeWorkerMain(List<Object?> bootstrap) async {
     if (command.kind == DecodeRequestKind.shutdown) {
       recognizer?.free();
       routed?.free();
+      punctuator?.dispose();
       toMain.send(
         DecodeWorkerAck(id: command.id, kind: command.kind).toMessage(),
       );
@@ -382,16 +421,30 @@ Future<void> decodeWorkerMain(List<Object?> bootstrap) async {
         recognizer: recognizer,
         routed: routed,
       );
+      // Punctuation is part of producing this result, so it is inside the
+      // timed section and inside the same try: a restore() that throws
+      // loses this one refine the way a decode that throws does, and leaves
+      // the session running.
+      final punct = punctuator;
+      var outText = text;
+      var punctuated = false;
+      if (punct != null &&
+          request.kind == DecodeRequestKind.refine &&
+          config.shouldPunctuateRefine(lang: lang)) {
+        outText = punct.restore(text);
+        punctuated = true;
+      }
       stopwatch.stop();
       toMain.send(
         DecodeWorkerResult(
           id: request.id,
           kind: request.kind,
           segmentId: request.segmentId,
-          text: text,
+          text: outText,
           lang: lang,
           switched: switched,
           latencyMs: stopwatch.elapsedMicroseconds / 1000,
+          punctuated: punctuated,
         ).toMessage(),
       );
     } catch (e) {
@@ -497,4 +550,74 @@ Future<sherpa_onnx.OfflineRecognizer> _buildPlainRecognizer(
     ).toMessage(),
   );
   return recognizer;
+}
+
+/// Builds the Japanese punctuation model [config] asks for, or returns
+/// `null` when it asks for none.
+///
+/// Loading it last is deliberate: the recognizers are what the session
+/// cannot run without, and the punctuation model is 181.8 MB on top of
+/// them, so a device that is going to run out of memory does so after the
+/// part that matters has had its chance. Progress is reported as
+/// `model: 'punct'` on the same `model_load` `start`/`done` events every
+/// other model uses, with the measured elapsed milliseconds on `done`.
+///
+/// A failure here throws [DecodeWorkerException] with a message naming the
+/// files, which the worker turns into a build failure and
+/// `LiveTranscriber.start` rethrows: a missing 182 MB file on a phone is a
+/// configuration mistake, and starting a session that silently produces
+/// unpunctuated text would hide it.
+///
+/// Called by the worker isolate. It is public, and takes a callback rather
+/// than the worker's `SendPort`, so a test can build exactly what a given
+/// config would build without spawning an isolate — which is as close to
+/// the real worker as a `flutter test` run can get, since the recognizers
+/// beside it need native libraries no test VM can load.
+Future<PunctuatorJa?> loadWorkerPunctuator(
+  DecodeWorkerConfig config, {
+  void Function(DecodeWorkerModelLoad event)? onModelLoad,
+}) async {
+  final modelPath = config.punctModelPath;
+  final vocabPath = config.punctVocabPath;
+  if (modelPath == null && vocabPath == null) {
+    return null;
+  }
+  if (modelPath == null || vocabPath == null) {
+    // Unreachable through JaPunctuation, which requires both, and caught by
+    // an assert in DecodeWorkerConfig in debug builds. Said out loud for
+    // anyone driving the worker directly in a release build.
+    throw DecodeWorkerException(
+      'The Japanese punctuation model needs both punctModelPath and '
+      'punctVocabPath; only '
+      '${modelPath == null ? 'the vocabulary' : 'the model'} was given.',
+    );
+  }
+
+  onModelLoad?.call(
+    const DecodeWorkerModelLoad(model: 'punct', phase: 'start'),
+  );
+  final stopwatch = Stopwatch()..start();
+  final PunctuatorJa punctuator;
+  try {
+    punctuator = await PunctuatorJa.load(
+      modelPath: modelPath,
+      vocabPath: vocabPath,
+      libraryPath: config.punctLibraryPath,
+      intraOpNumThreads: config.punctNumThreads,
+    );
+  } catch (e) {
+    throw DecodeWorkerException(
+      'Could not load the Japanese punctuation model "$modelPath" '
+      '(vocabulary "$vocabPath"): $e',
+    );
+  }
+  stopwatch.stop();
+  onModelLoad?.call(
+    DecodeWorkerModelLoad(
+      model: 'punct',
+      phase: 'done',
+      ms: stopwatch.elapsedMicroseconds / 1000,
+    ),
+  );
+  return punctuator;
 }

--- a/mobile/hayamimi_core/lib/live/decode_worker.dart
+++ b/mobile/hayamimi_core/lib/live/decode_worker.dart
@@ -569,6 +569,13 @@ Future<sherpa_onnx.OfflineRecognizer> _buildPlainRecognizer(
 /// `model: 'punct'` on the same `model_load` `start`/`done` events every
 /// other model uses, with the measured elapsed milliseconds on `done`.
 ///
+/// That `done` duration includes one warm-up [PunctuatorJa.restore] call on
+/// a short fixed string, run right after the model loads: the first
+/// `restore()` in a process costs ~300 ms more than every later one, and
+/// with finals punctuated by default that cost would otherwise fall on the
+/// first caption line a user sees rather than on this already-reported
+/// startup cost. See the comment at the call site below.
+///
 /// A failure here throws [DecodeWorkerException] with a message naming the
 /// files, which the worker turns into a build failure and
 /// `LiveTranscriber.start` rethrows: a missing 182 MB file on a phone is a
@@ -612,6 +619,18 @@ Future<PunctuatorJa?> loadWorkerPunctuator(
       libraryPath: config.punctLibraryPath,
       intraOpNumThreads: config.punctNumThreads,
     );
+    // Warm-up: the fp16 model's first restore() in a process costs ~300 ms
+    // more than every later one (ONNX Runtime builds its execution plan and
+    // allocates workspace on first run). Finals are punctuated by default
+    // now (see JaPunctuation.applyToFinals), so without this, that cold
+    // start would land on the first caption line a user sees instead of
+    // here. Paying it now folds the cost into this model's `model_load`
+    // duration -- already ~0.9-1.8 s and already understood as startup
+    // cost -- so the number reported on `done` below is ~300 ms higher, in
+    // exchange for no 400 ms spike on the first final or refine. The input
+    // and its result are both throwaway; only the side effect of warming
+    // the ONNX Runtime session is wanted.
+    punctuator.restore('あ');
   } catch (e) {
     throw DecodeWorkerException(
       'Could not load the Japanese punctuation model "$modelPath" '

--- a/mobile/hayamimi_core/lib/live/decode_worker.dart
+++ b/mobile/hayamimi_core/lib/live/decode_worker.dart
@@ -25,14 +25,22 @@
 /// measured), so running it on the caller's isolate would hand back the
 /// pause that moving decoding here removed.
 ///
-/// Only refine ("清書") results are punctuated. That is where the desktop
-/// pipeline punctuates, and it is the pass with the context to do it well:
-/// a refine re-decodes a whole buffered group, while a final covers one
-/// speech segment and a draft covers part of one still being spoken, so
-/// sentence boundaries there fall wherever the speaker paused. Punctuating
-/// every final would also add a full model run to every utterance, on a
-/// phone, for a line the next refine replaces. Finals and drafts therefore
-/// come back exactly as the recognizer produced them, with
+/// Refines ("清書") and finals are punctuated; drafts are not. Refines were
+/// punctuated first, because that is where the desktop pipeline punctuates
+/// and it is the pass with the most context. Finals were added because a
+/// refine does not always emit its own text: when the merged re-decode
+/// comes back much shorter than the fast finals it is replacing, the caller
+/// discards it and emits those finals joined instead, so unpunctuated
+/// finals meant an unpunctuated refine in exactly the case the guard exists
+/// for. The desktop has no such hole because its fast finals are already
+/// punctuated. That costs one model run per utterance, which is the
+/// trade-off `JaPunctuation.applyToFinals` exists to decline.
+///
+/// Drafts stay unpunctuated: a draft covers part of a segment still being
+/// spoken and is re-decoded about once a second, so a mark placed in one is
+/// a guess about a sentence that has not finished, paid for on a phone, on
+/// a line the segment's own final replaces a moment later. They come back
+/// exactly as the recognizer produced them, with
 /// [DecodeWorkerResult.punctuated] false.
 ///
 /// Ownership, stated once: from `initBindings` to the [DecodeRequestKind.shutdown]
@@ -423,14 +431,13 @@ Future<void> decodeWorkerMain(List<Object?> bootstrap) async {
       );
       // Punctuation is part of producing this result, so it is inside the
       // timed section and inside the same try: a restore() that throws
-      // loses this one refine the way a decode that throws does, and leaves
+      // loses this one result the way a decode that throws does, and leaves
       // the session running.
       final punct = punctuator;
       var outText = text;
       var punctuated = false;
       if (punct != null &&
-          request.kind == DecodeRequestKind.refine &&
-          config.shouldPunctuateRefine(lang: lang)) {
+          config.shouldPunctuate(kind: request.kind, lang: lang)) {
         outText = punct.restore(text);
         punctuated = true;
       }

--- a/mobile/hayamimi_core/lib/live/draft_pass.dart
+++ b/mobile/hayamimi_core/lib/live/draft_pass.dart
@@ -32,16 +32,6 @@ const double defaultDraftWindowSeconds = 8.0;
 /// wasting a decode call on near-silence.
 const double defaultMinDraftAudioSeconds = 0.25;
 
-/// Whether it's time to fire another draft decode.
-///
-/// [isDecoding] is the "skip, don't queue" guard: [LiveTranscriber] sends
-/// every decode -- fast-final, refine and draft alike -- to a single
-/// worker isolate that serves them one at a time. If anything is already
-/// outstanding there, this returns `false` rather than letting drafts pile
-/// up behind it: a queued draft would only delay whichever decode actually
-/// matters (the next final), and would be superseded by that final anyway.
-/// The caller is expected to just try again on the next frame, which
-/// naturally catches up once the worker is free.
 /// Drops whole frames off the front of [frames] until their total sample
 /// count is within [maxSeconds] of [sampleRate] audio (or exactly one frame
 /// remains, even if that single frame alone exceeds the budget).
@@ -50,7 +40,7 @@ const double defaultMinDraftAudioSeconds = 0.25;
 /// draft accumulator, so the accumulator itself never grows past this
 /// window. Without it, a long uninterrupted utterance made the accumulator
 /// -- and therefore the concatFloat32Lists pass over the whole thing that
-/// [_runDraftDecode] repeated on every draft tick -- grow without bound,
+/// `_runDraftDecode` repeated on every draft tick -- grow without bound,
 /// even though [capDraftWindow] only ever decodes the trailing
 /// [defaultDraftWindowSeconds] of it anyway: total work across the
 /// utterance was effectively O(n^2) in its length. Trimming at the source
@@ -70,6 +60,16 @@ List<Float32List> slideDraftFrames(
   return start == 0 ? frames : frames.sublist(start);
 }
 
+/// Whether it's time to fire another draft decode.
+///
+/// [isDecoding] is the "skip, don't queue" guard: [LiveTranscriber] sends
+/// every decode -- fast-final, refine and draft alike -- to a single
+/// worker isolate that serves them one at a time. If anything is already
+/// outstanding there, this returns `false` rather than letting drafts pile
+/// up behind it: a queued draft would only delay whichever decode actually
+/// matters (the next final), and would be superseded by that final anyway.
+/// The caller is expected to just try again on the next frame, which
+/// naturally catches up once the worker is free.
 bool isDraftDue({
   required bool isDecoding,
   required Duration sinceLastDraft,

--- a/mobile/hayamimi_core/lib/live/ja_punctuation.dart
+++ b/mobile/hayamimi_core/lib/live/ja_punctuation.dart
@@ -44,6 +44,7 @@ class JaPunctuation {
     required this.vocabPath,
     this.libraryPath,
     this.numThreads = defaultPunctNumThreads,
+    this.applyToFinals = true,
   });
 
   /// The punctuation model file, e.g. `punct_bert.fp16.onnx` (181.8 MB).
@@ -63,4 +64,34 @@ class JaPunctuation {
   /// How many threads ONNX Runtime may use inside a single operator.
   /// Defaults to [defaultPunctNumThreads].
   final int numThreads;
+
+  /// Whether finalized per-segment lines are punctuated too, and not only
+  /// refine ("清書") passes. Defaults to `true`.
+  ///
+  /// Refines were punctuated first, because that is where the desktop
+  /// pipeline punctuates. But a refine does not always emit its own text: a
+  /// merged re-decode that comes back much shorter than the fast finals it
+  /// is replacing is discarded in favour of those finals joined together
+  /// (see `isRefineTextTooShort`), and if nothing punctuated them, the
+  /// refine goes out unpunctuated — losing the marks in exactly the case
+  /// the guard exists to protect. The Japanese recognizer in this repo
+  /// collapses multi-sentence audio to its last sentence, so on a group of
+  /// two or more segments that guard is the normal outcome, not the rare
+  /// one. Punctuating the finals is what gives the fallback something
+  /// punctuated to fall back to — the same thing the desktop relies on,
+  /// where the fast finals have already been through `punct_ja.py`.
+  ///
+  /// The cost is one extra run of the punctuation model per utterance
+  /// (~25-35 ms per ~11-14 characters on the Android emulator the README
+  /// measured; no phone was measured), inside the decode worker, on text
+  /// the next refine may replace anyway. Set `false` to buy that back and
+  /// keep the fast line exactly as the recognizer produced it; refines are
+  /// still punctuated, and a refine that falls back to the finals then
+  /// reports `punctuated: false` as it did before this flag existed.
+  ///
+  /// Drafts ("発話中の暫定字幕") are never punctuated either way: a draft
+  /// covers part of a segment still being spoken and is re-decoded about
+  /// once a second, so any mark placed in one is a guess about a sentence
+  /// that has not finished.
+  final bool applyToFinals;
 }

--- a/mobile/hayamimi_core/lib/live/ja_punctuation.dart
+++ b/mobile/hayamimi_core/lib/live/ja_punctuation.dart
@@ -81,10 +81,13 @@ class JaPunctuation {
   /// punctuated to fall back to — the same thing the desktop relies on,
   /// where the fast finals have already been through `punct_ja.py`.
   ///
-  /// The cost is one extra run of the punctuation model per utterance
-  /// (~25-35 ms per ~11-14 characters on the Android emulator the README
-  /// measured; no phone was measured), inside the decode worker, on text
-  /// the next refine may replace anyway. Set `false` to buy that back and
+  /// The cost is one extra run of the punctuation model per utterance,
+  /// inside the decode worker, on text the next refine may replace anyway.
+  /// Measured directly on an Android emulator (x86_64, API 35, host Ryzen 5
+  /// 5600 — not a phone) by decoding the same audio with this flag on and
+  /// off: **~40-50 ms per ~11-14 characters** (1.8-2.4 s of audio; finals
+  /// went from 61.7/77.6/68.8 ms to 109.5/115.4/117.3 ms). No phone was
+  /// measured. Set `false` to buy that back and
   /// keep the fast line exactly as the recognizer produced it; refines are
   /// still punctuated, and a refine that falls back to the finals then
   /// reports `punctuated: false` as it did before this flag existed.

--- a/mobile/hayamimi_core/lib/live/ja_punctuation.dart
+++ b/mobile/hayamimi_core/lib/live/ja_punctuation.dart
@@ -1,0 +1,66 @@
+/// How intra-op threads ONNX Runtime is told to use for the punctuation
+/// model when a caller does not say.
+///
+/// Two, matching the recognizers' own default (`DecodeWorkerConfig.numThreads`):
+/// the punctuation model runs in the same isolate as the recognizers and on
+/// the same phone cores, so asking for more threads here takes them from
+/// the decode that is about to follow rather than finding idle ones.
+const int defaultPunctNumThreads = 2;
+
+/// Where a session's Japanese punctuation model lives, and how to run it.
+///
+/// The problem: hayamimi's speech recognizer emits a bare run of
+/// characters. The desktop pipeline puts 、 and 。 back with
+/// `scripts/punct_ja.py` before anything sees the text, so desktop captions
+/// read as sentences; this package's refine ("清書") output arrived
+/// unpunctuated. Passing one of these to `LiveTranscriber.start` (or
+/// `HayamimiLive.start`) is what closes that gap — `null`, the default,
+/// leaves the session behaving exactly as it did before this parameter
+/// existed.
+///
+/// This is a description of where the files are, not the model itself. The
+/// session hands it to its decode worker isolate, which is where the model
+/// is loaded and where `PunctuatorJa.restore` actually runs; nothing native
+/// is created on the caller's isolate. Immutable, so the same instance can
+/// be reused across sessions.
+///
+/// ```dart
+/// await live.start(
+///   modelDir: modelDir,
+///   vadModelPath: vadPath,
+///   punctuation: JaPunctuation(
+///     modelPath: '$dir/punct_bert.fp16.onnx',
+///     vocabPath: '$dir/vocab.txt',
+///   ),
+/// );
+/// ```
+///
+/// Both files are local build artifacts today — see the README's "Japanese
+/// punctuation restoration" section for where they come from and what is
+/// still unverified.
+class JaPunctuation {
+  const JaPunctuation({
+    required this.modelPath,
+    required this.vocabPath,
+    this.libraryPath,
+    this.numThreads = defaultPunctNumThreads,
+  });
+
+  /// The punctuation model file, e.g. `punct_bert.fp16.onnx` (181.8 MB).
+  final String modelPath;
+
+  /// The model's `vocab.txt` (28 KB), which maps characters to token ids.
+  final String vocabPath;
+
+  /// Where ONNX Runtime — the inference engine that runs the model — comes
+  /// from. Leave unset on Android, where the session borrows the copy
+  /// `sherpa_onnx` has already loaded; pass a path on a desktop host,
+  /// where nothing puts that library on the loader search path. `OrtLibrary`
+  /// documents the per-platform default this `null` selects, including why
+  /// iOS refuses rather than guesses.
+  final String? libraryPath;
+
+  /// How many threads ONNX Runtime may use inside a single operator.
+  /// Defaults to [defaultPunctNumThreads].
+  final int numThreads;
+}

--- a/mobile/hayamimi_core/lib/live/live_transcriber.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcriber.dart
@@ -7,6 +7,7 @@ import 'package:sherpa_onnx/sherpa_onnx.dart' as sherpa_onnx;
 
 import '../bench/model_file_resolver.dart';
 import '../bench/model_kind.dart';
+import '../punct/punct_ja_text.dart';
 import '../remote/wav_pcm_reader.dart';
 import '../routing/routed_recognizer.dart';
 import '../routing/routing_profile.dart';
@@ -14,6 +15,7 @@ import 'decode_protocol.dart';
 import 'decode_session.dart';
 import 'decode_worker.dart';
 import 'draft_pass.dart';
+import 'ja_punctuation.dart';
 import 'live_transcript_entry.dart';
 import 'live_vad.dart';
 import 'model_load_event.dart';
@@ -235,10 +237,11 @@ class LiveTranscriber {
   // demand, re-decode the whole group together for a cleaner result than
   // any single segment got on its own (same effect the desktop pipeline's
   // `Refiner` gets from re-decoding across segment boundaries — see
-  // `scripts/realtime_transcribe.py`). No punctuation-restoration model is
-  // layered on top of this; it's re-decode only. Built in the constructor
-  // initializer list above (its cap comes from the refineBufferMaxSeconds
-  // constructor parameter).
+  // `scripts/realtime_transcribe.py`). When start() was given a
+  // `punctuation` model, the worker also restores 、 and 。 into the result
+  // before sending it back; without one this stays re-decode only. Built in
+  // the constructor initializer list above (its cap comes from the
+  // refineBufferMaxSeconds constructor parameter).
   final RefineBuffer _refineBuffer;
   DateTime? _lastSegmentAt;
   Timer? _autoRefineTimer;
@@ -308,6 +311,11 @@ class LiveTranscriber {
   /// Refine ("清書") results: one entry per manual or automatic refine
   /// pass, each covering everything buffered since the previous refine (or
   /// since the session started).
+  ///
+  /// This is the only stream Japanese punctuation restoration touches: when
+  /// [start] was given a `punctuation` model, an entry here can carry 、 。
+  /// ？ that the recognizer never produced, and says so through
+  /// [LiveTranscriptEntry.punctuated].
   Stream<LiveTranscriptEntry> get refineEntries => _refineEntriesController.stream;
 
   /// In-progress ("draft") decodes: one per draft re-decode while a VAD
@@ -419,6 +427,29 @@ class LiveTranscriber {
   /// knobs and [vadSensitivity], hotwords have no runtime setter — they're
   /// baked into the recognizer at build time, so changing them requires a
   /// fresh [start] (or [stop] + [start]).
+  ///
+  /// [punctuation] turns on Japanese punctuation restoration for this
+  /// session's refine ("清書") results: the recognizer emits a bare run of
+  /// characters, and the model named here puts 、 and 。 (and ？ after a
+  /// question ending) back into it, the way the desktop pipeline's
+  /// `scripts/punct_ja.py` does. `null` (the
+  /// default) leaves it off, which is what this method did before the
+  /// parameter existed. What changes when it is set:
+  ///
+  ///  * only [refineEntries] is affected — [entries] and [drafts] carry the
+  ///    recognizer's text unchanged (see `decode_worker.dart` for why);
+  ///  * a routed session punctuates the refines that came back as Japanese
+  ///    and leaves the rest alone; a plain session punctuates every refine,
+  ///    so **only pass this to a plain session whose model is Japanese**;
+  ///  * each affected entry carries [LiveTranscriptEntry.punctuated];
+  ///  * the model is loaded in the decode worker, after the recognizers,
+  ///    and reported on [modelLoads] as `model: 'punct'`. It is another
+  ///    181.8 MB of memory for the life of the session, and a failure to
+  ///    load it fails this call rather than starting a session that
+  ///    quietly produces unpunctuated text.
+  ///
+  /// Like hotwords, it is fixed for the session: changing it means a fresh
+  /// [start].
   Future<void> start({
     required ModelKind modelKind,
     required String modelDir,
@@ -430,6 +461,7 @@ class LiveTranscriber {
     VadSensitivity? vadSensitivity,
     String? hotwordsFile,
     double hotwordsScore = 1.5,
+    JaPunctuation? punctuation,
   }) async {
     if (isRunning || _debugStreaming || _starting) {
       return;
@@ -455,6 +487,7 @@ class LiveTranscriber {
           vadSensitivity: vadSensitivity ?? _vadSensitivity,
           hotwordsFile: hotwordsFile,
           hotwordsScore: hotwordsScore,
+          punctuation: punctuation,
         );
       } catch (_) {
         // _buildNativeState can throw after already building the
@@ -557,6 +590,7 @@ class LiveTranscriber {
     required VadSensitivity vadSensitivity,
     String? hotwordsFile,
     double hotwordsScore = 1.5,
+    JaPunctuation? punctuation,
   }) async {
     // A new generation starts the moment this build begins, not once it
     // succeeds: any setVadSensitivity rebuild already in flight for the
@@ -590,6 +624,22 @@ class LiveTranscriber {
       );
     }
 
+    if (punctuation != null) {
+      // Checked here, alongside the recognizer and VAD paths, so a missing
+      // 182 MB model is reported before an isolate is spawned and up to
+      // 396 MB of recognizer weights are loaded for a session that is about
+      // to fail anyway. The worker checks again -- it is the one that can
+      // tell a file that exists from a file it can actually load.
+      for (final (label, path) in <(String, String)>[
+        ('Japanese punctuation model', punctuation.modelPath),
+        ('Japanese punctuation vocabulary', punctuation.vocabPath),
+      ]) {
+        if (!await File(path).exists()) {
+          throw LiveTranscriberException('$label not found: $path');
+        }
+      }
+    }
+
     // Captured before the worker is started and stamped on every callback
     // below (see [_ifCurrent]): a worker replies on its own schedule, so
     // this is what tells a reply whether the session it belongs to is
@@ -609,6 +659,15 @@ class LiveTranscriber {
           hotwordsFile: hotwordsFile,
           hotwordsScore: hotwordsScore,
           sampleRate: sampleRate,
+          punctModelPath: punctuation?.modelPath,
+          punctVocabPath: punctuation?.vocabPath,
+          punctLibraryPath: punctuation?.libraryPath,
+          punctNumThreads: punctuation?.numThreads ?? defaultPunctNumThreads,
+          // Left at the default (true): for a plain single-model session
+          // there is no language tag to test, and passing a Japanese
+          // punctuation model to one is itself the statement that its model
+          // transcribes Japanese. See
+          // DecodeWorkerConfig.punctuatePlainSession.
         ),
         buildRefinePayload: () => _buildRefinePayload(generation),
         onFinal: (samples, result) =>
@@ -855,11 +914,24 @@ class LiveTranscriber {
     DecodeWorkerResult result,
   ) {
     var text = result.text.trim();
+    var punctuated = result.punctuated;
     // A merged re-decode must never LOSE content: if it comes back much
     // shorter than the fast finals combined, trust those instead (mirrors
     // scripts/realtime_transcribe.py's Refiner).
-    if (isRefineTextTooShort(text, payload.fastText)) {
+    //
+    // The length compared is the text WITHOUT the marks the punctuation
+    // model wrote: it runs in the worker, before this, so by here a
+    // punctuated refine is several characters longer than what was actually
+    // said, and crediting it for those would let a truncated re-decode pass
+    // a check it should fail. The fast text it is compared against is never
+    // punctuated (only refines are), so only this side is stripped.
+    if (isRefineTextTooShort(
+      punctuated ? withoutRestoredMarks(text) : text,
+      payload.fastText,
+    )) {
       text = payload.fastText;
+      // The fallback is the finals' own text, which no model punctuated.
+      punctuated = false;
     }
     if (text.isEmpty) {
       return;
@@ -872,6 +944,7 @@ class LiveTranscriber {
           latencyMs: result.latencyMs,
           lang: result.lang,
           audioSeconds: payload.samples.length / sampleRate,
+          punctuated: punctuated,
         ),
       );
     }
@@ -1298,7 +1371,9 @@ class LiveTranscriber {
   /// segment has been flushed and decoded -- same shutdown behavior [stop]
   /// gives a live session.
   /// See [start] for what [decodingMethod]/[vadSensitivity]/[hotwordsFile]/
-  /// [hotwordsScore] do -- identical meaning and defaults here.
+  /// [hotwordsScore]/[punctuation] do -- identical meaning and defaults
+  /// here, which is what makes this the way to see punctuated refine output
+  /// on an emulator.
   Future<void> startDebugWavStream({
     required ModelKind modelKind,
     required String modelDir,
@@ -1312,6 +1387,7 @@ class LiveTranscriber {
     VadSensitivity? vadSensitivity,
     String? hotwordsFile,
     double hotwordsScore = 1.5,
+    JaPunctuation? punctuation,
   }) async {
     if (isRunning || _debugStreaming || _starting) {
       return;
@@ -1331,6 +1407,7 @@ class LiveTranscriber {
         vadSensitivity: vadSensitivity ?? _vadSensitivity,
         hotwordsFile: hotwordsFile,
         hotwordsScore: hotwordsScore,
+        punctuation: punctuation,
       );
     } finally {
       _starting = false;
@@ -1350,6 +1427,7 @@ class LiveTranscriber {
     required VadSensitivity vadSensitivity,
     String? hotwordsFile,
     double hotwordsScore = 1.5,
+    JaPunctuation? punctuation,
   }) async {
     final wavFile = File(wavPath);
     if (!await wavFile.exists()) {
@@ -1368,6 +1446,7 @@ class LiveTranscriber {
         vadSensitivity: vadSensitivity,
         hotwordsFile: hotwordsFile,
         hotwordsScore: hotwordsScore,
+        punctuation: punctuation,
       );
     } catch (_) {
       // See start()'s identical catch: _buildNativeState can throw after

--- a/mobile/hayamimi_core/lib/live/live_transcriber.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcriber.dart
@@ -46,6 +46,10 @@ const _decodeDrainTimeout = Duration(seconds: 10);
 /// tests (see [LiveTranscriber]'s `decodeWorkerFactory`).
 DecodeWorker _spawnDecodeWorker() => IsolateDecodeWorker();
 
+/// A [LiveTranscriber] failure: thrown by `start`/`startDebugWavStream`
+/// for a bad configuration (e.g. a missing model file), and emitted on
+/// [LiveTranscriber.errors] for a failure mid-session -- e.g. the OS
+/// revoking microphone access, or the decode worker isolate dying.
 class LiveTranscriberException implements Exception {
   LiveTranscriberException(this.message);
   final String message;
@@ -139,6 +143,8 @@ class LiveTranscriber {
        _vadFactory = vadFactory ?? buildSileroLiveVad,
        _recorder = recorder ?? AudioRecorder();
 
+  /// The mic capture / VAD / recognizer sample rate this transcriber uses
+  /// throughout, in Hz. Fixed -- not configurable per session.
   static const int sampleRate = 16000;
 
   static double _requirePositive(double value, String name) {
@@ -353,6 +359,8 @@ class LiveTranscriber {
   /// `events` stream).
   Stream<void> get sessionResets => _sessionResetController.stream;
 
+  /// Whether a session is currently active: microphone capture is running
+  /// and the decode worker is loaded.
   bool get isRunning => _micSubscription != null;
 
   /// Whether [startDebugWavStream] is currently paced-streaming a wav file
@@ -369,7 +377,7 @@ class LiveTranscriber {
   /// Total audio currently buffered for the next refine pass, in seconds.
   double get refineBufferedSeconds => _refineBuffer.totalDurationSeconds;
 
-  /// Whether auto-refine (silence-triggered, see [refine_pass.dart]) is on.
+  /// Whether auto-refine (silence-triggered, see `refine_pass.dart`) is on.
   /// Defaults to off: on a phone every refine is a full re-decode burning
   /// battery and generating heat, so firing it automatically is opt-in —
   /// the manual "清書" button always works regardless of this setting.

--- a/mobile/hayamimi_core/lib/live/live_transcriber.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcriber.dart
@@ -43,6 +43,13 @@ const _autoRefineCheckInterval = Duration(seconds: 1);
 /// close.
 const _decodeDrainTimeout = Duration(seconds: 10);
 
+/// The least audio a refine ("清書") pass is worth running over, in
+/// seconds. Mirrors the desktop `Refiner`'s own `len(buf) < sr // 2`
+/// guard: re-decoding a fraction of a second of speech as a "group" costs
+/// a full decode and cannot produce a better result than the final that
+/// already covered it.
+const _minRefineAudioSeconds = 0.5;
+
 /// Builds the real, isolate-backed decode worker. Swapped out only by
 /// tests (see [LiveTranscriber]'s `decodeWorkerFactory`).
 DecodeWorker _spawnDecodeWorker() => IsolateDecodeWorker();
@@ -445,7 +452,7 @@ class LiveTranscriber {
     if (!value) {
       _autoRefineTimer?.cancel();
       _autoRefineTimer = null;
-    } else if (isRunning) {
+    } else if (isRunning || _debugStreaming) {
       _startAutoRefineTimer();
     }
   }
@@ -1069,7 +1076,7 @@ class LiveTranscriber {
     }
     final segments = _refineBuffer.takeAll();
     final combined = combineSegmentSamples(segments);
-    if (combined.length < sampleRate ~/ 2) {
+    if (combined.length < sampleRate * _minRefineAudioSeconds) {
       return null;
     }
     return RefineRequestPayload(
@@ -1475,9 +1482,28 @@ class LiveTranscriber {
   /// [realtime] paces delivery to roughly the wav's own duration (one VAD
   /// window's worth of audio every ~32ms at 16kHz); pass `false` to stream
   /// as fast as decoding allows instead, e.g. for a quick smoke test.
-  /// Awaits until the whole file has been fed through and any in-progress
-  /// segment has been flushed and decoded -- same shutdown behavior [stop]
-  /// gives a live session.
+  ///
+  /// **What "awaits until done" covers.** The whole file is fed through,
+  /// any in-progress segment is flushed and decoded, and then -- unlike
+  /// [stop], which drops whatever was buffered -- one last refine ("清書")
+  /// pass runs over the finals this stream produced, provided they add up
+  /// to at least half a second of audio. That refine is awaited before the
+  /// session is torn down, so by the time this future completes,
+  /// [refineEntries] has already carried it.
+  ///
+  /// That closing refine is deliberate, and it is the difference between
+  /// this method and [start]. The session is gone before the future
+  /// resolves (the same teardown [stop] performs), so a caller who awaits
+  /// this and *then* calls [refineNow] gets nothing: there is no longer a
+  /// worker to run it. Without the closing pass, a default-configured debug
+  /// stream would produce no refine at all -- which is the one thing this
+  /// method exists to demonstrate on a device with no usable microphone.
+  ///
+  /// [autoRefineEnabled] also works here, not only for microphone
+  /// sessions: set it to `true` before calling this and refines fire on
+  /// silence gaps during the stream, the same way they would live. Setting
+  /// it while a stream is already running works too.
+  ///
   /// See [start] for what [decodingMethod]/[vadSensitivity]/[hotwordsFile]/
   /// [hotwordsScore]/[punctuation] do -- identical meaning and defaults
   /// here, which is what makes this the way to see punctuated refine output
@@ -1609,10 +1635,28 @@ class LiveTranscriber {
       if (!_debugStreamCancelRequested) {
         _vad?.flush();
         _drainReadySegments();
+        await _waitForDecodesToDrain();
+        // The whole point of this method is to show what a live session
+        // produces, and on a device without a microphone it is the only
+        // way to see a punctuated refine at all. Teardown below ends the
+        // session before this future completes, so a caller cannot ask for
+        // one afterwards -- refineNow() would find no worker and silently
+        // do nothing. So run the last one here, while there is still a
+        // session to run it in, over everything the finals just buffered.
+        if (_refineBuffer.totalDurationSeconds >= _minRefineAudioSeconds) {
+          await refineNow();
+        }
+      } else {
+        await _waitForDecodesToDrain();
       }
-      await _waitForDecodesToDrain();
     } finally {
       _debugStreaming = false;
+      // Started by _resetSessionState above when autoRefineEnabled was
+      // already on. Nothing else cancels it on this path -- stop() only
+      // ends a microphone session -- so without this it would keep ticking
+      // against a torn-down session for the life of the object.
+      _autoRefineTimer?.cancel();
+      _autoRefineTimer = null;
       await _teardownNativeState();
     }
   }

--- a/mobile/hayamimi_core/lib/live/live_transcriber.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcriber.dart
@@ -367,6 +367,12 @@ class LiveTranscriber {
       _requirePositive(value, 'refineBufferMaxSeconds');
 
   /// Finalized transcript lines, one per detected speech segment.
+  ///
+  /// When [start] was given a `punctuation` model, a line here can carry
+  /// 、 。 ？ the recognizer never produced, and says so through
+  /// [LiveTranscriptEntry.punctuated] — see `JaPunctuation.applyToFinals`,
+  /// which turns that off for this stream while leaving [refineEntries]
+  /// punctuated.
   Stream<LiveTranscriptEntry> get entries => _entriesController.stream;
 
   /// Emits `true` when the decode worker has work outstanding and `false`
@@ -382,10 +388,11 @@ class LiveTranscriber {
   /// pass, each covering everything buffered since the previous refine (or
   /// since the session started).
   ///
-  /// This is the only stream Japanese punctuation restoration touches: when
-  /// [start] was given a `punctuation` model, an entry here can carry 、 。
-  /// ？ that the recognizer never produced, and says so through
-  /// [LiveTranscriptEntry.punctuated].
+  /// When [start] was given a `punctuation` model, an entry here carries
+  /// 、 。 ？ that the recognizer never produced, and says so through
+  /// [LiveTranscriptEntry.punctuated] — including when the pass falls back
+  /// to the finals' own text, since those are punctuated too unless
+  /// `JaPunctuation.applyToFinals` said not to.
   Stream<LiveTranscriptEntry> get refineEntries => _refineEntriesController.stream;
 
   /// In-progress ("draft") decodes: one per draft re-decode while a VAD
@@ -501,18 +508,19 @@ class LiveTranscriber {
   /// fresh [start] (or [stop] + [start]).
   ///
   /// [punctuation] turns on Japanese punctuation restoration for this
-  /// session's refine ("清書") results: the recognizer emits a bare run of
-  /// characters, and the model named here puts 、 and 。 (and ？ after a
-  /// question ending) back into it, the way the desktop pipeline's
-  /// `scripts/punct_ja.py` does. `null` (the
-  /// default) leaves it off, which is what this method did before the
+  /// session: the recognizer emits a bare run of characters, and the model
+  /// named here puts 、 and 。 (and ？ after a question ending) back into
+  /// it, the way the desktop pipeline's `scripts/punct_ja.py` does. `null`
+  /// (the default) leaves it off, which is what this method did before the
   /// parameter existed. What changes when it is set:
   ///
-  ///  * only [refineEntries] is affected — [entries] and [drafts] carry the
-  ///    recognizer's text unchanged (see `decode_worker.dart` for why);
-  ///  * a routed session punctuates the refines that came back as Japanese
-  ///    and leaves the rest alone; a plain session punctuates every refine,
-  ///    so **only pass this to a plain session whose model is Japanese**;
+  ///  * [refineEntries] and [entries] are affected; [drafts] carry the
+  ///    recognizer's text unchanged (see `decode_worker.dart` for why).
+  ///    `JaPunctuation.applyToFinals: false` narrows this back to
+  ///    [refineEntries] alone;
+  ///  * a routed session punctuates what came back as Japanese and leaves
+  ///    the rest alone; a plain session punctuates everything, so **only
+  ///    pass this to a plain session whose model is Japanese**;
   ///  * each affected entry carries [LiveTranscriptEntry.punctuated];
   ///  * the model is loaded in the decode worker, after the recognizers,
   ///    and reported on [modelLoads] as `model: 'punct'`. It is another
@@ -735,10 +743,11 @@ class LiveTranscriber {
           punctVocabPath: punctuation?.vocabPath,
           punctLibraryPath: punctuation?.libraryPath,
           punctNumThreads: punctuation?.numThreads ?? defaultPunctNumThreads,
-          // Left at the default (true): for a plain single-model session
-          // there is no language tag to test, and passing a Japanese
-          // punctuation model to one is itself the statement that its model
-          // transcribes Japanese. See
+          punctuateFinals: punctuation?.applyToFinals ?? true,
+          // punctuatePlainSession is left at the default (true): for a plain
+          // single-model session there is no language tag to test, and
+          // passing a Japanese punctuation model to one is itself the
+          // statement that its model transcribes Japanese. See
           // DecodeWorkerConfig.punctuatePlainSession.
         ),
         buildRefinePayload: () => _buildRefinePayload(generation),
@@ -992,12 +1001,21 @@ class LiveTranscriber {
           lang: result.lang,
           audioSeconds: samples.length / sampleRate,
           switched: result.switched,
+          punctuated: result.punctuated,
         ),
       );
     }
     _lastSegmentAt = now;
+    // The buffered text is the punctuated one when the worker punctuated it,
+    // because this is what a refine falls back to when its merged re-decode
+    // is rejected -- see _onRefineDecoded.
     _refineBuffer.add(
-      RefineSegment(samples: samples, text: text, capturedAt: now),
+      RefineSegment(
+        samples: samples,
+        text: text,
+        capturedAt: now,
+        punctuated: result.punctuated,
+      ),
     );
   }
 
@@ -1028,19 +1046,22 @@ class LiveTranscriber {
     // shorter than the fast finals combined, trust those instead (mirrors
     // scripts/realtime_transcribe.py's Refiner).
     //
-    // The length compared is the text WITHOUT the marks the punctuation
-    // model wrote: it runs in the worker, before this, so by here a
-    // punctuated refine is several characters longer than what was actually
-    // said, and crediting it for those would let a truncated re-decode pass
-    // a check it should fail. The fast text it is compared against is never
-    // punctuated (only refines are), so only this side is stripped.
+    // The lengths compared are WITHOUT the marks the punctuation model
+    // wrote: it runs in the worker, before this, so by here a punctuated
+    // text is several characters longer than what was actually said, and
+    // crediting either side for those would tilt a comparison that is meant
+    // to be about words. Both sides can be punctuated now that finals are
+    // too, so each is stripped when it says it is.
     if (isRefineTextTooShort(
       punctuated ? withoutRestoredMarks(text) : text,
-      payload.fastText,
+      payload.fastTextPunctuated
+          ? withoutRestoredMarks(payload.fastText)
+          : payload.fastText,
     )) {
       text = payload.fastText;
-      // The fallback is the finals' own text, which no model punctuated.
-      punctuated = false;
+      // The fallback is the finals' own text, so it is punctuated exactly
+      // when they were.
+      punctuated = payload.fastTextPunctuated;
     }
     if (text.isEmpty) {
       return;
@@ -1082,6 +1103,7 @@ class LiveTranscriber {
     return RefineRequestPayload(
       samples: combined,
       fastText: combineSegmentFastText(segments),
+      fastTextPunctuated: isCombinedFastTextPunctuated(segments),
     );
   }
 

--- a/mobile/hayamimi_core/lib/live/live_transcriber.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcriber.dart
@@ -21,6 +21,7 @@ import 'live_vad.dart';
 import 'model_load_event.dart';
 import 'native_model_loader.dart';
 import 'pcm_frame_buffer.dart';
+import 'preroll.dart';
 import 'refine_pass.dart';
 import 'speech_segment_filter.dart';
 import 'vad_sensitivity.dart';
@@ -65,8 +66,9 @@ class LiveTranscriberException implements Exception {
 /// This class owns the mic stream, the native VAD/recognizer handles, and
 /// the glue between them, so it isn't unit-testable on its own (it needs a
 /// real device/emulator mic and the sherpa-onnx native libs). The pure
-/// pieces it's built from — [pcm16BytesToFloat32], [PcmFrameBuffer], and
-/// [isSegmentWorthDecoding] — are unit tested separately.
+/// pieces it's built from — [pcm16BytesToFloat32], [PcmFrameBuffer],
+/// [isSegmentWorthDecoding] and [PrerollHistory] — are unit tested
+/// separately.
 ///
 /// Threading: neither model loading nor decoding runs on the caller's
 /// isolate. Loading happens on short-lived background isolates (see
@@ -87,6 +89,10 @@ class LiveTranscriber {
   /// unchanged. All six must be positive and finite; an out-of-range value
   /// throws [ArgumentError] here (and from the property setters) rather
   /// than silently misbehaving mid-session.
+  ///
+  /// [prerollSeconds] (see `preroll.dart`) is the seventh knob and the one
+  /// exception to that rule: it may be 0, which turns pre-roll off, and
+  /// only a negative or non-finite value throws.
   ///
   /// Validation runs before [recorder] is defaulted to a fresh
   /// `AudioRecorder()` (Dart evaluates an initializer list left to right):
@@ -112,7 +118,12 @@ class LiveTranscriber {
     double autoRefineSilenceSeconds = defaultAutoRefineSilenceSeconds,
     double autoRefineMaxBufferedSeconds = defaultAutoRefineMaxBufferedSeconds,
     double refineBufferMaxSeconds = defaultRefineBufferMaxSeconds,
-  }) : _draftIntervalSeconds = _requirePositive(
+    double prerollSeconds = defaultPrerollSeconds,
+  }) : _prerollSeconds = _requireNonNegative(
+         prerollSeconds,
+         'prerollSeconds',
+       ),
+       _draftIntervalSeconds = _requirePositive(
          draftIntervalSeconds,
          'draftIntervalSeconds',
        ),
@@ -154,6 +165,19 @@ class LiveTranscriber {
     return value;
   }
 
+  /// Same as [_requirePositive] but allows zero, for [prerollSeconds]: zero
+  /// is the meaningful "no pre-roll at all" setting, not a mistake.
+  static double _requireNonNegative(double value, String name) {
+    if (!value.isFinite || value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be a non-negative, finite number',
+      );
+    }
+    return value;
+  }
+
   final AudioRecorder _recorder;
   final DecodeWorker Function() _decodeWorkerFactory;
   final LiveVadFactory _vadFactory;
@@ -168,6 +192,18 @@ class LiveTranscriber {
   final _sessionResetController = StreamController<void>.broadcast();
 
   LiveVad? _vad;
+  // The audio a segment's pre-roll is taken from: every frame fed to the
+  // VAD is also pushed here, so a segment can be extended backwards past
+  // the onset the VAD reported (see preroll.dart for why that is needed).
+  // Built alongside the VAD, dropped with it.
+  PrerollHistory? _prerollHistory;
+  // How much audio this session has fed its VAD(s) in total, and how much
+  // it had fed when the CURRENT VAD instance was installed. A VAD counts
+  // samples from its own first frame, so a mid-session sensitivity swap
+  // resets that count to zero; adding the origin back is what keeps
+  // segment positions on one continuous session clock.
+  int _samplesFedToVad = 0;
+  int _vadSampleOrigin = 0;
   // The worker isolate that owns this session's recognizer(s), and the
   // queue in front of it. Null between sessions; built by
   // _buildNativeState, shut down by _teardownNativeState.
@@ -229,6 +265,7 @@ class LiveTranscriber {
   double _minDraftAudioSeconds;
   double _autoRefineSilenceSeconds;
   double _autoRefineMaxBufferedSeconds;
+  double _prerollSeconds;
   bool _debugStreaming = false;
   bool _debugStreamCancelRequested = false;
   // Set synchronously by [start]/[startDebugWavStream] before their first
@@ -293,6 +330,26 @@ class LiveTranscriber {
         value,
         'autoRefineMaxBufferedSeconds',
       );
+
+  /// How much audio from before a segment's detected onset is prepended to
+  /// it before decoding, in seconds. Defaults to [defaultPrerollSeconds].
+  ///
+  /// Silero VAD reports a speech onset slightly late, so the samples it
+  /// hands over can start partway into the first word and the recognizer
+  /// then transcribes that word wrong (`資料は` came back as `昨日は` on the
+  /// Android emulator). Prepending the audio recorded just before the
+  /// onset gives the recognizer the run-up it needs. That audio counts as
+  /// part of the segment: it is what gets decoded, what
+  /// [LiveTranscriptEntry.audioSeconds] reports, and what the refine
+  /// ("清書") buffer stores.
+  ///
+  /// Runtime-settable, applying from the next segment onward, without
+  /// touching any native model. Unlike the other knobs, `0` is allowed and
+  /// means "no pre-roll", i.e. decode exactly what the VAD delimited;
+  /// negative or non-finite values throw [ArgumentError].
+  double get prerollSeconds => _prerollSeconds;
+  set prerollSeconds(double value) =>
+      _prerollSeconds = _requireNonNegative(value, 'prerollSeconds');
 
   /// Hard cap (seconds) on how much audio the refine buffer holds before it
   /// starts dropping the oldest segment. Defaults to
@@ -735,6 +792,9 @@ class LiveTranscriber {
       ms: vadStopwatch.elapsedMicroseconds / 1000,
     );
     _frameBuffer = PcmFrameBuffer(frameSize: vad.frameSize);
+    _prerollHistory = PrerollHistory(sampleRate: sampleRate);
+    _samplesFedToVad = 0;
+    _vadSampleOrigin = 0;
   }
 
   void _emitModelLoad({
@@ -803,6 +863,11 @@ class LiveTranscriber {
     if (vad == null) {
       return;
     }
+    // Recorded before the VAD sees it, on the same clock the VAD counts
+    // on, so a segment the VAD reports can be extended backwards into the
+    // audio that preceded it.
+    _prerollHistory?.push(frame);
+    _samplesFedToVad += frame.length;
     vad.acceptWaveform(frame);
 
     // Accumulate this VAD window for the draft pass while a segment is in
@@ -849,24 +914,53 @@ class LiveTranscriber {
       return;
     }
     while (vad.hasSegment) {
-      final samples = vad.takeSegment();
+      final segment = vad.takeSegment();
       // The segment just taken supersedes whatever the draft pass had
       // accumulated for it -- the real (properly routed/decoded) final is
       // about to replace any draft the UI was showing.
       _clearDraftFrames();
       _draftSegmentActive = false;
-      _decodeSegment(samples);
+      _decodeSegment(segment);
     }
   }
 
-  void _decodeSegment(Float32List samples) {
-    if (!isSegmentWorthDecoding(samples, sampleRate: sampleRate)) {
+  void _decodeSegment(LiveSpeechSegment segment) {
+    // Judged on what the VAD actually delimited, before any pre-roll is
+    // added: pre-roll is context, not speech, and letting a second of it
+    // pad a 0.1s blip past the minimum would send near-silence to the
+    // recognizer for no reason.
+    final worthDecoding = isSegmentWorthDecoding(
+      segment.samples,
+      sampleRate: sampleRate,
+    );
+    // Extended even when the segment is about to be dropped, because this
+    // call is also what moves the history's "do not reach back past here"
+    // marker: skipping it would let the NEXT segment's pre-roll cover this
+    // one's audio. Same order the desktop pipeline's drain_segments uses.
+    final samples = _withPreroll(segment);
+    if (!worthDecoding) {
       return;
     }
     // Queued at the worker, never dropped, and answered in the order the
     // segments closed -- so the transcript keeps the order the speaker
     // said things in even when several segments finish back to back.
     _decode?.submitFinal(samples);
+  }
+
+  /// Gives [segment] the audio recorded just before the VAD noticed it,
+  /// which is what stops an utterance-initial word being clipped (see
+  /// `preroll.dart`). Returns the segment's own samples unchanged when
+  /// [prerollSeconds] is 0, or when there is no history to draw on.
+  Float32List _withPreroll(LiveSpeechSegment segment) {
+    final history = _prerollHistory;
+    if (history == null) {
+      return segment.samples;
+    }
+    return history.withPreroll(
+      segmentStartSample: _vadSampleOrigin + segment.startSample,
+      samples: segment.samples,
+      prerollSeconds: _prerollSeconds,
+    );
   }
 
   /// Turns one finished segment's decode into a transcript line and files
@@ -1171,6 +1265,7 @@ class LiveTranscriber {
     // safe swap point.
     _pendingVadInstall?.free();
     _pendingVadInstall = null;
+    _prerollHistory = null;
     _vadModelPath = null;
     // The decode worker owns this session's recognizer handles and is the
     // only isolate allowed to free them, so ending the session means
@@ -1337,6 +1432,11 @@ class LiveTranscriber {
     _pendingVadInstall = null;
     final old = _vad;
     _vad = pending;
+    // The replacement has been fed nothing yet, so its own sample counter
+    // starts at zero here. Remembering where "here" falls on the session
+    // clock keeps segment positions -- and therefore pre-roll -- correct
+    // across the swap.
+    _vadSampleOrigin = _samplesFedToVad;
     old?.free();
   }
 

--- a/mobile/hayamimi_core/lib/live/live_transcriber.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcriber.dart
@@ -481,10 +481,10 @@ class LiveTranscriber {
   ///
   /// [vadSensitivity] configures Silero VAD's speech/silence detection
   /// (threshold, minimum silence/speech durations, max segment duration —
-  /// see [VadSensitivity]); `null` (the default) uses sherpa-onnx's own
-  /// defaults, same as before this parameter existed. Change it after
-  /// [start] via [setVadSensitivity] instead of stopping and restarting the
-  /// session.
+  /// see [VadSensitivity], whose defaults are the desktop pipeline's tuned
+  /// values rather than sherpa-onnx's stock ones, and which explains why).
+  /// `null` (the default) uses those defaults. Change it after [start] via
+  /// [setVadSensitivity] instead of stopping and restarting the session.
   ///
   /// [hotwordsFile]/[hotwordsScore] bias the recognizer toward a wordlist
   /// (sherpa-onnx's own hotwords feature) on the plain path and the routed

--- a/mobile/hayamimi_core/lib/live/live_transcript_entry.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcript_entry.dart
@@ -43,10 +43,15 @@ class LiveTranscriptEntry {
   /// wrote from text the recognizer produced — e.g. to skip its own
   /// sentence splitting, or to show that this line is the finished one.
   ///
-  /// Only refine ("清書") entries can be `true`, and only when the session
-  /// was started with a `JaPunctuation` model that applies to the entry's
-  /// language. Always `false` for finals and drafts, and `false` again for
-  /// a refine that fell back to the fast finals' text because the merged
-  /// re-decode came back too short (that fallback text is unpunctuated).
+  /// Refine ("清書") and final entries can be `true`, and only when the
+  /// session was started with a `JaPunctuation` model that applies to the
+  /// entry's language. Always `false` for drafts, which are re-decoded every
+  /// second and never punctuated, and `false` for finals when that
+  /// `JaPunctuation` set `applyToFinals: false`.
+  ///
+  /// A refine that fell back to the fast finals' text — because the merged
+  /// re-decode came back too short — reports whatever those finals were:
+  /// `true` in the default configuration, `false` when finals were left
+  /// unpunctuated, since the text that survived is theirs.
   final bool punctuated;
 }

--- a/mobile/hayamimi_core/lib/live/live_transcript_entry.dart
+++ b/mobile/hayamimi_core/lib/live/live_transcript_entry.dart
@@ -8,6 +8,7 @@ class LiveTranscriptEntry {
     this.lang,
     this.audioSeconds,
     this.switched = false,
+    this.punctuated = false,
   });
 
   final String text;
@@ -36,4 +37,16 @@ class LiveTranscriptEntry {
   /// entries, which re-judge a whole group rather than a single switch
   /// point.
   final bool switched;
+
+  /// `true` when this entry's text had Japanese punctuation (、 。 ？)
+  /// restored into it, so a caller can tell text the punctuation model
+  /// wrote from text the recognizer produced — e.g. to skip its own
+  /// sentence splitting, or to show that this line is the finished one.
+  ///
+  /// Only refine ("清書") entries can be `true`, and only when the session
+  /// was started with a `JaPunctuation` model that applies to the entry's
+  /// language. Always `false` for finals and drafts, and `false` again for
+  /// a refine that fell back to the fast finals' text because the merged
+  /// re-decode came back too short (that fallback text is unpunctuated).
+  final bool punctuated;
 }

--- a/mobile/hayamimi_core/lib/live/live_vad.dart
+++ b/mobile/hayamimi_core/lib/live/live_vad.dart
@@ -28,6 +28,34 @@ import 'vad_sensitivity.dart';
 /// the ring never truncates a segment that is still being spoken.
 const double _vadBufferSeconds = 30;
 
+/// One finished speech segment, as a session takes it from its VAD.
+///
+/// This used to be just the samples. It carries where the segment starts as
+/// well because the samples alone are not enough to decode well: a VAD
+/// reports an onset slightly late, so the first word can be clipped, and
+/// repairing that means going back to the audio recorded just before the
+/// segment (see `preroll.dart`). Knowing where "just before" is, on a clock
+/// shared with the audio the session captured, is what [startSample]
+/// provides.
+class LiveSpeechSegment {
+  const LiveSpeechSegment({required this.samples, required this.startSample});
+
+  /// The segment's audio: 16 kHz mono float samples, exactly the speech the
+  /// VAD delimited, with nothing added.
+  final Float32List samples;
+
+  /// Where the segment begins, counted in samples from the first sample
+  /// ever fed to *this VAD instance* -- sherpa-onnx's own
+  /// `SpeechSegment.start`.
+  ///
+  /// Per instance, not per session: a session that changes its VAD
+  /// sensitivity mid-flight swaps in a freshly built VAD, whose counter
+  /// starts again at zero. `LiveTranscriber` keeps track of how much audio
+  /// it had already fed when it swapped and adds that back, so the position
+  /// it works with stays on one continuous session clock.
+  final int startSample;
+}
+
 /// A voice-activity detector driving one live session.
 ///
 /// Stateful across [acceptWaveform] calls: the implementation is tracking
@@ -49,8 +77,8 @@ abstract class LiveVad {
   /// Whether at least one finished segment is waiting to be taken.
   bool get hasSegment;
 
-  /// Removes and returns the oldest finished segment's samples.
-  Float32List takeSegment();
+  /// Removes and returns the oldest finished segment.
+  LiveSpeechSegment takeSegment();
 
   /// Ends any segment in progress and makes it available to [takeSegment],
   /// so stopping does not silently drop what the speaker had just said.
@@ -129,10 +157,13 @@ class SileroLiveVad implements LiveVad {
   bool get hasSegment => !_vad.isEmpty();
 
   @override
-  Float32List takeSegment() {
+  LiveSpeechSegment takeSegment() {
     final segment = _vad.front();
     _vad.pop();
-    return segment.samples;
+    return LiveSpeechSegment(
+      samples: segment.samples,
+      startSample: segment.start,
+    );
   }
 
   @override

--- a/mobile/hayamimi_core/lib/live/model_load_event.dart
+++ b/mobile/hayamimi_core/lib/live/model_load_event.dart
@@ -13,8 +13,10 @@ class ModelLoadEvent {
 
   /// Which native model this phase is about: `"vad"` (both the initial
   /// build and any [LiveTranscriber.setVadSensitivity] rebuild),
-  /// `"recognizer"` (the plain, non-routed path's single model), or for
-  /// [RoutingProfile.jaSenseVoice]: `"ja"`, `"sensevoice"`, `"lid"`.
+  /// `"recognizer"` (the plain, non-routed path's single model), for
+  /// [RoutingProfile.jaSenseVoice]: `"ja"`, `"sensevoice"`, `"lid"`, and
+  /// `"punct"` (the Japanese punctuation model, when `start` was given a
+  /// `JaPunctuation` — it loads last, after the recognizers).
   final String model;
 
   /// `"start"` right before the background-isolate build call, `"done"`

--- a/mobile/hayamimi_core/lib/live/model_load_event.dart
+++ b/mobile/hayamimi_core/lib/live/model_load_event.dart
@@ -16,7 +16,12 @@ class ModelLoadEvent {
   /// `"recognizer"` (the plain, non-routed path's single model), for
   /// [RoutingProfile.jaSenseVoice]: `"ja"`, `"sensevoice"`, `"lid"`, and
   /// `"punct"` (the Japanese punctuation model, when `start` was given a
-  /// `JaPunctuation` — it loads last, after the recognizers).
+  /// `JaPunctuation` — it loads last, after the recognizers). `"punct"`'s
+  /// `ms` on `"done"` includes one warm-up inference run right after the
+  /// model loads, so the model's first real `restore()` call in this
+  /// process is fast: without it, the ~300 ms a cold ONNX Runtime session
+  /// pays on its first run would land on the first punctuated final or
+  /// refine instead of here.
   final String model;
 
   /// `"start"` right before the background-isolate build call, `"done"`

--- a/mobile/hayamimi_core/lib/live/preroll.dart
+++ b/mobile/hayamimi_core/lib/live/preroll.dart
@@ -1,0 +1,192 @@
+/// Pure logic for "pre-roll": prepending a moment of the audio that came
+/// *before* a speech segment's detected onset to that segment, so the
+/// recognizer sees the run-up to the first word instead of starting
+/// mid-word.
+///
+/// **The problem.** Silero VAD (the model that decides "is this speech or
+/// silence") reports a speech onset slightly after the speaker actually
+/// started, so the samples it hands over can begin partway into the first
+/// word. On the Android emulator run recorded in
+/// `docs/MOBILE.md`, `資料は昨日送りました` came back from the recognizer as
+/// `昨日は昨日送りました` and `あしたの会議は十時からです` lost its `あしたの`
+/// entirely — both utterance-initial words, both clipped by the onset.
+///
+/// **The fix, and where it comes from.** The desktop pipeline has kept a
+/// rolling buffer of recent audio since long before this package existed
+/// (`AudioHistory` / `PREROLL_S` in `scripts/realtime_transcribe.py`) and
+/// prepends up to one second of it to every segment it decodes; its
+/// `tests/test_asr_segment.py` pins the behaviour on the same fixture that
+/// regressed above. This file is that idea in Dart.
+///
+/// Everything here is plain data/logic with no FFI or platform dependency,
+/// so it is unit tested directly (`test/preroll_test.dart`). The glue that
+/// feeds it live microphone frames and hands the extended segment to the
+/// decode worker lives in `live_transcriber.dart`.
+library;
+
+import 'dart:collection';
+import 'dart:typed_data';
+
+/// How much audio from before a segment's detected onset is prepended to
+/// it, in seconds, unless a caller says otherwise.
+///
+/// One second, the same value the desktop pipeline's `PREROLL_S` uses. It
+/// is generous next to the onset lag it compensates for (a couple of
+/// hundred milliseconds), and being generous is cheap: the extra audio is
+/// silence or room tone the recognizer transcribes to nothing.
+const double defaultPrerollSeconds = 1.0;
+
+/// How much recent audio [PrerollHistory] keeps by default, in seconds.
+///
+/// Only the trailing [defaultPrerollSeconds] is ever read, so this is
+/// mostly headroom; it is sized to match the native VAD's own internal
+/// buffer (see `_vadBufferSeconds` in `live_vad.dart`) so a segment the
+/// VAD can still produce is one this history can still find context for.
+/// At 16 kHz mono float samples, 30 s is under 2 MB.
+const double defaultPrerollKeepSeconds = 30.0;
+
+/// A bounded rolling buffer of the most recently captured audio, able to
+/// hand back a finished speech segment with its run-up attached.
+///
+/// A session pushes every frame it feeds the VAD into one of these
+/// ([push]), then asks for the extended segment when the VAD finalizes one
+/// ([withPreroll]). Sample positions are absolute: sample 0 is the first
+/// frame ever pushed, and the buffer remembers how many samples it has
+/// dropped off the front, so a position stays meaningful after old audio
+/// has aged out.
+///
+/// Two rules keep the extra audio honest, both inherited from the desktop
+/// implementation this mirrors:
+///
+///  * never reach back past what the buffer still holds, and
+///  * never reach back into the previous segment. Two utterances a
+///    half-second apart would otherwise both contain that half second, the
+///    refine ("清書") pass would re-decode it twice, and a word spoken in
+///    the gap could be transcribed into both lines.
+class PrerollHistory {
+  PrerollHistory({
+    this.sampleRate = 16000,
+    this.keepSeconds = defaultPrerollKeepSeconds,
+  });
+
+  /// The rate the pushed audio was captured at, in Hz. Only used to turn
+  /// the seconds-valued knobs into sample counts.
+  final int sampleRate;
+
+  /// How much audio this keeps before dropping the oldest, in seconds.
+  final double keepSeconds;
+
+  // Frames as pushed, oldest first. Kept as separate lists rather than one
+  // growing buffer: concatenating on every frame would copy the whole
+  // history ~31 times a second, whereas a segment only needs the frames
+  // its pre-roll actually spans, once, when it closes.
+  final Queue<Float32List> _frames = Queue<Float32List>();
+  int _bufferedSamples = 0;
+  int _offset = 0;
+  int _lastSegmentEnd = 0;
+
+  /// Absolute index of the oldest sample still held: everything before it
+  /// has been dropped and can no longer be prepended to anything.
+  int get offset => _offset;
+
+  /// How many samples are currently held.
+  int get bufferedSamples => _bufferedSamples;
+
+  /// Absolute index just past the end of the last segment [withPreroll]
+  /// was called for -- the line no later pre-roll is allowed to cross.
+  int get lastSegmentEnd => _lastSegmentEnd;
+
+  /// Records one frame of captured audio, then drops whole frames off the
+  /// front until the buffer is back within [keepSeconds].
+  ///
+  /// A frame is only dropped while what remains still covers the keep
+  /// window, so this holds between [keepSeconds] and [keepSeconds] plus one
+  /// frame -- never less than it promised, and never unbounded.
+  void push(Float32List frame) {
+    if (frame.isEmpty) {
+      return;
+    }
+    _frames.add(frame);
+    _bufferedSamples += frame.length;
+    final keep = (keepSeconds * sampleRate).round();
+    while (_frames.isNotEmpty &&
+        _bufferedSamples - _frames.first.length >= keep) {
+      final dropped = _frames.removeFirst();
+      _bufferedSamples -= dropped.length;
+      _offset += dropped.length;
+    }
+  }
+
+  /// Returns [samples] with up to [prerollSeconds] of the audio recorded
+  /// immediately before [segmentStartSample] prepended to it.
+  ///
+  /// [segmentStartSample] is where the VAD says the segment began, counted
+  /// in samples from the start of the session (the same clock [push] feeds).
+  /// The returned audio is what should actually be decoded and buffered for
+  /// a later refine pass, so a final's reported duration covers the pre-roll
+  /// too.
+  ///
+  /// Returns [samples] unchanged when there is nothing to prepend: an empty
+  /// history, a segment that starts where the previous one ended, or
+  /// `prerollSeconds: 0`, which is how a caller turns pre-roll off.
+  ///
+  /// Calling this also moves [lastSegmentEnd] past the segment, which is
+  /// what stops the *next* call reaching back into it. Call it once per
+  /// segment the VAD produces, in order, including for segments that are
+  /// then dropped without being decoded -- skipping one would let the next
+  /// segment's pre-roll cover audio this one already accounted for.
+  Float32List withPreroll({
+    required int segmentStartSample,
+    required Float32List samples,
+    double prerollSeconds = defaultPrerollSeconds,
+  }) {
+    final end = _clamp(segmentStartSample);
+    var start = segmentStartSample - (prerollSeconds * sampleRate).round();
+    if (start < _lastSegmentEnd) {
+      start = _lastSegmentEnd;
+    }
+    start = _clamp(start);
+    _lastSegmentEnd = segmentStartSample + samples.length;
+    if (start >= end) {
+      return samples;
+    }
+    final preroll = _read(start, end);
+    final extended = Float32List(preroll.length + samples.length);
+    extended.setRange(0, preroll.length, preroll);
+    extended.setRange(preroll.length, extended.length, samples);
+    return extended;
+  }
+
+  /// Pins an absolute sample position inside the audio still held, so a
+  /// position from before the buffer slid (or from beyond what has been
+  /// pushed, which a stand-in VAD in a test can report) reads as "nothing
+  /// there" instead of throwing.
+  int _clamp(int index) {
+    final oldest = _offset;
+    final newest = _offset + _bufferedSamples;
+    if (index < oldest) return oldest;
+    if (index > newest) return newest;
+    return index;
+  }
+
+  /// Copies the absolute range [start], [end) out of the held frames.
+  Float32List _read(int start, int end) {
+    final out = Float32List(end - start);
+    var framePosition = _offset;
+    var written = 0;
+    for (final frame in _frames) {
+      final frameEnd = framePosition + frame.length;
+      if (frameEnd > start && framePosition < end) {
+        final from = start > framePosition ? start - framePosition : 0;
+        final to = end < frameEnd ? end - framePosition : frame.length;
+        out.setRange(written, written + (to - from), frame, from);
+        written += to - from;
+      }
+      framePosition = frameEnd;
+      if (framePosition >= end) {
+        break;
+      }
+    }
+    return out;
+  }
+}

--- a/mobile/hayamimi_core/lib/live/refine_pass.dart
+++ b/mobile/hayamimi_core/lib/live/refine_pass.dart
@@ -28,11 +28,19 @@ class RefineSegment {
     required this.samples,
     required this.text,
     required this.capturedAt,
+    this.punctuated = false,
   });
 
   final Float32List samples;
   final String text;
   final DateTime capturedAt;
+
+  /// Whether [text] already had Japanese punctuation restored into it when
+  /// the final was produced (see `JaPunctuation.applyToFinals`). It matters
+  /// here because [text] is what a refine falls back to when its merged
+  /// re-decode is rejected, and the fallback can only claim to be
+  /// punctuated if the text it is made of was.
+  final bool punctuated;
 
   double durationSeconds(int sampleRate) => samples.length / sampleRate;
 }
@@ -117,6 +125,21 @@ String combineSegmentFastText(List<RefineSegment> segments) {
       .join(' ');
 }
 
+/// Whether [combineSegmentFastText]'s output over [segments] is punctuated
+/// throughout — i.e. every segment that contributes a word to it was itself
+/// punctuated ([RefineSegment.punctuated]).
+///
+/// A refine that falls back to that joined text reports this as its
+/// `punctuated`. All or nothing is the honest answer for one flag over one
+/// line: a group where only some finals went through the punctuation model
+/// produces a line that is partly punctuated, which is not a line a consumer
+/// can treat as punctuated. Empty (nothing contributed any text) is `false`
+/// for the same reason.
+bool isCombinedFastTextPunctuated(List<RefineSegment> segments) {
+  final contributing = segments.where((s) => s.text.trim().isNotEmpty);
+  return contributing.isNotEmpty && contributing.every((s) => s.punctuated);
+}
+
 /// Whether a merged re-decode came back suspiciously short compared to the
 /// fast finals it's replacing, mirroring the desktop `Refiner`'s guard: "a
 /// merged re-decode must never LOSE content; if it comes back much shorter
@@ -125,9 +148,11 @@ String combineSegmentFastText(List<RefineSegment> segments) {
 /// relative-shrink check this guards (not meant as a linguistic measure).
 ///
 /// Both arguments must be equally punctuated, or the comparison is unfair:
-/// restoring 、 and 。 into a refine adds characters nobody said, so a
-/// punctuated [refineText] would be measured against unpunctuated fast text
-/// and could pass a check it should fail. Callers strip it first — see
+/// restoring 、 and 。 adds characters nobody said, and one per clause is
+/// enough to lift a genuinely truncated re-decode back over the threshold.
+/// Either side can arrive punctuated — refines always could, and finals can
+/// too (see `JaPunctuation.applyToFinals`) — so the caller strips the marks
+/// off whichever side has them before calling this; see
 /// `withoutRestoredMarks` in `punct/punct_ja_text.dart`.
 bool isRefineTextTooShort(
   String refineText,

--- a/mobile/hayamimi_core/lib/live/refine_pass.dart
+++ b/mobile/hayamimi_core/lib/live/refine_pass.dart
@@ -114,15 +114,24 @@ Float32List combineSegmentSamples(List<RefineSegment> segments) {
   return combined;
 }
 
-/// Joins segments' fast (per-segment) text with single spaces, skipping any
-/// blank ones. Used both as the refine's fallback text (see
-/// [isRefineTextTooShort]) and to show what fell out of the fast path for
-/// comparison.
+/// Joins segments' fast (per-segment) text, skipping any blank ones. Used
+/// both as the refine's fallback text (see [isRefineTextTooShort]) and to
+/// show what fell out of the fast path for comparison.
+///
+/// When every contributing segment was punctuated
+/// ([isCombinedFastTextPunctuated]), the join uses `''`: each sentence
+/// already ends in a mark like 。, and a following space is not how Japanese
+/// is set (the desktop's own refine output for the same text has none).
+/// Otherwise the join falls back to a single space, mirroring the desktop
+/// joiner for unpunctuated text (`scripts/realtime_transcribe.py`'s
+/// `" ".join(...)`), which is still the only separator available when there
+/// is no punctuation to lean on.
 String combineSegmentFastText(List<RefineSegment> segments) {
+  final separator = isCombinedFastTextPunctuated(segments) ? '' : ' ';
   return segments
       .map((s) => s.text.trim())
       .where((t) => t.isNotEmpty)
-      .join(' ');
+      .join(separator);
 }
 
 /// Whether [combineSegmentFastText]'s output over [segments] is punctuated

--- a/mobile/hayamimi_core/lib/live/refine_pass.dart
+++ b/mobile/hayamimi_core/lib/live/refine_pass.dart
@@ -4,12 +4,13 @@ import 'dart:typed_data';
 /// over several already-finalized VAD segments' audio, run together instead
 /// of one at a time, the same "re-decode with more context" trick the
 /// desktop pipeline's `Refiner` class uses (see
-/// `scripts/realtime_transcribe.py`, `GROUP_GAP_S`/`GROUP_MAX_S`). No
-/// punctuation-restoration model is added here — this is re-decode only.
+/// `scripts/realtime_transcribe.py`, `GROUP_GAP_S`/`GROUP_MAX_S`).
 ///
 /// Everything in this file is plain data/logic with no FFI or platform
 /// dependency, so it's unit tested directly. The FFI glue (actually running
-/// the recognizer over the combined audio) lives in `live_transcriber.dart`.
+/// the recognizer over the combined audio, and restoring Japanese
+/// punctuation into the result when the session asked for it) lives in
+/// `decode_worker.dart`; `live_transcriber.dart` drives both.
 
 /// Hard cap on how much audio [RefineBuffer] holds at once, in seconds.
 ///
@@ -122,6 +123,12 @@ String combineSegmentFastText(List<RefineSegment> segments) {
 /// than the fast finals combined, trust those" (scripts/realtime_transcribe.py).
 /// Length is compared in UTF-16 code units, which is good enough for the
 /// relative-shrink check this guards (not meant as a linguistic measure).
+///
+/// Both arguments must be equally punctuated, or the comparison is unfair:
+/// restoring 、 and 。 into a refine adds characters nobody said, so a
+/// punctuated [refineText] would be measured against unpunctuated fast text
+/// and could pass a check it should fail. Callers strip it first — see
+/// `withoutRestoredMarks` in `punct/punct_ja_text.dart`.
 bool isRefineTextTooShort(
   String refineText,
   String fastJoinedText, {

--- a/mobile/hayamimi_core/lib/live/vad_sensitivity.dart
+++ b/mobile/hayamimi_core/lib/live/vad_sensitivity.dart
@@ -14,15 +14,37 @@
 /// `live_transcriber.dart`.
 library;
 
-/// Silero VAD's four tunable knobs, with sherpa-onnx's own defaults as this
-/// class's defaults so passing `VadSensitivity()` reproduces today's
-/// unconfigurable behavior exactly.
+/// Silero VAD's four tunable knobs.
+///
+/// The defaults were sherpa-onnx's own (`minSilenceSeconds` 0.5,
+/// `maxSpeechSeconds` 5.0) until an Android emulator run showed what that
+/// costs. On a three-sentence Japanese recording whose pauses are just
+/// under half a second, the 0.5 s silence default merged all three
+/// sentences into one 6.13 s segment, and the recognizer given that segment
+/// returned only the last sentence -- a caption that is wrong, not merely
+/// rough, with nothing in the output to say two sentences went missing.
+/// The desktop pipeline this package is the mobile port of does not have
+/// that problem because it does not use the stock values: it runs
+/// `--min-silence 0.35` and `--max-speech 12.0`
+/// (`scripts/realtime_transcribe.py`), and its own comment records that
+/// 0.35 s measured no worse for accuracy than 0.5 s while finalizing a
+/// segment 150 ms sooner. Re-running the same audio through this package
+/// with 0.35 s split it into three segments and all three sentences came
+/// out.
+///
+/// So the two defaults here are the desktop's, not sherpa-onnx's:
+/// [minSilenceSeconds] is 0.35 and [maxSpeechSeconds] is 12.0.
+/// [threshold] and [minSpeechSeconds] are unchanged from sherpa-onnx's
+/// values, which the desktop also leaves alone. For a caller, this means
+/// segments finalize on shorter pauses than before -- more transcript
+/// lines, each of them shorter, and each decoded from audio the recognizer
+/// can actually handle. Pass explicit values to get the old behavior back.
 class VadSensitivity {
   VadSensitivity({
     this.threshold = 0.5,
-    this.minSilenceSeconds = 0.5,
+    this.minSilenceSeconds = 0.35,
     this.minSpeechSeconds = 0.25,
-    this.maxSpeechSeconds = 5.0,
+    this.maxSpeechSeconds = 12.0,
   }) {
     if (threshold <= 0 || threshold > 1 || !threshold.isFinite) {
       throw ArgumentError.value(
@@ -44,6 +66,11 @@ class VadSensitivity {
   /// How long a silence has to last before an in-progress segment is
   /// considered finished and finalized. Lower = shorter pauses split
   /// segments; higher = a speaker's brief pauses stay inside one segment.
+  ///
+  /// Defaults to 0.35 s, matching the desktop pipeline. Raising it back
+  /// toward sherpa-onnx's own 0.5 s risks merging consecutive sentences
+  /// into one segment, which this repo's ja recognizer answers by
+  /// transcribing only the last of them -- see this class's doc.
   final double minSilenceSeconds;
 
   /// Minimum speech duration before a detected segment is kept at all --
@@ -51,9 +78,20 @@ class VadSensitivity {
   /// [LiveTranscriber.entries].
   final double minSpeechSeconds;
 
-  /// Hard cap on how long a single segment is allowed to run before Silero
-  /// VAD force-closes it, even mid-speech, so one very long utterance can't
-  /// block segmentation indefinitely.
+  /// Roughly how long a single segment is allowed to run before Silero VAD
+  /// closes it mid-speech, so an unbroken monologue still produces timely
+  /// lines instead of one enormous one at the end.
+  ///
+  /// This is sherpa-onnx's `max_speech_duration`, and it is not a hard
+  /// cap. On the Android emulator run behind these defaults, a session
+  /// configured with 5.0 s emitted a 6.134 s segment; the value influences
+  /// when the VAD force-closes a segment rather than bounding what it can
+  /// hand over. Do not size a buffer, a timeout, or a UI element on the
+  /// assumption that no segment can exceed it.
+  ///
+  /// Defaults to 12.0 s, matching the desktop pipeline, which force-splits
+  /// breathless commentary at that length and lets the refine ("清書") pass
+  /// re-merge the group afterwards.
   final double maxSpeechSeconds;
 
   static void _requirePositive(double value, String name) {

--- a/mobile/hayamimi_core/lib/punct/punct_ja_text.dart
+++ b/mobile/hayamimi_core/lib/punct/punct_ja_text.dart
@@ -54,6 +54,28 @@ const List<String> jaQuestionSuffixes = <String>[
   'ましたか',
 ];
 
+/// The only marks the restorer ever writes: [insertMarks] writes 、 and 。,
+/// and [applyQuestionMarks] rewrites some of those 。 as ？. Everything else
+/// in [jaPunctuationCharacters] is a mark it merely recognizes in its input.
+const Set<String> restoredMarkCharacters = <String>{'、', '。', '？'};
+
+final RegExp _restoredMarks = RegExp('[${restoredMarkCharacters.join()}]');
+
+/// Removes the marks the restorer writes, giving back a string that can be
+/// compared, by length, against text that was never punctuated.
+///
+/// Restoring punctuation makes text longer, and `isRefineTextTooShort`
+/// (`live/refine_pass.dart`) decides whether a refine pass lost content by
+/// comparing its length against the unpunctuated fast finals it replaces.
+/// Comparing a punctuated refine directly would credit it for characters
+/// nobody said — one mark per sentence or clause is enough to push a
+/// genuinely truncated result back over the threshold — so the caller
+/// strips them first. NFKC normalization, which the restorer also applies,
+/// is not undone here: it folds character *forms*, so it leaves the count
+/// alone except where it composes a two-character half-width katakana into
+/// one, which no recognizer in this package emits.
+String withoutRestoredMarks(String text) => text.replaceAll(_restoredMarks, '');
+
 /// Converts a logit to a probability, the same way the reference
 /// implementation's `1 / (1 + exp(-x))` does.
 double sigmoid(double logit) => 1.0 / (1.0 + math.exp(-logit));

--- a/mobile/hayamimi_core/lib/remote/remote_event.dart
+++ b/mobile/hayamimi_core/lib/remote/remote_event.dart
@@ -36,6 +36,7 @@ class RemoteFinalEvent extends RemoteEvent {
     this.tier = '',
     this.audioSeconds,
     this.switched = false,
+    this.punctuated = false,
   });
 
   final String text;
@@ -54,6 +55,16 @@ class RemoteFinalEvent extends RemoteEvent {
   /// if the server didn't send it (including servers running a version of
   /// `subtitle_server.py` from before this field existed).
   final bool switched;
+
+  /// Whether the server had already punctuated this line, mirroring
+  /// `FinalSubtitleEvent.punctuated`. `false` if it didn't send the field.
+  ///
+  /// The desktop pipeline does punctuate its Japanese finals, but
+  /// `subtitle_server.py` has no `punctuated` key on `final` frames to say
+  /// so, so today this is `false` for every real server and exists so that a
+  /// consumer reading `FinalSubtitleEvent.punctuated` gets the same field
+  /// from both paths rather than a field that only some producers have.
+  final bool punctuated;
 }
 
 /// A machine translation of the most recent final line.
@@ -173,6 +184,7 @@ RemoteEvent parseRemoteEvent(String raw) {
         tier: map['tier'] as String? ?? '',
         audioSeconds: (map['audio_s'] as num?)?.toDouble(),
         switched: map['switched'] as bool? ?? false,
+        punctuated: map['punctuated'] as bool? ?? false,
       );
     case 'translation':
       return RemoteTranslationEvent(

--- a/mobile/hayamimi_core/lib/remote/remote_event.dart
+++ b/mobile/hayamimi_core/lib/remote/remote_event.dart
@@ -125,6 +125,8 @@ class RemoteUnknownEvent extends RemoteEvent {
   final Map<String, dynamic> raw;
 }
 
+/// Thrown while decoding a server frame into a [RemoteEvent]: malformed
+/// JSON, or JSON that isn't an object.
 class RemoteEventParseException implements Exception {
   RemoteEventParseException(this.message);
   final String message;

--- a/mobile/hayamimi_core/lib/remote/remote_transcriber.dart
+++ b/mobile/hayamimi_core/lib/remote/remote_transcriber.dart
@@ -9,6 +9,9 @@ import 'remote_event.dart';
 import 'remote_handshake.dart';
 import 'wav_pcm_reader.dart';
 
+/// Thrown by [RemoteTranscriber.connect]/[RemoteTranscriber.sendTestWavFile]
+/// for a connection or microphone-permission failure -- a rejected
+/// handshake, an unreachable server, or a denied `RECORD_AUDIO` request.
 class RemoteTranscriberException implements Exception {
   RemoteTranscriberException(this.message);
   final String message;
@@ -35,8 +38,13 @@ const _reconnectDelay = Duration(seconds: 2);
 /// microphone (see `scripts/ws_mic_client.py`, the desktop-side reference
 /// client this mirrors).
 class RemoteTranscriber {
+  /// Creates a client with no active connection. Pass [recorder] only to
+  /// inject a fake `AudioRecorder` in tests; a real host app should leave
+  /// it unset.
   RemoteTranscriber({AudioRecorder? recorder}) : _recorder = recorder ?? AudioRecorder();
 
+  /// The mic capture rate this client records at and streams to the
+  /// server, in Hz. Fixed -- not configurable per session.
   static const int sampleRate = 16000;
 
   final AudioRecorder _recorder;
@@ -62,9 +70,14 @@ class RemoteTranscriber {
   /// or a [sendTestWavFile] debug send.
   Stream<RemoteEvent> get events => _eventsController.stream;
 
+  /// Fires whenever [state] changes, e.g. connecting -> connected, or a
+  /// dropped socket -> reconnecting.
   Stream<RemoteConnectionState> get connectionState => _stateController.stream;
+
+  /// This client's current connection lifecycle state.
   RemoteConnectionState get state => _state;
 
+  /// Shorthand for `state == RemoteConnectionState.connected`.
   bool get isConnected => _state == RemoteConnectionState.connected;
 
   /// Connects to [url] (e.g. `ws://10.0.2.2:8833/ingest`), sends the

--- a/mobile/hayamimi_core/lib/remote/wav_pcm_reader.dart
+++ b/mobile/hayamimi_core/lib/remote/wav_pcm_reader.dart
@@ -17,6 +17,9 @@ class WavPcm16 {
   final Uint8List pcmBytes;
 }
 
+/// Thrown when a `.wav` file isn't the canonical, uncompressed 16-bit PCM
+/// format this reader parses -- e.g. a missing `RIFF`/`WAVE`/`fmt `/`data`
+/// chunk, or a compressed/float sample format.
 class WavParseException implements Exception {
   WavParseException(this.message);
   final String message;

--- a/mobile/hayamimi_core/lib/routing/lang_routing.dart
+++ b/mobile/hayamimi_core/lib/routing/lang_routing.dart
@@ -111,7 +111,7 @@ class StickyLangResult {
 /// `docs/MOBILE.md`), so [RoutedRecognizerSet] never reaches this path.
 /// It's kept, not deleted, as a faithful, tested port so a future
 /// non-SenseVoice language tier can reuse it without re-deriving the
-/// hysteresis rules from the desktop pipeline. Only [lang_routing_test.dart]
+/// hysteresis rules from the desktop pipeline. Only `lang_routing_test.dart`
 /// exercises it for now.
 ///
 /// A single new-language detection can be a babble-noise misfire or a

--- a/mobile/hayamimi_core/lib/routing/routed_recognizer.dart
+++ b/mobile/hayamimi_core/lib/routing/routed_recognizer.dart
@@ -8,6 +8,8 @@ import '../live/native_model_loader.dart';
 import 'lang_routing.dart';
 import 'routing_profile.dart';
 
+/// Thrown by [RoutedRecognizerSet.build] for a bad routing configuration
+/// (e.g. a missing model file for one of the routed tiers).
 class RoutedRecognizerException implements Exception {
   RoutedRecognizerException(this.message);
   final String message;

--- a/mobile/hayamimi_core/lib/server/subtitle_event.dart
+++ b/mobile/hayamimi_core/lib/server/subtitle_event.dart
@@ -100,6 +100,7 @@ class RefineSubtitleEvent extends SubtitleEvent {
     this.speaker = '',
     this.latencyMs,
     this.audioSeconds,
+    this.punctuated = false,
   });
 
   final String text;
@@ -111,6 +112,12 @@ class RefineSubtitleEvent extends SubtitleEvent {
   /// `null` when the producing session doesn't report it.
   final double? audioSeconds;
 
+  /// Whether [text] had Japanese punctuation (、 。 ？) restored into it —
+  /// see `LiveTranscriptEntry.punctuated`. `false` from any producer that
+  /// does not punctuate, which includes every remote (desktop) session and
+  /// any on-device session started without a `JaPunctuation` model.
+  final bool punctuated;
+
   @override
   Map<String, dynamic> toJson() => {
     'type': 'refine',
@@ -119,6 +126,7 @@ class RefineSubtitleEvent extends SubtitleEvent {
     'speaker': speaker,
     'latency_ms': latencyMs,
     'audio_s': audioSeconds,
+    'punctuated': punctuated,
   };
 }
 

--- a/mobile/hayamimi_core/lib/server/subtitle_event.dart
+++ b/mobile/hayamimi_core/lib/server/subtitle_event.dart
@@ -38,6 +38,7 @@ class FinalSubtitleEvent extends SubtitleEvent {
     this.latencyMs,
     this.audioSeconds,
     this.switched = false,
+    this.punctuated = false,
   });
 
   final String text;
@@ -64,6 +65,13 @@ class FinalSubtitleEvent extends SubtitleEvent {
   /// Always `false` for a single-model session.
   final bool switched;
 
+  /// Whether [text] had Japanese punctuation (、 。 ？) restored into it —
+  /// see `LiveTranscriptEntry.punctuated`. `false` from any producer that
+  /// does not punctuate its fast line, which includes every remote (desktop)
+  /// session, any on-device session started without a `JaPunctuation`
+  /// model, and one whose `JaPunctuation` set `applyToFinals: false`.
+  final bool punctuated;
+
   @override
   Map<String, dynamic> toJson() => {
     'type': 'final',
@@ -73,6 +81,7 @@ class FinalSubtitleEvent extends SubtitleEvent {
     'latency_ms': latencyMs,
     'audio_s': audioSeconds,
     'switched': switched,
+    'punctuated': punctuated,
   };
 }
 

--- a/mobile/hayamimi_core/lib/setup/model_downloader.dart
+++ b/mobile/hayamimi_core/lib/setup/model_downloader.dart
@@ -288,6 +288,8 @@ class ModelDownloadEvent {
   final int? totalBytes;
 }
 
+/// [downloadProfile]/[downloadModelSource]'s `onProgress` callback type --
+/// called once per [ModelDownloadEvent], e.g. to drive a progress bar.
 typedef ModelDownloadProgress = void Function(ModelDownloadEvent event);
 
 /// Transport [downloadProfile] uses to fetch a URL, factored out so tests
@@ -301,11 +303,15 @@ abstract class ModelDownloadTransport {
   Future<ModelDownloadResponse> get(Uri url);
 }
 
+/// A [ModelDownloadTransport.get] result: the response body as a byte
+/// stream, plus its declared length when the server sent one.
 class ModelDownloadResponse {
   const ModelDownloadResponse({required this.contentLength, required this.stream});
 
   /// `null` when the server didn't send a `Content-Length` header.
   final int? contentLength;
+
+  /// The response body, in whatever chunks the transport delivers them.
   final Stream<List<int>> stream;
 }
 

--- a/mobile/hayamimi_core/pubspec.yaml
+++ b/mobile/hayamimi_core/pubspec.yaml
@@ -1,12 +1,12 @@
 name: hayamimi_core
 description: >-
-  Reusable CPU real-time speech recognition core extracted from hayamimi:
-  on-device live transcription (sherpa-onnx + Silero VAD), a thin client for
-  a remote hayamimi server (--input ws --serve), and a LAN subtitle
-  broadcast server compatible with the desktop hayamimi overlay/SSE format.
+  On-device CPU speech recognition for Flutter: live sherpa-onnx
+  transcription, a remote hayamimi client, and a LAN subtitle broadcast
+  server.
 version: 0.1.0
 homepage: https://github.com/oboroge0/hayamimi
 repository: https://github.com/oboroge0/hayamimi
+issue_tracker: https://github.com/oboroge0/hayamimi/issues
 topics:
   - speech-recognition
   - subtitles
@@ -16,6 +16,10 @@ topics:
 environment:
   sdk: ^3.13.1
   flutter: ">=1.17.0"
+
+platforms:
+  android:
+  ios:
 
 dependencies:
   flutter:

--- a/mobile/hayamimi_core/test/decode_protocol_test.dart
+++ b/mobile/hayamimi_core/test/decode_protocol_test.dart
@@ -19,6 +19,10 @@ void main() {
         hotwordsScore: 2.5,
         numThreads: 4,
         sampleRate: 16000,
+        punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+        punctVocabPath: '/models/punct/vocab.txt',
+        punctLibraryPath: '/lib/onnxruntime.dll',
+        punctNumThreads: 3,
       );
 
       final decoded = DecodeWorkerConfig.fromMessage(config.toMessage());
@@ -32,6 +36,11 @@ void main() {
       expect(decoded.hotwordsScore, 2.5);
       expect(decoded.numThreads, 4);
       expect(decoded.sampleRate, 16000);
+      expect(decoded.punctModelPath, '/models/punct/punct_bert.fp16.onnx');
+      expect(decoded.punctVocabPath, '/models/punct/vocab.txt');
+      expect(decoded.punctLibraryPath, '/lib/onnxruntime.dll');
+      expect(decoded.punctNumThreads, 3);
+      expect(decoded.punctuatePlainSession, isTrue);
     });
 
     test('round-trips a plain session, nulls included', () {
@@ -45,6 +54,79 @@ void main() {
       expect(decoded.decodingMethod, isNull);
       expect(decoded.hotwordsFile, isNull);
       expect(decoded.hotwordsScore, 1.5);
+      expect(decoded.punctModelPath, isNull);
+      expect(decoded.punctVocabPath, isNull);
+      expect(decoded.punctLibraryPath, isNull);
+      expect(decoded.punctNumThreads, defaultPunctNumThreads);
+      expect(decoded.hasPunctuation, isFalse);
+    });
+
+    test('a plain session can say its own language is not Japanese', () {
+      const config = DecodeWorkerConfig(
+        routed: false,
+        modelDir: '/models/en',
+        punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+        punctVocabPath: '/models/punct/vocab.txt',
+        punctuatePlainSession: false,
+      );
+
+      final decoded = DecodeWorkerConfig.fromMessage(config.toMessage());
+
+      expect(decoded.punctuatePlainSession, isFalse);
+    });
+  });
+
+  group('DecodeWorkerConfig.shouldPunctuateRefine', () {
+    // The rule the worker applies to every refine result it produces, read
+    // on its own: punctuating text the model was not trained for produces
+    // nonsense rather than nothing, so each case is spelled out.
+    const routed = DecodeWorkerConfig(
+      routed: true,
+      modelDir: '/models/ja',
+      senseVoiceModelDir: '/models/sv',
+      lidModelDir: '/models/lid',
+      punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+      punctVocabPath: '/models/punct/vocab.txt',
+    );
+
+    test('a routed session punctuates only what came back as Japanese', () {
+      expect(routed.shouldPunctuateRefine(lang: 'ja'), isTrue);
+      expect(routed.shouldPunctuateRefine(lang: 'en'), isFalse);
+      expect(routed.shouldPunctuateRefine(lang: 'zh'), isFalse);
+      // Before the first segment resolves a language there is nothing to
+      // punctuate for.
+      expect(routed.shouldPunctuateRefine(), isFalse);
+    });
+
+    test('a plain session goes by the flag, having no language tag', () {
+      const japanese = DecodeWorkerConfig(
+        routed: false,
+        modelDir: '/models/ja',
+        punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+        punctVocabPath: '/models/punct/vocab.txt',
+      );
+      const notJapanese = DecodeWorkerConfig(
+        routed: false,
+        modelDir: '/models/en',
+        punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+        punctVocabPath: '/models/punct/vocab.txt',
+        punctuatePlainSession: false,
+      );
+
+      expect(japanese.shouldPunctuateRefine(), isTrue);
+      expect(notJapanese.shouldPunctuateRefine(), isFalse);
+    });
+
+    test('a session with no punctuation model never punctuates', () {
+      const noPunct = DecodeWorkerConfig(
+        routed: true,
+        modelDir: '/models/ja',
+        senseVoiceModelDir: '/models/sv',
+        lidModelDir: '/models/lid',
+      );
+
+      expect(noPunct.hasPunctuation, isFalse);
+      expect(noPunct.shouldPunctuateRefine(lang: 'ja'), isFalse);
     });
   });
 
@@ -138,6 +220,25 @@ void main() {
       expect(decoded.lang, 'ja');
       expect(decoded.switched, isTrue);
       expect(decoded.latencyMs, 123.5);
+      expect(decoded.punctuated, isFalse);
+    });
+
+    test('a refine result carries whether punctuation was restored', () {
+      const result = DecodeWorkerResult(
+        id: 12,
+        kind: DecodeRequestKind.refine,
+        text: '今日は疲れた。もう寝る。',
+        lang: 'ja',
+        latencyMs: 480.0,
+        punctuated: true,
+      );
+
+      final decoded =
+          DecodeWorkerMessage.fromMessage(result.toMessage())
+              as DecodeWorkerResult;
+
+      expect(decoded.punctuated, isTrue);
+      expect(decoded.text, '今日は疲れた。もう寝る。');
     });
 
     test('a plain-session result keeps its null language', () {

--- a/mobile/hayamimi_core/test/decode_protocol_test.dart
+++ b/mobile/hayamimi_core/test/decode_protocol_test.dart
@@ -41,6 +41,7 @@ void main() {
       expect(decoded.punctLibraryPath, '/lib/onnxruntime.dll');
       expect(decoded.punctNumThreads, 3);
       expect(decoded.punctuatePlainSession, isTrue);
+      expect(decoded.punctuateFinals, isTrue);
     });
 
     test('round-trips a plain session, nulls included', () {
@@ -59,6 +60,7 @@ void main() {
       expect(decoded.punctLibraryPath, isNull);
       expect(decoded.punctNumThreads, defaultPunctNumThreads);
       expect(decoded.hasPunctuation, isFalse);
+      expect(decoded.punctuateFinals, isTrue);
     });
 
     test('a plain session can say its own language is not Japanese', () {
@@ -74,12 +76,34 @@ void main() {
 
       expect(decoded.punctuatePlainSession, isFalse);
     });
+
+    test('a session can ask for refines to be punctuated but not finals', () {
+      const config = DecodeWorkerConfig(
+        routed: false,
+        modelDir: '/models/ja',
+        punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+        punctVocabPath: '/models/punct/vocab.txt',
+        punctuateFinals: false,
+      );
+
+      final decoded = DecodeWorkerConfig.fromMessage(config.toMessage());
+
+      expect(decoded.punctuateFinals, isFalse);
+      expect(
+        decoded.shouldPunctuate(kind: DecodeRequestKind.refine),
+        isTrue,
+      );
+      expect(
+        decoded.shouldPunctuate(kind: DecodeRequestKind.finalSegment),
+        isFalse,
+      );
+    });
   });
 
-  group('DecodeWorkerConfig.shouldPunctuateRefine', () {
-    // The rule the worker applies to every refine result it produces, read
-    // on its own: punctuating text the model was not trained for produces
-    // nonsense rather than nothing, so each case is spelled out.
+  group('DecodeWorkerConfig.shouldPunctuate', () {
+    // The rule the worker applies to every result it produces, read on its
+    // own: punctuating text the model was not trained for produces nonsense
+    // rather than nothing, so each case is spelled out.
     const routed = DecodeWorkerConfig(
       routed: true,
       modelDir: '/models/ja',
@@ -90,12 +114,34 @@ void main() {
     );
 
     test('a routed session punctuates only what came back as Japanese', () {
-      expect(routed.shouldPunctuateRefine(lang: 'ja'), isTrue);
-      expect(routed.shouldPunctuateRefine(lang: 'en'), isFalse);
-      expect(routed.shouldPunctuateRefine(lang: 'zh'), isFalse);
-      // Before the first segment resolves a language there is nothing to
-      // punctuate for.
-      expect(routed.shouldPunctuateRefine(), isFalse);
+      for (final kind in <DecodeRequestKind>[
+        DecodeRequestKind.refine,
+        DecodeRequestKind.finalSegment,
+      ]) {
+        expect(routed.shouldPunctuate(kind: kind, lang: 'ja'), isTrue);
+        expect(routed.shouldPunctuate(kind: kind, lang: 'en'), isFalse);
+        expect(routed.shouldPunctuate(kind: kind, lang: 'zh'), isFalse);
+        // Before the first segment resolves a language there is nothing to
+        // punctuate for.
+        expect(routed.shouldPunctuate(kind: kind), isFalse);
+      }
+    });
+
+    test('finals are punctuated by default, drafts never are', () {
+      // A draft covers part of a segment still being spoken and is
+      // re-decoded about once a second, so a mark in one is a guess about a
+      // sentence that has not finished.
+      expect(
+        routed.shouldPunctuate(
+          kind: DecodeRequestKind.finalSegment,
+          lang: 'ja',
+        ),
+        isTrue,
+      );
+      expect(
+        routed.shouldPunctuate(kind: DecodeRequestKind.draft, lang: 'ja'),
+        isFalse,
+      );
     });
 
     test('a plain session goes by the flag, having no language tag', () {
@@ -113,8 +159,22 @@ void main() {
         punctuatePlainSession: false,
       );
 
-      expect(japanese.shouldPunctuateRefine(), isTrue);
-      expect(notJapanese.shouldPunctuateRefine(), isFalse);
+      expect(
+        japanese.shouldPunctuate(kind: DecodeRequestKind.refine),
+        isTrue,
+      );
+      expect(
+        japanese.shouldPunctuate(kind: DecodeRequestKind.finalSegment),
+        isTrue,
+      );
+      expect(
+        notJapanese.shouldPunctuate(kind: DecodeRequestKind.refine),
+        isFalse,
+      );
+      expect(
+        notJapanese.shouldPunctuate(kind: DecodeRequestKind.finalSegment),
+        isFalse,
+      );
     });
 
     test('a session with no punctuation model never punctuates', () {
@@ -126,7 +186,17 @@ void main() {
       );
 
       expect(noPunct.hasPunctuation, isFalse);
-      expect(noPunct.shouldPunctuateRefine(lang: 'ja'), isFalse);
+      expect(
+        noPunct.shouldPunctuate(kind: DecodeRequestKind.refine, lang: 'ja'),
+        isFalse,
+      );
+      expect(
+        noPunct.shouldPunctuate(
+          kind: DecodeRequestKind.finalSegment,
+          lang: 'ja',
+        ),
+        isFalse,
+      );
     });
   });
 

--- a/mobile/hayamimi_core/test/fake_decode_worker.dart
+++ b/mobile/hayamimi_core/test/fake_decode_worker.dart
@@ -98,16 +98,32 @@ class FakeDecodeWorker implements DecodeWorker {
       commands.whereType<DecodeRequest>().toList();
 
   /// Answers the outstanding request with a result.
-  void reply(String text, {String? lang, bool switched = false}) =>
-      replyTo(lastRequest, text, lang: lang, switched: switched);
+  void reply(
+    String text, {
+    String? lang,
+    bool switched = false,
+    bool punctuated = false,
+  }) => replyTo(
+    lastRequest,
+    text,
+    lang: lang,
+    switched: switched,
+    punctuated: punctuated,
+  );
 
   /// Answers a specific request -- including one that was answered already,
   /// which is how a reply arriving after its session ended is staged.
+  ///
+  /// [punctuated] stands in for the real worker having run the punctuation
+  /// model over a refine result: this fake never restores anything itself,
+  /// so a test supplies both the punctuated text and the flag, and what it
+  /// is checking is what the session does with them.
   void replyTo(
     DecodeRequest request,
     String text, {
     String? lang,
     bool switched = false,
+    bool punctuated = false,
   }) {
     _emit(
       DecodeWorkerResult(
@@ -118,6 +134,7 @@ class FakeDecodeWorker implements DecodeWorker {
         lang: lang,
         switched: switched,
         latencyMs: 12.5,
+        punctuated: punctuated,
       ),
     );
   }

--- a/mobile/hayamimi_core/test/fake_live_vad.dart
+++ b/mobile/hayamimi_core/test/fake_live_vad.dart
@@ -26,16 +26,31 @@ class FakeLiveVad implements LiveVad {
 
   /// Handed over one per subsequent accepted frame, as if the speaker had
   /// just paused: the segment ends and [isSpeechDetected] goes false.
-  final Queue<Float32List> segmentsPerFrame = Queue<Float32List>();
+  ///
+  /// Each carries where it started, in samples from this VAD's first
+  /// frame, because that is what the session's pre-roll works from — see
+  /// `PrerollHistory`. Use [segment] to build one.
+  final Queue<LiveSpeechSegment> segmentsPerFrame = Queue<LiveSpeechSegment>();
 
   /// Handed over on [flush] instead — what a session stopping, or a debug
   /// wav file ending, produces.
-  Float32List? flushSegment;
+  LiveSpeechSegment? flushSegment;
 
   int flushCount = 0;
   bool freed = false;
 
-  final Queue<Float32List> _ready = Queue<Float32List>();
+  final Queue<LiveSpeechSegment> _ready = Queue<LiveSpeechSegment>();
+
+  /// A segment of [seconds] of silence claiming to start [startSample]
+  /// samples into the session.
+  static LiveSpeechSegment segment(
+    double seconds, {
+    int startSample = 0,
+    int sampleRate = 16000,
+  }) => LiveSpeechSegment(
+    samples: Float32List((seconds * sampleRate).round()),
+    startSample: startSample,
+  );
 
   @override
   void acceptWaveform(Float32List frame) {
@@ -53,7 +68,7 @@ class FakeLiveVad implements LiveVad {
   bool get hasSegment => _ready.isNotEmpty;
 
   @override
-  Float32List takeSegment() => _ready.removeFirst();
+  LiveSpeechSegment takeSegment() => _ready.removeFirst();
 
   @override
   void flush() {

--- a/mobile/hayamimi_core/test/hayamimi_live_events_test.dart
+++ b/mobile/hayamimi_core/test/hayamimi_live_events_test.dart
@@ -68,12 +68,14 @@ LiveTranscriptEntry _entry(
   String? lang,
   double? audioSeconds,
   bool switched = false,
+  bool punctuated = false,
 }) => LiveTranscriptEntry(
   text: text,
   timestamp: DateTime.now(),
   lang: lang,
   audioSeconds: audioSeconds,
   switched: switched,
+  punctuated: punctuated,
 );
 
 void main() {
@@ -91,7 +93,7 @@ void main() {
   });
 
   test(
-    'a final entry\'s audioSeconds/switched propagate onto FinalSubtitleEvent',
+    'a final entry\'s audioSeconds/switched/punctuated propagate onto FinalSubtitleEvent',
     () async {
       final fake = _FakeLiveTranscriber();
       final live = HayamimiLive(transcriber: fake);
@@ -101,13 +103,20 @@ void main() {
       live.events.listen(events.add);
 
       fake.emitFinal(
-        _entry('hello', lang: 'en', audioSeconds: 1.75, switched: true),
+        _entry(
+          'hello',
+          lang: 'en',
+          audioSeconds: 1.75,
+          switched: true,
+          punctuated: true,
+        ),
       );
       await Future<void>.delayed(Duration.zero);
 
       final finalEvent = events.whereType<FinalSubtitleEvent>().single;
       expect(finalEvent.audioSeconds, 1.75);
       expect(finalEvent.switched, isTrue);
+      expect(finalEvent.punctuated, isTrue);
     },
   );
 

--- a/mobile/hayamimi_core/test/live_transcriber_config_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_config_test.dart
@@ -5,7 +5,7 @@ import 'package:record/record.dart';
 import 'fake_record_platform.dart';
 
 /// Runtime-configuration surface added for the embedding API (issue #29):
-/// the six pacing knobs' constructor defaults/validation/runtime setters,
+/// the seven pacing knobs' constructor defaults/validation/runtime setters,
 /// and [LiveTranscriber.resetSession]/[LiveTranscriber.setVadSensitivity]
 /// when no session is running. None of this needs the sherpa-onnx native
 /// libs or a real mic -- only [LiveTranscriber]'s constructor and these
@@ -46,6 +46,7 @@ void main() {
         defaultAutoRefineMaxBufferedSeconds,
       );
       expect(transcriber.refineBufferMaxSeconds, defaultRefineBufferMaxSeconds);
+      expect(transcriber.prerollSeconds, defaultPrerollSeconds);
     });
 
     test('accepts and reads back custom values', () {
@@ -56,6 +57,7 @@ void main() {
         autoRefineSilenceSeconds: 3.0,
         autoRefineMaxBufferedSeconds: 15.0,
         refineBufferMaxSeconds: 30.0,
+        prerollSeconds: 0.5,
       );
       addTearDown(transcriber.dispose);
 
@@ -65,6 +67,7 @@ void main() {
       expect(transcriber.autoRefineSilenceSeconds, 3.0);
       expect(transcriber.autoRefineMaxBufferedSeconds, 15.0);
       expect(transcriber.refineBufferMaxSeconds, 30.0);
+      expect(transcriber.prerollSeconds, 0.5);
     });
 
     test('a non-positive or non-finite value throws ArgumentError', () {
@@ -93,6 +96,20 @@ void main() {
         throwsArgumentError,
       );
     });
+
+    test('prerollSeconds accepts 0 but not a negative or non-finite value', () {
+      // The one knob where 0 is meaningful rather than a mistake: it means
+      // "decode exactly what the VAD delimited, add nothing".
+      final transcriber = LiveTranscriber(prerollSeconds: 0);
+      addTearDown(transcriber.dispose);
+      expect(transcriber.prerollSeconds, 0);
+
+      expect(() => LiveTranscriber(prerollSeconds: -0.1), throwsArgumentError);
+      expect(
+        () => LiveTranscriber(prerollSeconds: double.nan),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('LiveTranscriber pacing-knob runtime setters', () {
@@ -117,6 +134,11 @@ void main() {
 
       transcriber.refineBufferMaxSeconds = 45.0;
       expect(transcriber.refineBufferMaxSeconds, 45.0);
+
+      transcriber.prerollSeconds = 0.4;
+      expect(transcriber.prerollSeconds, 0.4);
+      transcriber.prerollSeconds = 0;
+      expect(transcriber.prerollSeconds, 0);
     });
 
     test('an out-of-range value throws and leaves the previous value in place', () {
@@ -134,6 +156,9 @@ void main() {
         throwsArgumentError,
       );
       expect(transcriber.refineBufferMaxSeconds, defaultRefineBufferMaxSeconds);
+
+      expect(() => transcriber.prerollSeconds = -1, throwsArgumentError);
+      expect(transcriber.prerollSeconds, defaultPrerollSeconds);
     });
   });
 

--- a/mobile/hayamimi_core/test/live_transcriber_decode_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_decode_test.dart
@@ -118,6 +118,165 @@ void main() {
     });
   });
 
+  group('Japanese punctuation', () {
+    late File punctModelFile;
+    late File punctVocabFile;
+
+    setUp(() {
+      // Stand-ins for the 181.8 MB model and its vocabulary: start() only
+      // checks that both files exist, and the fake worker never loads them.
+      final sep = Platform.pathSeparator;
+      punctModelFile = File('${modelDir.path}${sep}punct.onnx')
+        ..writeAsBytesSync(<int>[0]);
+      punctVocabFile = File('${modelDir.path}${sep}vocab.txt')
+        ..writeAsStringSync('[PAD]\n');
+    });
+
+    JaPunctuation punctuation({String? libraryPath, int numThreads = 2}) =>
+        JaPunctuation(
+          modelPath: punctModelFile.path,
+          vocabPath: punctVocabFile.path,
+          libraryPath: libraryPath,
+          numThreads: numThreads,
+        );
+
+    test('reaches the worker as part of its config', () async {
+      worker.buildFailure = 'stop here';
+      final transcriber = newTranscriber();
+      addTearDown(transcriber.dispose);
+
+      await expectLater(
+        transcriber.start(
+          modelKind: ModelKind.zipformerTransducer,
+          modelDir: modelDir.path,
+          vadModelPath: vadModelFile.path,
+          punctuation: punctuation(
+            libraryPath: '/lib/onnxruntime.dll',
+            numThreads: 3,
+          ),
+        ),
+        throwsA(isA<LiveTranscriberException>()),
+      );
+
+      final config = worker.config!;
+      expect(config.punctModelPath, punctModelFile.path);
+      expect(config.punctVocabPath, punctVocabFile.path);
+      expect(config.punctLibraryPath, '/lib/onnxruntime.dll');
+      expect(config.punctNumThreads, 3);
+      // A plain session says its own language is Japanese by being given a
+      // Japanese punctuation model at all.
+      expect(config.punctuatePlainSession, isTrue);
+      expect(config.shouldPunctuateRefine(), isTrue);
+    });
+
+    test('a session started without it asks the worker for none', () async {
+      worker.buildFailure = 'stop here';
+      final transcriber = newTranscriber();
+      addTearDown(transcriber.dispose);
+
+      await expectLater(
+        transcriber.start(
+          modelKind: ModelKind.zipformerTransducer,
+          modelDir: modelDir.path,
+          vadModelPath: vadModelFile.path,
+        ),
+        throwsA(isA<LiveTranscriberException>()),
+      );
+
+      expect(worker.config!.hasPunctuation, isFalse);
+    });
+
+    test('a model that will not load fails start(), naming it', () async {
+      // No silent degradation: a missing or unreadable 182 MB file is a
+      // configuration error, and a session that came up quietly producing
+      // unpunctuated text would hide it.
+      worker.buildFailure =
+          'Could not load the Japanese punctuation model '
+          '"${punctModelFile.path}" (vocabulary "${punctVocabFile.path}"): '
+          'OrtLibraryException: Could not load "libonnxruntime.so"';
+      final transcriber = newTranscriber();
+      addTearDown(transcriber.dispose);
+
+      await expectLater(
+        transcriber.start(
+          modelKind: ModelKind.zipformerTransducer,
+          modelDir: modelDir.path,
+          vadModelPath: vadModelFile.path,
+          punctuation: punctuation(),
+        ),
+        throwsA(
+          isA<LiveTranscriberException>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('Japanese punctuation model'),
+              contains(punctModelFile.path),
+            ),
+          ),
+        ),
+      );
+
+      expect(transcriber.isRunning, isFalse);
+      expect(worker.shutdownCount, 1);
+    });
+
+    test('a missing file is reported before any worker is spawned', () async {
+      final transcriber = newTranscriber();
+      addTearDown(transcriber.dispose);
+      final missing = '${modelDir.path}${Platform.pathSeparator}absent.onnx';
+
+      await expectLater(
+        transcriber.start(
+          modelKind: ModelKind.zipformerTransducer,
+          modelDir: modelDir.path,
+          vadModelPath: vadModelFile.path,
+          punctuation: JaPunctuation(
+            modelPath: missing,
+            vocabPath: punctVocabFile.path,
+          ),
+        ),
+        throwsA(
+          isA<LiveTranscriberException>().having(
+            (e) => e.message,
+            'message',
+            'Japanese punctuation model not found: $missing',
+          ),
+        ),
+      );
+
+      // Nothing was spawned and no recognizer weights were loaded for a
+      // session that could not have worked.
+      expect(worker.startCount, 0);
+    });
+
+    test('a missing vocabulary is reported the same way', () async {
+      final transcriber = newTranscriber();
+      addTearDown(transcriber.dispose);
+      final missing = '${modelDir.path}${Platform.pathSeparator}absent.txt';
+
+      await expectLater(
+        transcriber.start(
+          modelKind: ModelKind.zipformerTransducer,
+          modelDir: modelDir.path,
+          vadModelPath: vadModelFile.path,
+          punctuation: JaPunctuation(
+            modelPath: punctModelFile.path,
+            vocabPath: missing,
+          ),
+        ),
+        throwsA(
+          isA<LiveTranscriberException>().having(
+            (e) => e.message,
+            'message',
+            'Japanese punctuation vocabulary not found: $missing',
+          ),
+        ),
+      );
+
+      expect(worker.startCount, 0);
+    });
+  });
+
   group('a model that will not load', () {
     test('surfaces the worker message verbatim and stays retryable', () async {
       worker.buildFailure =

--- a/mobile/hayamimi_core/test/live_transcriber_decode_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_decode_test.dart
@@ -132,13 +132,17 @@ void main() {
         ..writeAsStringSync('[PAD]\n');
     });
 
-    JaPunctuation punctuation({String? libraryPath, int numThreads = 2}) =>
-        JaPunctuation(
-          modelPath: punctModelFile.path,
-          vocabPath: punctVocabFile.path,
-          libraryPath: libraryPath,
-          numThreads: numThreads,
-        );
+    JaPunctuation punctuation({
+      String? libraryPath,
+      int numThreads = 2,
+      bool applyToFinals = true,
+    }) => JaPunctuation(
+      modelPath: punctModelFile.path,
+      vocabPath: punctVocabFile.path,
+      libraryPath: libraryPath,
+      numThreads: numThreads,
+      applyToFinals: applyToFinals,
+    );
 
     test('reaches the worker as part of its config', () async {
       worker.buildFailure = 'stop here';
@@ -166,7 +170,38 @@ void main() {
       // A plain session says its own language is Japanese by being given a
       // Japanese punctuation model at all.
       expect(config.punctuatePlainSession, isTrue);
-      expect(config.shouldPunctuateRefine(), isTrue);
+      expect(config.punctuateFinals, isTrue);
+      expect(config.shouldPunctuate(kind: DecodeRequestKind.refine), isTrue);
+      expect(
+        config.shouldPunctuate(kind: DecodeRequestKind.finalSegment),
+        isTrue,
+      );
+    });
+
+    test('applyToFinals: false reaches the worker as punctuateFinals', () async {
+      worker.buildFailure = 'stop here';
+      final transcriber = newTranscriber();
+      addTearDown(transcriber.dispose);
+
+      await expectLater(
+        transcriber.start(
+          modelKind: ModelKind.zipformerTransducer,
+          modelDir: modelDir.path,
+          vadModelPath: vadModelFile.path,
+          punctuation: punctuation(applyToFinals: false),
+        ),
+        throwsA(isA<LiveTranscriberException>()),
+      );
+
+      final config = worker.config!;
+      expect(config.punctuateFinals, isFalse);
+      // The refine pass is untouched by the switch: it is the fast line the
+      // caller asked to leave alone.
+      expect(config.shouldPunctuate(kind: DecodeRequestKind.refine), isTrue);
+      expect(
+        config.shouldPunctuate(kind: DecodeRequestKind.finalSegment),
+        isFalse,
+      );
     });
 
     test('a session started without it asks the worker for none', () async {

--- a/mobile/hayamimi_core/test/live_transcriber_session_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_session_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -528,6 +529,116 @@ void main() {
       expect(h.transcriber.isDebugStreaming, isFalse);
       expect(h.worker.shutdownCount, 1);
       expect(h.vad.freed, isTrue);
+    });
+
+    test('ends with a refine over what it transcribed', () async {
+      // The session is torn down before this future completes, so a caller
+      // cannot ask for a refine afterwards -- refineNow() would find no
+      // worker. Without a closing pass, the method that exists to show
+      // punctuated refine output on a device with no microphone would
+      // never produce one.
+      h.workerSetUp = (worker) => worker.autoReplyText = 'flushed line';
+      h.vads.setUp = (vad) => vad.flushSegment = FakeLiveVad.segment(1.0);
+      final wavPath = h.writeWav(sampleCount: 4096);
+
+      await h.transcriber.startDebugWavStream(
+        modelKind: ModelKind.zipformerTransducer,
+        modelDir: h.modelDir.path,
+        vadModelPath: h.vadModelPath,
+        wavPath: wavPath,
+        realtime: false,
+      );
+
+      expect(
+        h.worker.decodeRequests.map((r) => r.kind),
+        contains(DecodeRequestKind.refine),
+      );
+      expect(h.refines.single.text, 'flushed line');
+      expect(h.refines.single.audioSeconds, closeTo(1.0, 1e-9));
+      // And it landed before the session went away, not after.
+      expect(h.transcriber.isDebugStreaming, isFalse);
+      expect(h.worker.shutdownCount, 1);
+    });
+
+    test('a stream that transcribed nothing ends with no refine', () async {
+      // Nothing buffered means nothing for a refine to cover; asking for
+      // one anyway would cost a decode of silence.
+      h.workerSetUp = (worker) => worker.autoReplyText = 'never asked for';
+      final wavPath = h.writeWav(sampleCount: 4096);
+
+      await h.transcriber.startDebugWavStream(
+        modelKind: ModelKind.zipformerTransducer,
+        modelDir: h.modelDir.path,
+        vadModelPath: h.vadModelPath,
+        wavPath: wavPath,
+        realtime: false,
+      );
+
+      expect(h.worker.decodeRequests, isEmpty);
+      expect(h.refines, isEmpty);
+    });
+
+    test('auto-refine set before the stream fires during it', () async {
+      // The autoRefineEnabled setter only started its timer for a
+      // microphone session; a debug stream got one only because
+      // _resetSessionState starts it when the flag is already set. Both
+      // paths now work, and this pins the documented one: set it, stream,
+      // and refines arrive as the audio goes by rather than only at the
+      // end.
+      h.workerSetUp = (worker) => worker.autoReplyText = 'a line';
+      h.vads.setUp = (vad) =>
+          vad.segmentsPerFrame.add(FakeLiveVad.segment(1.0));
+      // Any silence at all is enough; the due check itself runs once a
+      // second, which is what paces this test.
+      h.transcriber.autoRefineSilenceSeconds = 0.001;
+      h.transcriber.autoRefineEnabled = true;
+      // ~2.6s of audio at 16kHz, streamed at its own pace, so the
+      // once-a-second due check runs at least twice while it plays.
+      final wavPath = h.writeWav(sampleCount: 41600);
+
+      // A second segment, timed to arrive after the first due check has
+      // already refined the first one.
+      Timer(const Duration(milliseconds: 1700), () {
+        h.vad.segmentsPerFrame.add(FakeLiveVad.segment(1.0));
+      });
+
+      await h.transcriber.startDebugWavStream(
+        modelKind: ModelKind.zipformerTransducer,
+        modelDir: h.modelDir.path,
+        vadModelPath: h.vadModelPath,
+        wavPath: wavPath,
+      );
+
+      // Two refines, not one: a single closing pass would have covered both
+      // segments at once, so the first one covering 1.0s on its own is the
+      // evidence that a refine fired while the stream was still playing.
+      expect(h.refines.length, greaterThanOrEqualTo(2));
+      expect(h.refines.first.audioSeconds, closeTo(1.0, 1e-9));
+    });
+
+    test('auto-refine turned on mid-stream starts firing too', () async {
+      h.workerSetUp = (worker) => worker.autoReplyText = 'a line';
+      h.vads.setUp = (vad) =>
+          vad.segmentsPerFrame.add(FakeLiveVad.segment(1.0));
+      h.transcriber.autoRefineSilenceSeconds = 0.001;
+      final wavPath = h.writeWav(sampleCount: 41600);
+
+      Timer(const Duration(milliseconds: 300), () {
+        h.transcriber.autoRefineEnabled = true;
+      });
+      Timer(const Duration(milliseconds: 1700), () {
+        h.vad.segmentsPerFrame.add(FakeLiveVad.segment(1.0));
+      });
+
+      await h.transcriber.startDebugWavStream(
+        modelKind: ModelKind.zipformerTransducer,
+        modelDir: h.modelDir.path,
+        vadModelPath: h.vadModelPath,
+        wavPath: wavPath,
+      );
+
+      expect(h.refines.length, greaterThanOrEqualTo(2));
+      expect(h.refines.first.audioSeconds, closeTo(1.0, 1e-9));
     });
 
     test('a wav at the wrong sample rate is rejected and leaves nothing running', () async {

--- a/mobile/hayamimi_core/test/live_transcriber_session_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_session_test.dart
@@ -394,7 +394,7 @@ void main() {
 
   group('stop', () {
     test('emits the segment its VAD flush produces before returning', () async {
-      h.vads.setUp = (vad) => vad.flushSegment = _samples(1.0);
+      h.vads.setUp = (vad) => vad.flushSegment = FakeLiveVad.segment(1.0);
       await h.start();
 
       final stopping = h.transcriber.stop();
@@ -431,10 +431,87 @@ void main() {
     });
   });
 
+  group('pre-roll', () {
+    // Silero VAD reports a speech onset slightly late, so a session decodes
+    // the second before the onset along with the segment (see
+    // preroll.dart). What is checked here is the wiring: that the audio
+    // actually sent to the worker grew, that the reported duration grew
+    // with it, and that two segments in a row do not both claim the gap
+    // between them.
+
+    test('a final is decoded with the second of audio before its onset', () async {
+      await h.start();
+      // 1.28s of session audio before the segment the VAD reports at 1.28s.
+      await h.pushFrames(40);
+
+      await h.endSegment(seconds: 1.0, startSample: 40 * 512);
+      expect(h.worker.lastRequest.samples.length, 16000 + 16000);
+
+      h.worker.reply('one line');
+      await settle();
+
+      // The pre-roll is part of the segment, so it is part of what the
+      // entry says it covered.
+      expect(h.entries.single.audioSeconds, closeTo(2.0, 1e-9));
+      expect(h.transcriber.refineBufferedSeconds, closeTo(2.0, 1e-9));
+    });
+
+    test('two segments in a row do not both include the gap between them', () async {
+      await h.start();
+      await h.pushFrames(60);
+
+      // 0.5s of speech starting half a second in: nothing before it has
+      // been claimed, so it takes its full half second of run-up.
+      await h.endSegment(seconds: 0.5, startSample: 8000);
+      expect(h.worker.lastRequest.samples.length, 8000 + 8000);
+      h.worker.reply('first');
+      await settle();
+
+      // The next starts 0.25s after the first ended. A full second of
+      // pre-roll would reach back into it; it gets the 0.25s gap instead.
+      await h.endSegment(seconds: 0.5, startSample: 20000);
+      expect(h.worker.lastRequest.samples.length, 4000 + 8000);
+      h.worker.reply('second');
+      await settle();
+
+      // 1.75s of session audio, decoded as 1.75s across two lines.
+      expect(h.entries[0].audioSeconds, closeTo(1.0, 1e-9));
+      expect(h.entries[1].audioSeconds, closeTo(0.75, 1e-9));
+    });
+
+    test('prerollSeconds = 0 decodes exactly what the VAD delimited', () async {
+      h.transcriber.prerollSeconds = 0;
+      await h.start();
+      await h.pushFrames(40);
+
+      await h.endSegment(seconds: 1.0, startSample: 40 * 512);
+
+      expect(h.worker.lastRequest.samples.length, 16000);
+      h.worker.reply('one line');
+      await settle();
+      expect(h.entries.single.audioSeconds, closeTo(1.0, 1e-9));
+    });
+
+    test('a segment dropped as too short still blocks the next pre-roll', () async {
+      // A blip the app-level guard throws away never reaches the worker,
+      // but the audio it covered has still been accounted for -- the next
+      // segment must not pick it up as context.
+      await h.start();
+      await h.pushFrames(60);
+
+      await h.endSegment(seconds: 0.05, startSample: 16000);
+      expect(h.worker.decodeRequests, isEmpty);
+
+      await h.endSegment(seconds: 0.5, startSample: 20000);
+      // 16000 + 800 = 16800, so only 3200 samples of gap are available.
+      expect(h.worker.lastRequest.samples.length, 3200 + 8000);
+    });
+  });
+
   group('startDebugWavStream', () {
     test('feeds the whole file through and flushes its last segment', () async {
       h.workerSetUp = (worker) => worker.autoReplyText = 'flushed line';
-      h.vads.setUp = (vad) => vad.flushSegment = _samples(1.0);
+      h.vads.setUp = (vad) => vad.flushSegment = FakeLiveVad.segment(1.0);
       final wavPath = h.writeWav(sampleCount: 4096);
 
       await h.transcriber.startDebugWavStream(
@@ -562,8 +639,19 @@ class _Harness {
 
   /// Ends a speech segment carrying [seconds] of audio, the way a speaker
   /// pausing does.
-  Future<void> endSegment({required double seconds}) async {
-    vad.segmentsPerFrame.add(_samples(seconds));
+  ///
+  /// [startSample] is where the VAD claims the segment began, counted in
+  /// samples from the session's first frame — what the pre-roll is measured
+  /// back from. It defaults to 0, i.e. "at the very start of the session",
+  /// which leaves nothing in front of the segment to prepend and so keeps
+  /// the audio a test sees equal to what it queued.
+  Future<void> endSegment({
+    required double seconds,
+    int startSample = 0,
+  }) async {
+    vad.segmentsPerFrame.add(
+      FakeLiveVad.segment(seconds, startSample: startSample),
+    );
     await pushFrames(1);
   }
 
@@ -597,8 +685,6 @@ class _Harness {
   }
 }
 
-Float32List _samples(double seconds, {int sampleRate = 16000}) =>
-    Float32List((seconds * sampleRate).round());
 
 /// A canonical 44-byte-header, 16-bit PCM wav of silence.
 Uint8List _wavBytes({

--- a/mobile/hayamimi_core/test/live_transcriber_session_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_session_test.dart
@@ -358,7 +358,7 @@ void main() {
 
       expect(
         h.refines.single.text,
-        '東京の天気は晴れです。 あしたの会議は十時からです。 資料は昨日送りました。',
+        '東京の天気は晴れです。あしたの会議は十時からです。資料は昨日送りました。',
       );
       expect(h.refines.single.text, contains('。'));
       expect(h.refines.single.punctuated, isTrue);

--- a/mobile/hayamimi_core/test/live_transcriber_session_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_session_test.dart
@@ -210,8 +210,8 @@ void main() {
   group('Japanese punctuation', () {
     // The punctuation model runs inside the worker, so what a session can be
     // checked for here is what it does with a punctuated reply: it is passed
-    // through untouched, it is reported, and it does not quietly excuse a
-    // refine that lost content.
+    // through untouched, it is reported, it reaches the refine buffer, and
+    // it does not quietly excuse a refine that lost content.
 
     test('a ja refine is emitted as the worker punctuated it', () async {
       await h.start(punctuation: h.writePunctuationFiles());
@@ -232,10 +232,25 @@ void main() {
 
       expect(h.refines.single.text, '今日めっちゃ疲れたわ。もう寝る。');
       expect(h.refines.single.punctuated, isTrue);
-      // Only the refine. The final that came before it is the recognizer's
-      // own text, and says so.
+      // The final the worker sent unpunctuated stays unpunctuated and says
+      // so -- the flag reports what the worker did, it is not inferred from
+      // the session's configuration.
       expect(h.entries.single.text, '今日めっちゃ疲れたわ');
       expect(h.entries.single.punctuated, isFalse);
+    });
+
+    test('a ja final is emitted as the worker punctuated it', () async {
+      // The default now: a session with a punctuation model gets its fast
+      // line punctuated too, not only its refines.
+      await h.start(punctuation: h.writePunctuationFiles());
+      expect(h.worker.config!.punctuateFinals, isTrue);
+
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('東京の天気は晴れです。', lang: 'ja', punctuated: true);
+      await settle();
+
+      expect(h.entries.single.text, '東京の天気は晴れです。');
+      expect(h.entries.single.punctuated, isTrue);
     });
 
     test('an unpunctuated refine still reports itself as such', () async {
@@ -315,6 +330,99 @@ void main() {
 
       expect(h.refines.single.text, 'あいうえおかきくけこ、さしすせそたちつてと。');
       expect(h.refines.single.punctuated, isTrue);
+    });
+
+    test('a refine that lost content falls back to the punctuated finals', () async {
+      // The case the Android emulator hit: three sentences, each finalized
+      // fine, and a merged re-decode that comes back holding only the last
+      // of them, because this ja transducer keeps the last utterance of
+      // multi-utterance audio. The guard rejects that re-decode -- and the
+      // text it falls back to is punctuated, because the finals were.
+      await h.start(punctuation: h.writePunctuationFiles());
+
+      for (final sentence in <String>[
+        '東京の天気は晴れです。',
+        'あしたの会議は十時からです。',
+        '資料は昨日送りました。',
+      ]) {
+        await h.endSegment(seconds: 1.0);
+        h.worker.reply(sentence, lang: 'ja', punctuated: true);
+        await settle();
+      }
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      h.worker.reply('資料は昨日送りました。', lang: 'ja', punctuated: true);
+      await settle();
+      await refine;
+
+      expect(
+        h.refines.single.text,
+        '東京の天気は晴れです。 あしたの会議は十時からです。 資料は昨日送りました。',
+      );
+      expect(h.refines.single.text, contains('。'));
+      expect(h.refines.single.punctuated, isTrue);
+    });
+
+    test('the shrink comparison strips the marks off the fast text too', () async {
+      // Both sides can be punctuated now, so both are measured without
+      // their marks. Here the fast finals are mark-heavy: counted raw they
+      // are 21 characters and the 12-character re-decode looks like a loss;
+      // counted as words -- 11 against 12 -- it lost nothing.
+      await h.start(punctuation: h.writePunctuationFiles());
+
+      for (final sentence in <String>[
+        'あ、い、う、え、お。',
+        'か、き、く、け、こ。',
+      ]) {
+        await h.endSegment(seconds: 1.0);
+        h.worker.reply(sentence, lang: 'ja', punctuated: true);
+        await settle();
+      }
+      expect('あ、い、う、え、お。 か、き、く、け、こ。'.length, 21);
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      h.worker.reply('あいうえお、かきくけこ。', lang: 'ja', punctuated: true);
+      await settle();
+      await refine;
+
+      expect(h.refines.single.text, 'あいうえお、かきくけこ。');
+      expect(h.refines.single.punctuated, isTrue);
+    });
+
+    test('applyToFinals: false leaves the finals -- and the fallback -- unpunctuated', () async {
+      // The switch is honoured in the worker, which this test stands in
+      // for, so it is checked in two places: the config the session sent,
+      // and what the session does with the unpunctuated finals that follow.
+      await h.start(
+        punctuation: h.writePunctuationFiles(applyToFinals: false),
+      );
+      expect(h.worker.config!.punctuateFinals, isFalse);
+
+      for (final sentence in <String>[
+        '東京の天気は晴れです',
+        'あしたの会議は十時からです',
+        '資料は昨日送りました',
+      ]) {
+        await h.endSegment(seconds: 1.0);
+        h.worker.reply(sentence, lang: 'ja');
+        await settle();
+      }
+      expect(h.entries.every((e) => !e.punctuated), isTrue);
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      h.worker.reply('資料は昨日送りました。', lang: 'ja', punctuated: true);
+      await settle();
+      await refine;
+
+      expect(
+        h.refines.single.text,
+        '東京の天気は晴れです あしたの会議は十時からです 資料は昨日送りました',
+      );
+      expect(h.refines.single.text, isNot(contains('。')));
+      expect(h.refines.single.punctuated, isFalse);
     });
   });
 
@@ -733,13 +841,17 @@ class _Harness {
   /// Stand-ins for the punctuation model and its vocabulary. `start()`
   /// checks both files exist before it spawns anything; the fake worker
   /// never loads them, so their contents do not matter.
-  JaPunctuation writePunctuationFiles() {
+  JaPunctuation writePunctuationFiles({bool applyToFinals = true}) {
     final sep = Platform.pathSeparator;
     final model = '${modelDir.path}${sep}punct.onnx';
     final vocab = '${modelDir.path}${sep}vocab.txt';
     File(model).writeAsBytesSync(<int>[0]);
     File(vocab).writeAsStringSync('[PAD]\n');
-    return JaPunctuation(modelPath: model, vocabPath: vocab);
+    return JaPunctuation(
+      modelPath: model,
+      vocabPath: vocab,
+      applyToFinals: applyToFinals,
+    );
   }
 
   /// Delivers [count] frames' worth of microphone audio.

--- a/mobile/hayamimi_core/test/live_transcriber_session_test.dart
+++ b/mobile/hayamimi_core/test/live_transcriber_session_test.dart
@@ -206,6 +206,117 @@ void main() {
     });
   });
 
+  group('Japanese punctuation', () {
+    // The punctuation model runs inside the worker, so what a session can be
+    // checked for here is what it does with a punctuated reply: it is passed
+    // through untouched, it is reported, and it does not quietly excuse a
+    // refine that lost content.
+
+    test('a ja refine is emitted as the worker punctuated it', () async {
+      await h.start(punctuation: h.writePunctuationFiles());
+
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('今日めっちゃ疲れたわ', lang: 'ja');
+      await settle();
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      h.worker.reply(
+        '今日めっちゃ疲れたわ。もう寝る。',
+        lang: 'ja',
+        punctuated: true,
+      );
+      await settle();
+      await refine;
+
+      expect(h.refines.single.text, '今日めっちゃ疲れたわ。もう寝る。');
+      expect(h.refines.single.punctuated, isTrue);
+      // Only the refine. The final that came before it is the recognizer's
+      // own text, and says so.
+      expect(h.entries.single.text, '今日めっちゃ疲れたわ');
+      expect(h.entries.single.punctuated, isFalse);
+    });
+
+    test('an unpunctuated refine still reports itself as such', () async {
+      // What a routed session's non-Japanese refine, or any session started
+      // without a punctuation model, looks like from here.
+      await h.start();
+
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('hello there', lang: 'en');
+      await settle();
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      h.worker.reply('hello there, refined', lang: 'en');
+      await settle();
+      await refine;
+
+      expect(h.refines.single.punctuated, isFalse);
+    });
+
+    test('restored marks do not save a refine that lost content', () async {
+      // The fallback guard compares lengths, and punctuation adds
+      // characters nobody said. Here the marks alone are what would push a
+      // truncated re-decode over the 0.7 threshold, so this is the case
+      // that fails if the comparison forgets to strip them.
+      await h.start(punctuation: h.writePunctuationFiles());
+
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('あいうえおかきくけこ', lang: 'ja');
+      await settle();
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('さしすせそたちつてと', lang: 'ja');
+      await settle();
+
+      // 21 characters of fast text; the guard fires below 14.7 of them.
+      const fastText = 'あいうえおかきくけこ さしすせそたちつてと';
+      expect(fastText.length, 21);
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      // 13 characters of speech, 16 with the marks: over the threshold as
+      // sent, under it once the marks come off.
+      h.worker.reply(
+        'あい、うえお。かきくけこさしす。',
+        lang: 'ja',
+        punctuated: true,
+      );
+      await settle();
+      await refine;
+
+      expect(h.refines.single.text, fastText);
+      // The text that survived is the finals', which nothing punctuated.
+      expect(h.refines.single.punctuated, isFalse);
+    });
+
+    test('a long enough punctuated refine keeps its own text', () async {
+      // The other side of the same guard: a refine that did not lose
+      // anything is emitted as the worker sent it, marks included.
+      await h.start(punctuation: h.writePunctuationFiles());
+
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('あいうえおかきくけこ', lang: 'ja');
+      await settle();
+      await h.endSegment(seconds: 1.0);
+      h.worker.reply('さしすせそたちつてと', lang: 'ja');
+      await settle();
+
+      final refine = h.transcriber.refineNow();
+      await settle();
+      h.worker.reply(
+        'あいうえおかきくけこ、さしすせそたちつてと。',
+        lang: 'ja',
+        punctuated: true,
+      );
+      await settle();
+      await refine;
+
+      expect(h.refines.single.text, 'あいうえおかきくけこ、さしすせそたちつてと。');
+      expect(h.refines.single.punctuated, isTrue);
+    });
+  });
+
   group('resetSession', () {
     test('lands behind the segment still decoding, then clears and reports', () async {
       await h.start();
@@ -424,11 +535,24 @@ class _Harness {
     return worker;
   }
 
-  Future<void> start() => transcriber.start(
+  Future<void> start({JaPunctuation? punctuation}) => transcriber.start(
     modelKind: ModelKind.zipformerTransducer,
     modelDir: modelDir.path,
     vadModelPath: vadModelPath,
+    punctuation: punctuation,
   );
+
+  /// Stand-ins for the punctuation model and its vocabulary. `start()`
+  /// checks both files exist before it spawns anything; the fake worker
+  /// never loads them, so their contents do not matter.
+  JaPunctuation writePunctuationFiles() {
+    final sep = Platform.pathSeparator;
+    final model = '${modelDir.path}${sep}punct.onnx';
+    final vocab = '${modelDir.path}${sep}vocab.txt';
+    File(model).writeAsBytesSync(<int>[0]);
+    File(vocab).writeAsStringSync('[PAD]\n');
+    return JaPunctuation(modelPath: model, vocabPath: vocab);
+  }
 
   /// Delivers [count] frames' worth of microphone audio.
   Future<void> pushFrames(int count) async {

--- a/mobile/hayamimi_core/test/preroll_test.dart
+++ b/mobile/hayamimi_core/test/preroll_test.dart
@@ -1,0 +1,206 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hayamimi_core/live/preroll.dart';
+
+/// [PrerollHistory] on its own: the rolling buffer, and the two rules that
+/// decide how far back a segment is allowed to reach.
+///
+/// Everything here runs at a made-up 100 Hz sample rate. The class only
+/// uses the rate to turn seconds into sample counts, and 100 makes the
+/// arithmetic readable — one second of "audio" is 100 samples, so a
+/// position and an index are the same number. The desktop tests this
+/// mirrors (`tests/test_units.py`) do the same.
+void main() {
+  const sampleRate = 100;
+
+  /// [count] samples whose value is their own absolute position, so an
+  /// assertion on a sample's value is an assertion on where it came from.
+  Float32List ramp(int from, int count) =>
+      Float32List.fromList(List<double>.generate(count, (i) => (from + i) * 1.0));
+
+  /// A stand-in for one segment's own audio, distinguishable from [ramp]'s.
+  Float32List speech(int count) => Float32List(count)..fillRange(0, count, -1.0);
+
+  PrerollHistory history({double keepSeconds = defaultPrerollKeepSeconds}) =>
+      PrerollHistory(sampleRate: sampleRate, keepSeconds: keepSeconds);
+
+  group('push', () {
+    test('keeps everything while under the keep window', () {
+      final h = history(keepSeconds: 5.0); // 500 samples
+      for (var i = 0; i < 4; i++) {
+        h.push(ramp(i * 100, 100));
+      }
+
+      expect(h.bufferedSamples, 400);
+      expect(h.offset, 0);
+    });
+
+    test('drops the oldest frames once past it, and says so through offset', () {
+      final h = history(keepSeconds: 5.0); // 500 samples
+      for (var i = 0; i < 20; i++) {
+        h.push(ramp(i * 100, 100));
+      }
+
+      // 2000 samples pushed, 500 kept: the first 1500 are gone, and offset
+      // is what says where the remaining audio starts.
+      expect(h.bufferedSamples, 500);
+      expect(h.offset, 1500);
+    });
+
+    test('never drops below the keep window it promised', () {
+      // Frames that do not divide the window evenly: dropping one more
+      // would leave less than 500 samples, so it is kept and the buffer
+      // sits slightly above the window instead of below it.
+      final h = history(keepSeconds: 5.0);
+      for (var i = 0; i < 20; i++) {
+        h.push(ramp(i * 30, 30));
+      }
+
+      expect(h.bufferedSamples, greaterThanOrEqualTo(500));
+      expect(h.bufferedSamples, lessThan(500 + 30));
+    });
+
+    test('ignores an empty frame', () {
+      final h = history();
+      h.push(Float32List(0));
+
+      expect(h.bufferedSamples, 0);
+    });
+  });
+
+  group('withPreroll', () {
+    test('prepends a full second of the audio before the onset', () {
+      final h = history();
+      h.push(ramp(0, 1000));
+
+      final out = h.withPreroll(
+        segmentStartSample: 500,
+        samples: speech(10),
+      );
+
+      expect(out.length, 100 + 10);
+      // The prepended samples are exactly positions 400..499, i.e. the
+      // second of audio immediately before the VAD noticed anything.
+      expect(out[0], 400.0);
+      expect(out[99], 499.0);
+      // ...followed by the segment's own audio, unchanged.
+      expect(out[100], -1.0);
+    });
+
+    test('prepends only what exists when the session just started', () {
+      final h = history();
+      h.push(ramp(0, 30)); // less than the 100 samples a second wants
+
+      final out = h.withPreroll(segmentStartSample: 30, samples: speech(10));
+
+      expect(out.length, 30 + 10);
+      expect(out[0], 0.0);
+    });
+
+    test('returns the segment untouched when nothing has been pushed', () {
+      final h = history();
+      final samples = speech(10);
+
+      final out = h.withPreroll(segmentStartSample: 0, samples: samples);
+
+      expect(identical(out, samples), isTrue);
+    });
+
+    test('never reaches back into the previous segment', () {
+      final h = history();
+      h.push(ramp(0, 1000));
+
+      // First segment runs 300..399.
+      h.withPreroll(segmentStartSample: 300, samples: speech(100));
+      // The second starts 50 samples later. A full second of pre-roll would
+      // start at 350, inside the first segment; it is clamped to 400.
+      final out = h.withPreroll(segmentStartSample: 450, samples: speech(10));
+
+      expect(out.length, 50 + 10);
+      expect(out[0], 400.0);
+    });
+
+    test('two adjacent segments together cover their audio exactly once', () {
+      final h = history();
+      h.push(ramp(0, 1000));
+
+      final first = h.withPreroll(segmentStartSample: 300, samples: speech(100));
+      final second = h.withPreroll(segmentStartSample: 450, samples: speech(10));
+
+      // 200..399 and 400..459: 260 samples for the 260 the two segments and
+      // their run-ups span, with none of it counted twice.
+      expect(first.length + second.length, 260);
+    });
+
+    test('does not reach past audio the buffer has already dropped', () {
+      final h = history(keepSeconds: 5.0);
+      for (var i = 0; i < 20; i++) {
+        h.push(ramp(i * 100, 100));
+      }
+      expect(h.offset, 1500);
+
+      final out = h.withPreroll(segmentStartSample: 1550, samples: speech(10));
+
+      // A full second back would be 1450, which is gone; it starts at the
+      // oldest sample still held instead.
+      expect(out.length, 50 + 10);
+      expect(out[0], 1500.0);
+    });
+
+    test('prerollSeconds of 0 turns it off', () {
+      final h = history();
+      h.push(ramp(0, 1000));
+      final samples = speech(10);
+
+      final out = h.withPreroll(
+        segmentStartSample: 500,
+        samples: samples,
+        prerollSeconds: 0,
+      );
+
+      expect(identical(out, samples), isTrue);
+    });
+
+    test('a segment starting beyond the pushed audio is left alone', () {
+      // A stand-in VAD in a test can report a position no audio was ever
+      // pushed for; that must read as "no context available", not throw.
+      final h = history();
+      h.push(ramp(0, 100));
+      final samples = speech(10);
+
+      final out = h.withPreroll(segmentStartSample: 5000, samples: samples);
+
+      expect(identical(out, samples), isTrue);
+    });
+
+    test('moves lastSegmentEnd past the segment, even when nothing was prepended', () {
+      final h = history();
+      h.push(ramp(0, 1000));
+
+      h.withPreroll(
+        segmentStartSample: 300,
+        samples: speech(100),
+        prerollSeconds: 0,
+      );
+
+      expect(h.lastSegmentEnd, 400);
+    });
+
+    test('reads across frame boundaries', () {
+      // The pre-roll window almost never lines up with the frames it was
+      // pushed in, so the copy has to stitch parts of several together.
+      final h = history();
+      for (var i = 0; i < 10; i++) {
+        h.push(ramp(i * 7, 7)); // 70 samples in frames of 7
+      }
+
+      final out = h.withPreroll(segmentStartSample: 70, samples: speech(1));
+
+      expect(out.length, 70 + 1);
+      for (var i = 0; i < 70; i++) {
+        expect(out[i], i * 1.0);
+      }
+    });
+  });
+}

--- a/mobile/hayamimi_core/test/punct/punct_ja_text_test.dart
+++ b/mobile/hayamimi_core/test/punct/punct_ja_text_test.dart
@@ -216,4 +216,25 @@ void main() {
       expect(applyQuestionMarks(''), '');
     });
   });
+
+  group('withoutRestoredMarks', () {
+    test('removes exactly the marks the restorer writes', () {
+      expect(
+        withoutRestoredMarks('今日は疲れた、もう寝る。元気ですか？'),
+        '今日は疲れたもう寝る元気ですか',
+      );
+      expect(restoredMarkCharacters, <String>{'、', '。', '？'});
+    });
+
+    test('leaves marks the restorer never writes alone', () {
+      // It recognizes these in its input but never produces one, so
+      // stripping them would change text the recognizer actually emitted.
+      expect(withoutRestoredMarks('「あい」・うえ！'), '「あい」・うえ！');
+    });
+
+    test('returns text with no marks, and empty text, unchanged', () {
+      expect(withoutRestoredMarks('あいうえお'), 'あいうえお');
+      expect(withoutRestoredMarks(''), '');
+    });
+  });
 }

--- a/mobile/hayamimi_core/test/punct/punct_worker_load_test.dart
+++ b/mobile/hayamimi_core/test/punct/punct_worker_load_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hayamimi_core/hayamimi_core.dart';
+
+import 'punct_test_paths.dart';
+
+/// The step where a session's punctuation model becomes a running
+/// `PunctuatorJa`: `loadWorkerPunctuator`, given the same
+/// [DecodeWorkerConfig] the decode worker isolate receives.
+///
+/// The rest of the worker cannot be exercised in a `flutter test` run — its
+/// first act is to bind the sherpa-onnx native library, which no test VM can
+/// load — but this part can, because ONNX Runtime is reachable on this host
+/// (the same way the parity test reaches it). So the load is run in-process
+/// instead of in an isolate: same config object, same function, no spawn.
+///
+/// The one test that needs the 182 MB model skips with a reason naming what
+/// is missing; everything else here runs on any checkout.
+void main() {
+  final String? modelPath = PunctTestPaths.modelPath();
+  final String? vocabPath = PunctTestPaths.vocabPath();
+  final String? libraryPath = PunctTestPaths.ortLibraryPath();
+
+  String? skipReason() {
+    if (modelPath == null) {
+      return 'the float16 punctuation model is not in '
+          'models/mojicast-punct-onnx/quantized_ort/ — build it with '
+          '"python scripts/quantize_punct.py --variant fp16"';
+    }
+    if (vocabPath == null) {
+      return 'models/mojicast-punct-onnx/vocab.txt is missing — see '
+          'docs/PUNCT_JA.md';
+    }
+    if (libraryPath == null) {
+      return 'no ONNX Runtime shared library was found (on Windows it comes '
+          'from the sherpa_onnx_windows package; elsewhere set '
+          '${PunctTestPaths.libraryEnvVar})';
+    }
+    return null;
+  }
+
+  test('a config with punctuation paths builds a working punctuator', () async {
+    final config = DecodeWorkerConfig(
+      routed: false,
+      modelDir: '/models/ja',
+      punctModelPath: modelPath!,
+      punctVocabPath: vocabPath!,
+      punctLibraryPath: libraryPath,
+    );
+    final loads = <DecodeWorkerModelLoad>[];
+
+    final punctuator = await loadWorkerPunctuator(
+      config,
+      onModelLoad: loads.add,
+    );
+    addTearDown(() => punctuator?.dispose());
+
+    expect(punctuator, isNotNull);
+    expect(punctuator!.restore('今日めっちゃ疲れたわもう寝る'), '今日めっちゃ疲れたわ。もう寝る。');
+
+    // The progress a host UI sees while a session starts, reported under the
+    // same model name every other model uses.
+    expect(loads.map((e) => '${e.model}/${e.phase}'), <String>[
+      'punct/start',
+      'punct/done',
+    ]);
+    expect(loads.first.ms, isNull);
+    expect(loads.last.ms, greaterThan(0));
+  }, skip: skipReason());
+
+  test('a config with no punctuation paths builds nothing', () async {
+    const config = DecodeWorkerConfig(routed: false, modelDir: '/models/ja');
+
+    expect(await loadWorkerPunctuator(config), isNull);
+  });
+
+  test('a model that cannot be read fails, naming both files', () async {
+    const config = DecodeWorkerConfig(
+      routed: false,
+      modelDir: '/models/ja',
+      punctModelPath: '/definitely/does/not/exist/punct.onnx',
+      punctVocabPath: '/definitely/does/not/exist/vocab.txt',
+    );
+    final loads = <DecodeWorkerModelLoad>[];
+
+    await expectLater(
+      loadWorkerPunctuator(config, onModelLoad: loads.add),
+      throwsA(
+        isA<DecodeWorkerException>().having(
+          (e) => e.message,
+          'message',
+          allOf(
+            contains('Japanese punctuation model'),
+            contains('/definitely/does/not/exist/punct.onnx'),
+            contains('/definitely/does/not/exist/vocab.txt'),
+          ),
+        ),
+      ),
+    );
+
+    // The failure is reported by the throw, so the load it announced is
+    // left without a matching "done" -- the same shape a recognizer that
+    // fails to build leaves behind.
+    expect(loads.map((e) => '${e.model}/${e.phase}'), <String>['punct/start']);
+  });
+
+  test('a config cannot name the model without its vocabulary', () {
+    // Both files or neither: a half-configured session would otherwise
+    // reach the worker and fail there instead of where it was written.
+    expect(
+      () => DecodeWorkerConfig(
+        routed: false,
+        modelDir: '/models/ja',
+        punctModelPath: '/models/punct/punct_bert.fp16.onnx',
+      ),
+      throwsAssertionError,
+    );
+    expect(
+      () => DecodeWorkerConfig(
+        routed: false,
+        modelDir: '/models/ja',
+        punctVocabPath: '/models/punct/vocab.txt',
+      ),
+      throwsAssertionError,
+    );
+  });
+}

--- a/mobile/hayamimi_core/test/refine_pass_test.dart
+++ b/mobile/hayamimi_core/test/refine_pass_test.dart
@@ -9,6 +9,7 @@ RefineSegment _segment({
   int sampleRate = 16000,
   DateTime? capturedAt,
   double fill = 0,
+  bool punctuated = false,
 }) {
   final samples = Float32List((seconds * sampleRate).round());
   if (fill != 0) {
@@ -20,6 +21,7 @@ RefineSegment _segment({
     samples: samples,
     text: text,
     capturedAt: capturedAt ?? DateTime(2026),
+    punctuated: punctuated,
   );
 }
 
@@ -106,6 +108,43 @@ void main() {
     test('returns empty string for no usable text', () {
       final segments = [_segment(seconds: 0.1, text: ''), _segment(seconds: 0.1, text: '   ')];
       expect(combineSegmentFastText(segments), '');
+    });
+  });
+
+  group('isCombinedFastTextPunctuated', () {
+    test('true when every segment contributing text was punctuated', () {
+      final segments = [
+        _segment(seconds: 0.1, text: '東京の天気は晴れです。', punctuated: true),
+        _segment(seconds: 0.1, text: '資料は昨日送りました。', punctuated: true),
+      ];
+      expect(isCombinedFastTextPunctuated(segments), isTrue);
+    });
+
+    test('false when any contributing segment was not', () {
+      // A group half of whose finals went through the punctuation model
+      // joins into a line that is partly punctuated, which is not a line a
+      // consumer can treat as punctuated.
+      final segments = [
+        _segment(seconds: 0.1, text: '東京の天気は晴れです。', punctuated: true),
+        _segment(seconds: 0.1, text: '資料は昨日送りました'),
+      ];
+      expect(isCombinedFastTextPunctuated(segments), isFalse);
+    });
+
+    test('ignores blank segments, which contribute nothing to the join', () {
+      final segments = [
+        _segment(seconds: 0.1, text: '   '),
+        _segment(seconds: 0.1, text: '東京の天気は晴れです。', punctuated: true),
+      ];
+      expect(isCombinedFastTextPunctuated(segments), isTrue);
+    });
+
+    test('false for a group with no text at all', () {
+      expect(isCombinedFastTextPunctuated(const []), isFalse);
+      expect(
+        isCombinedFastTextPunctuated([_segment(seconds: 0.1, text: '')]),
+        isFalse,
+      );
     });
   });
 

--- a/mobile/hayamimi_core/test/refine_pass_test.dart
+++ b/mobile/hayamimi_core/test/refine_pass_test.dart
@@ -96,13 +96,40 @@ void main() {
   });
 
   group('combineSegmentFastText', () {
-    test('joins non-blank segment text with spaces', () {
+    test('joins non-blank, unpunctuated segment text with spaces', () {
       final segments = [
         _segment(seconds: 0.1, text: 'こんにちは'),
         _segment(seconds: 0.1, text: '  '),
         _segment(seconds: 0.1, text: '世界'),
       ];
       expect(combineSegmentFastText(segments), 'こんにちは 世界');
+    });
+
+    test('joins a fully punctuated group with no separator', () {
+      // Every sentence already ends in 。, so a following space would be a
+      // second, redundant separator -- not how Japanese is set.
+      final segments = [
+        _segment(seconds: 0.1, text: '東京の天気は晴れです。', punctuated: true),
+        _segment(seconds: 0.1, text: '資料は昨日送りました。', punctuated: true),
+      ];
+      expect(
+        combineSegmentFastText(segments),
+        '東京の天気は晴れです。資料は昨日送りました。',
+      );
+    });
+
+    test('falls back to spaces for a mixed group, which is not punctuated', () {
+      // isCombinedFastTextPunctuated is all-or-nothing; a group where only
+      // some finals were punctuated is not treated as punctuated, so the
+      // join keeps the space separator it needs for the unpunctuated part.
+      final segments = [
+        _segment(seconds: 0.1, text: '東京の天気は晴れです。', punctuated: true),
+        _segment(seconds: 0.1, text: '資料は昨日送りました'),
+      ];
+      expect(
+        combineSegmentFastText(segments),
+        '東京の天気は晴れです。 資料は昨日送りました',
+      );
     });
 
     test('returns empty string for no usable text', () {

--- a/mobile/hayamimi_core/test/remote_event_test.dart
+++ b/mobile/hayamimi_core/test/remote_event_test.dart
@@ -24,7 +24,7 @@ void main() {
       final event = parseRemoteEvent(
         '{"type": "final", "text": "こんにちは", "lang": "ja", '
         '"speaker": "spk1", "latency_ms": 123.5, "tier": "fast", '
-        '"audio_s": 2.5, "switched": true}',
+        '"audio_s": 2.5, "switched": true, "punctuated": true}',
       );
       expect(event, isA<RemoteFinalEvent>());
       final finalEvent = event as RemoteFinalEvent;
@@ -35,6 +35,7 @@ void main() {
       expect(finalEvent.tier, 'fast');
       expect(finalEvent.audioSeconds, 2.5);
       expect(finalEvent.switched, isTrue);
+      expect(finalEvent.punctuated, isTrue);
     });
 
     test('parses a final event with missing optional fields as defaults', () {
@@ -46,6 +47,9 @@ void main() {
       expect(finalEvent.tier, '');
       expect(finalEvent.audioSeconds, isNull);
       expect(finalEvent.switched, isFalse);
+      // No real server sends `punctuated` on a final frame yet -- the field
+      // exists so the two paths agree, not because one is filling it in.
+      expect(finalEvent.punctuated, isFalse);
     });
 
     test('parses a translation event', () {

--- a/mobile/hayamimi_core/test/subtitle_event_test.dart
+++ b/mobile/hayamimi_core/test/subtitle_event_test.dart
@@ -25,10 +25,11 @@ void main() {
         'latency_ms': null,
         'audio_s': null,
         'switched': false,
+        'punctuated': false,
       });
     });
 
-    test('toJson carries lang/speaker/latency/audio_s/switched through', () {
+    test('toJson carries lang/speaker/latency/audio_s/switched/punctuated through', () {
       const event = FinalSubtitleEvent(
         text: 'hello',
         lang: 'ja',
@@ -36,6 +37,7 @@ void main() {
         latencyMs: 123.5,
         audioSeconds: 2.5,
         switched: true,
+        punctuated: true,
       );
       expect(event.toJson(), {
         'type': 'final',
@@ -45,6 +47,7 @@ void main() {
         'latency_ms': 123.5,
         'audio_s': 2.5,
         'switched': true,
+        'punctuated': true,
       });
     });
 

--- a/mobile/hayamimi_core/test/subtitle_event_test.dart
+++ b/mobile/hayamimi_core/test/subtitle_event_test.dart
@@ -67,6 +67,7 @@ void main() {
         'speaker': '',
         'latency_ms': null,
         'audio_s': null,
+        'punctuated': false,
       });
     });
 
@@ -85,7 +86,20 @@ void main() {
         'speaker': 'S2',
         'latency_ms': 456.0,
         'audio_s': 12.0,
+        'punctuated': false,
       });
+    });
+
+    test('toJson reports restored Japanese punctuation', () {
+      // A consumer that receives this over the LAN can tell text the
+      // punctuation model wrote from text the recognizer produced.
+      const event = RefineSubtitleEvent(
+        text: '今日は疲れた。もう寝る。',
+        lang: 'ja',
+        punctuated: true,
+      );
+      expect(event.toJson()['punctuated'], isTrue);
+      expect(event.toJson()['text'], '今日は疲れた。もう寝る。');
     });
   });
 

--- a/mobile/hayamimi_core/test/vad_sensitivity_test.dart
+++ b/mobile/hayamimi_core/test/vad_sensitivity_test.dart
@@ -3,12 +3,18 @@ import 'package:hayamimi_core/live/vad_sensitivity.dart';
 
 void main() {
   group('VadSensitivity', () {
-    test('default constructor reproduces sherpa-onnx\'s own VAD defaults', () {
+    test('the default constructor matches the desktop pipeline\'s tuned values', () {
+      // minSilenceSeconds/maxSpeechSeconds are the desktop's
+      // (scripts/realtime_transcribe.py), not sherpa-onnx's 0.5/5.0: the
+      // stock silence default merged three spoken sentences into one
+      // segment on an Android emulator and the recognizer then returned
+      // only the last of them. threshold/minSpeechSeconds are
+      // sherpa-onnx's own, which the desktop also leaves alone.
       final sensitivity = VadSensitivity();
       expect(sensitivity.threshold, 0.5);
-      expect(sensitivity.minSilenceSeconds, 0.5);
+      expect(sensitivity.minSilenceSeconds, 0.35);
       expect(sensitivity.minSpeechSeconds, 0.25);
-      expect(sensitivity.maxSpeechSeconds, 5.0);
+      expect(sensitivity.maxSpeechSeconds, 12.0);
     });
 
     test('accepts and reads back custom values', () {


### PR DESCRIPTION
Release preparation for `hayamimi_core` 0.1.0: issue #15 phase 2 (punctuation wired into the refine pass), issue #16 (pub.dev readiness), and the fixes that came out of the first Android emulator run of this package. **Stacked**: base branch is `agent/feature/decode-isolate` (#44), and this branch also contains #43's commits (merged, no conflicts) because both #15 phases and #24 touch the same package. Once #42, #44 and #43 merge, retarget this PR to `main` and the diff shrinks to what is described here.

## Problem

Three things stood between the package and a first release. The Japanese punctuation restorer from #43 existed as a standalone class but the refine ("清書") output still came out without 、。 on a phone. The package had never been checked against pub.dev's requirements (description length, platform declaration, a README that works as a landing page with absolute links, an API reference that builds without warnings, notices scoped to what the package actually ships). And nothing in #24 or #15 had ever run on Android, so the claims about the worker isolate and the shared ONNX Runtime were reasoning, not observation.

## Change

- **Punctuation in the pipeline (#15 phase 2).** `HayamimiLive.start(..., punctuation: JaPunctuation(modelPath:, vocabPath:))` loads `PunctuatorJa` inside the decode worker isolate (so the native call never lands on the UI isolate) and applies it to Japanese refine results and, by default, to Japanese finals (`JaPunctuation.applyToFinals`, off = refine only); `FinalSubtitleEvent` and `RefineSubtitleEvent` gain `punctuated`. Finals are punctuated for the same reason the desktop does it: when a multi-sentence refine's re-decode collapses (a known model property) and the package falls back to the joined fast text, that text must already carry its marks — the third emulator run caught exactly this case coming out unpunctuated before the change. Drafts stay unpunctuated. A punctuated fallback is joined without spaces (Japanese sets `。` with no space after it), and the punctuation model is warmed once during its own load phase so its ~300 ms first-inference cost lands in the reported `model_load` time instead of on the first caption line. A load failure fails `start()` with the file names, on purpose: on a phone a missing 182 MB model is a configuration error, not something to degrade quietly.
- **pub.dev readiness (#16).** One-sentence `description`, `issue_tracker`, an explicit `platforms: android, ios`; the 0.1.0 CHANGELOG rewritten as one coherent release entry; the README reorganized as the landing page (embedding guide with `initBindings()` and permissions, model placement guide with the exact directory layout each profile expects, platform status, absolute links); THIRD_PARTY_NOTICES and the LICENSE note scoped to this package's real dependencies and models; dartdoc warnings fixed and the consumer-facing public API documented. `flutter pub publish --dry-run` reports 0 warnings; the standalone dartdoc reports 0 warnings and 0 errors. (The SDK's bundled `dart doc` 9.0.6 crashes on this Windows machine for an unrelated CRLF bug in the Flutter SDK's own sources, dart-lang/dartdoc#4266; not a package problem.)
- **Android emulator run, and what it changed.** On an x86_64 AVD (API 35, host Ryzen 5 5600), the decode worker isolate started, built its models and was torn down and rebuilt three times without error; `libonnxruntime.so` resolved to sherpa_onnx's single copy (the APK contains exactly one); ja refines came out `punctuated: true` with 。 at the same sentence ends as the Python reference. The run also showed that the package's VAD defaults (0.5 s silence, 5 s max speech) merged three sentences into one segment so the refine returned only the last one, and that utterance onsets were clipped because the package had no pre-roll. This branch therefore changes the VAD defaults to the desktop's tuned 0.35 s / 12 s, adds a 1.0 s pre-roll (`prerollSeconds`, runtime-settable, clamped so adjacent segments never double-include audio — the same rule as the desktop's `AudioHistory.with_preroll`), and makes `startDebugWavStream` finish with the refine it promises instead of tearing down first. The full run is recorded in `docs/MOBILE.md`.

## Why this shape

Punctuation runs where decoding runs so #24's guarantee (no recognizer call on the UI isolate) still holds. The VAD defaults follow the desktop because that is the configuration whose accuracy has been measured on real audio; the package's previous defaults were sherpa-onnx's, never tuned for this pipeline. Pre-roll is implemented as a bounded frame queue rather than a growing buffer to avoid copying the whole history on every 32 ms frame.

## Effect

A host app can turn on punctuation with one parameter and get punctuated refine events; the package passes pub.dev's pre-publish checks and ships with a README a first-time reader can follow; on the emulator, a three-sentence clip now segments like the desktop does. Publishing itself, the model hosting decision (the fp16 punctuation model and `vocab.txt` are still local artifacts of `scripts/quantize_punct.py --variant fp16`), and iOS remain with the maintainer.

## Verification

- `flutter analyze`: no issues in `mobile/hayamimi_core`, `mobile/`, `example/`. `flutter test`: 378 passed (base 213 on #42; includes the fake-worker session suite, pre-roll arithmetic tests, and the punctuation parity test, which loads the fp16 model and the pub-cache `onnxruntime.dll` and skips where they are absent).
- `flutter pub publish --dry-run`: 0 warnings. Standalone dartdoc 9.0.9: 0 warnings, 0 errors, 44 libraries.
- Three Android emulator runs (x86_64 AVD, API 35, host Ryzen 5 5600 — not a phone), recorded in `docs/MOBILE.md`. Run 1 verified the worker isolate, the shared ONNX Runtime and punctuated refines, and found the VAD-default merge and the clipped onsets. Run 2, on the changed defaults and pre-roll, produced all three sentences character-for-character equal to the desktop reference (`東京の天気は晴れです。／あしたの会議は十時からです。／資料は昨日送りました。`); a `prerollSeconds: 0` control reproduced run 1's clipped text and exact `audio_s`, and an old-defaults control reproduced the single merged segment. Run 3, after finals became punctuated, showed the multi-sentence fallback refine as `punctuated: true` with 。 at each sentence end (run 2 had it as `punctuated: false`), with an `applyToFinals: false` control reproducing run 2. Measured directly on the same audio, punctuating a final costs +38 to +49 ms on the emulator (61.7/77.6/68.8 ms → 109.5/115.4/117.3 ms for 1.8–2.4 s of audio). Model loads: recognizer median 3.2–3.9 s across runs, punctuation model 1.1–1.3 s, VAD ~35 ms.

Known limitations recorded in the README/CHANGELOG: a refine over a long group can drop its leading sentences (a model property the desktop works around with a split-and-retry that is not ported yet); no physical ARM device run; `RoutingProfile.jaSenseVoice` not exercised on Android; iOS punctuation unverified and refused by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
