### PR TITLE
asr: survive a missing omni fallback model; download the int8 omnilingual tarball

### DIFF
--- a/scripts/asr_engine.py
+++ b/scripts/asr_engine.py
@@ -1575,9 +1575,17 @@ class RoutedASR:
             text, text_model = self._decode(rec, samples, sample_rate), tier
         if not text.strip() and tier != "omni" and not suppress_fallback:
             # safety net: the specialist came back empty (likely LID mistake);
-            # the 1600-language generalist gets the last word.
-            text = self._decode(self._get("omni"), samples, sample_rate)
-            tier, text_model = "omni", "omni"
+            # the 1600-language generalist gets the last word. On a minimal
+            # install (no omni model) the empty result stands: every other
+            # _get() caller already tolerates ModelUnavailable, and letting
+            # it escape here killed the whole live process mid-stream.
+            try:
+                omni = self._get("omni")
+            except ModelUnavailable:
+                omni = None
+            if omni is not None:
+                text = self._decode(omni, samples, sample_rate)
+                tier, text_model = "omni", "omni"
         corrected = script_corrected_lang(lang, text)
         if self.forced_lang is None and live and text.strip() and corrected != lang:
             # the decoded script contradicts the LID tag (romaji-mangled

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -24,6 +24,7 @@ not permissive like the rest.
 import argparse
 import io
 import os
+import shutil
 import sys
 import tarfile
 import urllib.request
@@ -115,23 +116,45 @@ def download_and_extract_tarbz2(url: str, dest_dir: str, label: str) -> None:
 def extract_members_only(url: str, dest_dir: str, wanted_basenames: set, label: str) -> None:
     """Like download_and_extract_tarbz2, but keeps only specific files from
     the tarball (used for omnilingual, where we only need the int8 weights
-    and tokens, not the README/test_wavs)."""
+    and tokens, not the README/test_wavs).
+
+    "Present" means every wanted file exists, not just the directory: an
+    earlier version skipped on the bare directory, so a tarball that lacked
+    one of the wanted files left a half-filled directory behind that every
+    later run then treated as complete (the 2026-09-04 omni incident: the
+    fp32 tarball has no model.int8.onnx, so models/omnilingual-300m-ctc-int8
+    held only tokens.txt and the live fallback route had no model to load).
+    A tarball missing a wanted file is now an error, and the partial
+    directory is removed so the next run retries instead of skipping."""
     target = os.path.join(MODELS_DIR, dest_dir)
-    if os.path.isdir(target):
+    have = {b for b in wanted_basenames if os.path.exists(os.path.join(target, b))}
+    if have == wanted_basenames:
         print(f"[skip] {label} (already present: {target})")
         return
+    if have:
+        print(f"  {target} is incomplete (has {sorted(have)}, "
+              f"needs {sorted(wanted_basenames)}): re-fetching")
     print(f"[get ] {label}")
     tmp = os.path.join(MODELS_DIR, f".{dest_dir}.tar.bz2.part")
     os.makedirs(target, exist_ok=True)
     _download_to(url, tmp)
     print(f"  extracting (selected files) -> {target}")
+    got = set()
     with tarfile.open(tmp, "r:bz2") as tf:
         for member in tf.getmembers():
             base = os.path.basename(member.name)
             if base in wanted_basenames:
                 member.name = base
                 tf.extract(member, target)
+                got.add(base)
     os.remove(tmp)
+    missing = wanted_basenames - got
+    if missing:
+        shutil.rmtree(target, ignore_errors=True)
+        raise RuntimeError(
+            f"{label}: the tarball at {url} does not contain {sorted(missing)} "
+            f"(it has no file by that name); refusing to leave a partial "
+            f"{target} behind. The URL or the wanted file list is wrong.")
 
 
 def download_hf_repo(repo: str, dest_dir: str, label: str, ignore_patterns=None) -> None:
@@ -220,11 +243,14 @@ def main():
         "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
         "Parakeet TDT 0.6B v3 (en + 24 EU languages)")
 
+    # The int8 weights live in their own "-int8-" tarball upstream; the
+    # plain "300M-ctc-2025-11-12" tarball is fp32 only (model.onnx, 1.3GB)
+    # and has no model.int8.onnx at all.
     extract_members_only(
-        f"{GITHUB_RELEASES}/{ASR_TAG}/sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-2025-11-12.tar.bz2",
+        f"{GITHUB_RELEASES}/{ASR_TAG}/sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12.tar.bz2",
         "omnilingual-300m-ctc-int8",
         {"model.int8.onnx", "tokens.txt"},
-        "Meta Omnilingual ASR 300M CTC (~1600-language fallback)")
+        "Meta Omnilingual ASR 300M CTC int8 (~1600-language fallback)")
 
     download_file(
         f"{GITHUB_RELEASES}/{SPEAKER_TAG}/3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx",

--- a/tests/test_download_models.py
+++ b/tests/test_download_models.py
@@ -1,0 +1,74 @@
+"""scripts/download_models.py: the selective tarball extractor must never
+leave a half-filled model directory behind (2026-09-04 omni incident)."""
+import os
+import shutil
+import sys
+import tarfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+import download_models  # noqa: E402
+
+WANTED = {"model.int8.onnx", "tokens.txt"}
+
+
+def _make_tarball(path, names):
+    src = os.path.join(os.path.dirname(path), "src")
+    top = os.path.join(src, "release-dir")
+    os.makedirs(os.path.join(top, "test_wavs"), exist_ok=True)
+    for name in names:
+        with open(os.path.join(top, name), "wb") as f:
+            f.write(b"x" * 16)
+    with open(os.path.join(top, "test_wavs", "en.wav"), "wb") as f:
+        f.write(b"RIFF")
+    with tarfile.open(path, "w:bz2") as tf:
+        tf.add(top, arcname="release-dir")
+    shutil.rmtree(src)
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setattr(download_models, "MODELS_DIR", str(models))
+    fetched = []
+
+    def fake_download(url, dest):
+        fetched.append(url)
+        shutil.copyfile(url, dest)
+
+    monkeypatch.setattr(download_models, "_download_to", fake_download)
+    return tmp_path, models, fetched
+
+
+def test_tarball_without_a_wanted_file_raises_and_leaves_no_partial_dir(sandbox):
+    tmp, models, fetched = sandbox
+    tar = str(tmp / "fp32.tar.bz2")
+    _make_tarball(tar, ["model.onnx", "tokens.txt"])  # no model.int8.onnx
+    with pytest.raises(RuntimeError, match="model.int8.onnx"):
+        download_models.extract_members_only(tar, "omni", WANTED, "omni")
+    assert not (models / "omni").exists(), "a partial directory would be skipped as complete forever"
+    assert not any(n.endswith(".part") for n in os.listdir(models))
+
+
+def test_complete_tarball_extracts_only_the_wanted_files(sandbox):
+    tmp, models, fetched = sandbox
+    tar = str(tmp / "int8.tar.bz2")
+    _make_tarball(tar, ["model.int8.onnx", "tokens.txt", "README.md"])
+    download_models.extract_members_only(tar, "omni", WANTED, "omni")
+    assert set(os.listdir(models / "omni")) == WANTED
+    assert not any(n.endswith(".part") for n in os.listdir(models))
+
+
+def test_partial_dir_is_refetched_and_complete_dir_is_skipped(sandbox):
+    tmp, models, fetched = sandbox
+    tar = str(tmp / "int8.tar.bz2")
+    _make_tarball(tar, ["model.int8.onnx", "tokens.txt"])
+    (models / "omni").mkdir()
+    (models / "omni" / "tokens.txt").write_bytes(b"old")  # the incident's leftover
+    download_models.extract_members_only(tar, "omni", WANTED, "omni")
+    assert fetched == [tar]
+    assert set(os.listdir(models / "omni")) == WANTED
+    download_models.extract_members_only(tar, "omni", WANTED, "omni")
+    assert fetched == [tar], "a complete directory must not be downloaded again"

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -941,3 +941,62 @@ def test_refiner_shutdown_must_drain_full_backlog_not_just_last_task():
     # and there is exactly one persistent worker thread, not one per call
     worker_threads = [t for t in threading.enumerate() if t is refiner._worker_thread]
     assert len(worker_threads) == 1
+
+
+def _omni_safety_net_stub(omni_available: bool):
+    """RoutedASR stub for the empty-specialist safety net in transcribe():
+    --mode single (forced ja), the ja route returns nothing, and the only
+    question is what happens when the omni fallback is or is not installed."""
+    asked = []
+
+    class _Stub:
+        forced_lang = "ja"
+        dual_confirm = False
+        last_lang = None
+        _pending_lang = None
+        _pending_count = 0
+        _unavailable = set() if omni_available else {"omni"}
+        _itn_overrides = asr_engine.itn_cjk.EMPTY_OVERRIDES
+        ko_spacer = None
+        punct = None
+        _looks_truncated = staticmethod(asr_engine.RoutedASR._looks_truncated)
+
+        def _get(self, name):
+            asked.append(name)
+            if name in self._unavailable:
+                raise asr_engine.ModelUnavailable(name)
+            return f"<{name}>"
+
+        def _route(self, lang):
+            assert lang == "ja"
+            return ("<rz>", "rz")
+
+        def _decode(self, rec, samples, sample_rate):
+            return "omni text" if rec == "<omni>" else ""
+
+        def _replace(self, text):
+            return text
+
+    return _Stub(), asked
+
+
+def test_empty_specialist_falls_through_to_omni_when_installed():
+    stub, asked = _omni_safety_net_stub(omni_available=True)
+    result = asr_engine.RoutedASR.transcribe(
+        stub, np.zeros(16000, dtype=np.float32), 16000, live=True)
+    assert asked == ["omni"]
+    assert result["text"] == "omni text"
+    assert result["tier"] == "omni"
+
+
+def test_empty_specialist_stays_empty_on_a_minimal_install():
+    """A minimal install has no omni model. The safety net must degrade to
+    the specialist's empty result (a non-speech line, dropped by the caller)
+    instead of letting ModelUnavailable escape -- on 2026-09-04 that escape
+    took the whole live process down mid-stream on the first empty decode."""
+    stub, asked = _omni_safety_net_stub(omni_available=False)
+    result = asr_engine.RoutedASR.transcribe(
+        stub, np.zeros(16000, dtype=np.float32), 16000, live=True)
+    assert asked == ["omni"]
+    assert result["text"] == ""
+    assert result["tier"] == "rz"


### PR DESCRIPTION
## Problem

While trying language switching on a live microphone (2026-09-04), the whole process died the first time a specialist decode came back empty:

```
asr_engine.ModelUnavailable: omni
```

Two things had gone wrong at once.

1. `transcribe()`'s empty-specialist safety net called `_get("omni")` without catching `ModelUnavailable`, unlike every other `_get()` caller. A short English "Once." under a `ja` tag was enough to reach it.
2. The omnilingual fallback model was not actually installed. `scripts/download_models.py` pointed at the fp32 tarball (`...300M-ctc-2025-11-12`, which only ships `model.onnx`) while asking for `model.int8.onnx`, so the selective extractor kept only `tokens.txt`. Because "present" was tested on the directory rather than its files, every later run skipped the half-filled directory as complete.

## Change

- `asr_engine.py`: catch `ModelUnavailable` in the safety net and let the empty result stand (the caller already drops empty finals as non-speech).
- `download_models.py`: fetch the upstream int8 tarball (`...300M-ctc-int8-2025-11-12`, `model.int8.onnx` = 365,352,120 bytes, the same artifact the 2026-08-24 benchmarks used); treat "present" as "every wanted file exists" so a partial directory is re-fetched; raise, after removing the partial directory, when a tarball lacks a wanted file.

## Reasoning

A minimal install (no omni model) is a supported configuration, so the fallback must degrade, not kill the session. The downloader bug is what made the guard matter on a full install too; fixing only the guard would have left the fallback route silently disabled.

An int8 produced locally with `onnxruntime.quantization.quantize_dynamic` was tried and rejected: on the 5 ja/en clips it ran at RTF 0.48–0.62 (fp32: 0.18, upstream int8: 0.12) and broke Japanese output.

## Effect

- Empty specialist decode with no omni model: an empty line, dropped, process keeps running.
- `python scripts/download_models.py` on a checkout with the old partial directory: re-fetches and restores `model.int8.onnx`.

## Verification

- `pytest tests -q`: 289 passed, 25 skipped (CI-like env without models); 5 new tests (2 stub-based for the safety net, 3 with tiny synthetic tarballs for the extractor).
- Live mic session in balanced mode ran through ja → en → ja switches after the model was restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
