### PR TITLE
docs: point the fp16 punctuation model at its Hugging Face repo

### DIFF
--- a/docs/design/mobile_quantization.md
+++ b/docs/design/mobile_quantization.md
@@ -516,9 +516,12 @@ int8-static/QDQ, fp16), **fp16 is the only one that clears the accuracy
 bar** — it is the recommended candidate *if* this model needs a
 smaller-than-fp32 footprint on a phone-deployable profile:
 `models/mojicast-punct-onnx/quantized_ort/punct_bert.fp16.onnx` (not
-committed; regenerate via `--variant fp16`), 181.8 MB vs fp32's 363.5 MB.
-Both INT8 approaches (dynamic and static/QDQ) are now considered
-exhausted for this model at default settings — see "if revisited" below.
+committed to this repo; regenerate via `--variant fp16`, or download the
+prebuilt file from
+[`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+on Hugging Face), 181.8 MB vs fp32's 363.5 MB. Both INT8 approaches
+(dynamic and static/QDQ) are now considered exhausted for this model at
+default settings — see "if revisited" below.
 
 As with the ASR-side fp16/int8 findings elsewhere in this document, **this
 does not change the PC default**: `scripts/punct_ja.py`'s `PunctuatorJa`

--- a/mobile/hayamimi_core/CHANGELOG.md
+++ b/mobile/hayamimi_core/CHANGELOG.md
@@ -150,11 +150,13 @@ into a standalone package a third-party Flutter app can embed.
   and loads in the decode worker isolate rather than the caller's, for the
   same reason every other decode moved there. New dependencies: `unorm_dart`
   (NFKC normalization, which `dart:core` has no equivalent of) and `ffi`.
-  The float16 model file (181.8 MB) is still not downloadable —
-  `ModelDownloader`/`downloadProfile` has no entry for it — so a host app
-  has to place it and its `vocab.txt` on the device itself; see "Japanese
-  punctuation restoration" in the README for the model-placement and
-  platform-status details, and "Known limitations" below.
+  The float16 model file (181.8 MB) is downloadable from
+  [`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+  on Hugging Face, but `ModelDownloader`/`downloadProfile` has no entry for
+  it — so a host app has to fetch it and its `vocab.txt` and place them on
+  the device itself; see "Japanese punctuation restoration" in the README
+  for the model-placement and platform-status details, and "Known
+  limitations" below.
 * **Segmentation and segment audio, after the first Android emulator run.**
   Running the live pipeline on an Android x86_64 emulator turned up two
   ways the mobile port produced worse text than the desktop pipeline on the
@@ -256,6 +258,11 @@ into a standalone package a third-party Flutter app can embed.
   manifest runs. Both are debug/dev tools, not part of the embedding
   surface a host app needs — see the `kDebugMode`-gated call sites in the
   `mobile/` reference app's Bench tab.
+* **Punctuation model now downloadable.** `punct_bert.fp16.onnx` and
+  `vocab.txt` are published at
+  [`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+  on Hugging Face, so a host app no longer has to build the fp16 file
+  itself to use Japanese punctuation restoration.
 
 ### Known limitations
 

--- a/mobile/hayamimi_core/README.ja.md
+++ b/mobile/hayamimi_core/README.ja.md
@@ -161,8 +161,10 @@ int8 が最小かつ最速で、大きい fp16/fp32 を積む速度上の理由�
   (数値は英語版 README の "Pacing knobs" を参照)。
 - 日本語向けの句読点復元 (デスクトップ側の BERT-char モデル、fp16 で 181.8 MB) は
   refine パスに組み込まれているが (下記「日本語の句読点復元」参照)、**どちらのダウンロード
-  プロファイルにも含まれていない**。モデルファイルはまだローカルのビルド成果物で、
-  ホストアプリが自分で端末に置く必要がある (下記参照)。
+  プロファイルにも含まれていない**。モデルファイルは
+  [`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+  (Hugging Face) でホストされているので、ホストアプリがそこから取得して端末に置く
+  必要がある (下記参照)。
 
 ### ディレクトリ配置
 
@@ -177,6 +179,15 @@ int8 が最小かつ最速で、大きい fp16/fp32 を積む速度上の理由�
 | `<targetDir>/sense_voice/` | `RoutingProfile.jaSenseVoice` のみ | `model.int8.onnx` + `tokens.txt` |
 | `<targetDir>/lid/` | `RoutingProfile.jaSenseVoice` のみ | `tiny-encoder.int8.onnx` + `tiny-decoder.int8.onnx` |
 | `JaPunctuation` に渡す任意のパス | 日本語句読点、任意、全プロファイルで使える | `punct_bert.fp16.onnx` (181.8 MB) + `vocab.txt` (28 KB) |
+
+句読点モデルの 2 ファイルは Hugging Face の
+[`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+でホストされている (直接ダウンロードは `resolve/main/<file>`):
+
+| ファイル | サイズ | sha256 |
+|---|---:|---|
+| `punct_bert.fp16.onnx` | 181,803,211 バイト (181.8 MB) | `bca0d6cb9d35fbb27f2070e9b003ad277e9f7494b0dff69b1e164e84e793149a` |
+| `vocab.txt` | 27,928 バイト (28 KB) | `57411bcac5e9559f2aa4d316a2217289048cb40fe23187b02a81aeb3e5d61cf3` |
 
 ### 自動ダウンロード
 
@@ -199,10 +210,14 @@ await live.start(
 (既にディスクにあるものはチェックサムで再検証し、欠けているか壊れているものだけ再取得する)。
 
 日本語句読点モデル (`punct_bert.fp16.onnx` + `vocab.txt`) はダウンロードプロファイルの
-対象外で、ローカルの `python scripts/quantize_punct.py --variant fp16` (メインの hayamimi
-リポジトリ側) が作るビルド成果物。`ModelDownloader` にはまだエントリがないので、手動で
-`JaPunctuation(modelPath: ..., vocabPath: ...)` に渡す場所へコピーすること (詳細は
-[`docs/design/punct_ja.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/design/punct_ja.md))。
+対象外で、
+[`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+(Hugging Face) からダウンロードすること (サイズと sha256 は上の表を参照)。このファイルは
+`python scripts/quantize_punct.py --variant fp16` (メインの hayamimi リポジトリ側) が上流の
+fp32 モデルから作るもので、詳細は
+[`docs/design/punct_ja.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/design/punct_ja.md)
+を参照。`ModelDownloader` にはまだエントリがないので、手動で
+`JaPunctuation(modelPath: ..., vocabPath: ...)` に渡す場所へコピーすること。
 
 モデルファイルはすべてサードパーティの成果物で、それぞれ独自のライセンスを持つ (このパッケージ
 自体のコードは MIT)。公開元・ライセンス・出所は

--- a/mobile/hayamimi_core/README.md
+++ b/mobile/hayamimi_core/README.md
@@ -793,9 +793,10 @@ Notes on the choice:
 - Punctuation restoration for ja (the desktop pipeline's BERT-char model,
   181.8 MB as fp16) is wired into the refine pass — see
   ["Japanese punctuation restoration"](#japanese-punctuation-restoration) —
-  but it is **not** part of either download profile: the model file is
-  still a local build artifact, so a host app has to put it on the device
-  itself (see below).
+  but it is **not** part of either download profile: it's hosted at
+  [`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+  on Hugging Face rather than bundled in a profile, so a host app has to
+  download it and put it on the device itself (see below).
 
 ### Directory layout each profile expects
 
@@ -811,6 +812,15 @@ Notes on the choice:
 | `<targetDir>/sense_voice/` | `RoutingProfile.jaSenseVoice` only | `model.int8.onnx` + `tokens.txt` |
 | `<targetDir>/lid/` | `RoutingProfile.jaSenseVoice` only | `tiny-encoder.int8.onnx` + `tiny-decoder.int8.onnx` |
 | any path you choose, passed to `JaPunctuation` | Japanese punctuation, optional, any profile | `punct_bert.fp16.onnx` (181.8 MB) + `vocab.txt` (28 KB) |
+
+The punctuation model's two files are hosted at
+[`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+on Hugging Face (`resolve/main/<file>` for direct download):
+
+| file | size | sha256 |
+|---|---:|---|
+| `punct_bert.fp16.onnx` | 181,803,211 bytes (181.8 MB) | `bca0d6cb9d35fbb27f2070e9b003ad277e9f7494b0dff69b1e164e84e793149a` |
+| `vocab.txt` | 27,928 bytes (28 KB) | `57411bcac5e9559f2aa4d316a2217289048cb40fe23187b02a81aeb3e5d61cf3` |
 
 Exact filenames inside `model/`/`sense_voice/`/`lid/` don't have to match
 this table character for character: `resolveZipformerTransducerFiles`/
@@ -888,9 +898,12 @@ If you'd rather manage the files by hand (a CI step, a custom CDN, …),
   probe doesn't need `tiny-tokens.txt` or the fp32 files also in that
   archive) into `<targetDir>/lid/`.
 - **Japanese punctuation (optional, any profile):** `punct_bert.fp16.onnx`
-  and its `vocab.txt` are not on the sherpa-onnx release page — they're a
-  local build artifact of `python scripts/quantize_punct.py --variant
-  fp16` in the main hayamimi repo, described in
+  and its `vocab.txt` are not on the sherpa-onnx release page — download
+  them from
+  [`oboroge0/hayamimi-punct-ja-fp16`](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16)
+  on Hugging Face (see the sizes and sha256 values in the table above).
+  That file is what `python scripts/quantize_punct.py --variant fp16` in
+  the main hayamimi repo produces from the upstream fp32 model, described in
   [`docs/design/punct_ja.md`](https://github.com/oboroge0/hayamimi/blob/main/docs/design/punct_ja.md).
   There is no `ModelDownloader` entry for it yet — copy both files to
   wherever you pass as `JaPunctuation(modelPath: ..., vocabPath: ...)`, no

--- a/mobile/hayamimi_core/THIRD_PARTY_NOTICES.md
+++ b/mobile/hayamimi_core/THIRD_PARTY_NOTICES.md
@@ -33,7 +33,7 @@ get it.
 
 | Model | Publisher | License | Source |
 |---|---|---|---|
-| `mojicast-punct-onnx` (`punct_bert.fp16.onnx` + `vocab.txt`) | Base models: Tohoku NLP + bobfromjapan; ONNX export: Mojicast (ishiki-emo) | Apache-2.0 | [tohoku-nlp/bert-base-japanese-char-v3](https://huggingface.co/tohoku-nlp/bert-base-japanese-char-v3), [bobfromjapan/bert_japanese_punctuation](https://huggingface.co/bobfromjapan/bert_japanese_punctuation), export: [ishiki-emo/mojicast-punct-onnx](https://huggingface.co/ishiki-emo/mojicast-punct-onnx) |
+| `mojicast-punct-onnx` (`punct_bert.fp16.onnx` + `vocab.txt`) | Base models: Tohoku NLP + bobfromjapan; ONNX export: Mojicast (ishiki-emo) | Apache-2.0 | [tohoku-nlp/bert-base-japanese-char-v3](https://huggingface.co/tohoku-nlp/bert-base-japanese-char-v3), [bobfromjapan/bert_japanese_punctuation](https://huggingface.co/bobfromjapan/bert_japanese_punctuation), export: [ishiki-emo/mojicast-punct-onnx](https://huggingface.co/ishiki-emo/mojicast-punct-onnx); fp16 distribution: [oboroge0/hayamimi-punct-ja-fp16](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16) |
 
 ## Dart package dependencies
 


### PR DESCRIPTION
## Problem

hayamimi_core's README (en/ja), CHANGELOG, THIRD_PARTY_NOTICES and `docs/design/mobile_quantization.md` all said the fp16 Japanese punctuation model was a local build artifact that nobody hosted, so a host app had to run `scripts/quantize_punct.py` itself before it could turn punctuation on.

## Change

The two files are now published at [oboroge0/hayamimi-punct-ja-fp16](https://huggingface.co/oboroge0/hayamimi-punct-ja-fp16) (Apache-2.0, credits to tohoku-nlp / bobfromjapan / Mojicast on the model card). Every "not hosted" statement is replaced with a pointer to that repo, and the README model tables gain a small sizes/sha256 table:

| file | size | sha256 |
|---|---:|---|
| `punct_bert.fp16.onnx` | 181,803,211 bytes | `bca0d6cb…149a` |
| `vocab.txt` | 27,928 bytes | `57411bca…1cf3` |

The sha256 values were verified against the LFS object on Hugging Face after upload. Nothing else in the docs changes; the desktop Python pipeline keeps downloading the upstream fp32 file.

## Not changed

`ModelDownloader` still has no entry for the punctuation model; the docs continue to say so. Adding one is a code change for a later release.

## Verification

- `scripts/check_doc_links.py`: all links resolve
- `pytest tests/test_doc_links.py tests/test_ja_pipeline_spec.py -q`: 4 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Japanese punctuation restoration’s fp16 model is now available for download from Hugging Face.
  - The published package includes the model and vocabulary file, with file sizes and SHA-256 checksums provided for verification.

- **Documentation**
  - Updated English and Japanese setup guidance with download and manual device-placement instructions.
  - Clarified that automatic download support is not available, so host applications must fetch and install the files themselves.
  - Added the model distribution source to third-party notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->