### PR TITLE
Add Windows speaker loopback and mixed microphone input

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -39,6 +39,7 @@ Whisper系・クラウドSTT API・他のローカルモデルとの比較（hay
 | 構造化イベント + 実行時設定 | パイプラインの各段階（確定文、翻訳、モデル読み込み、警告、セッション集計...）が`EventHub`に発行され、組み込み先アプリはこれを直接listenできる。`--serve`時はさらに`GET`/`POST /config`と`POST /reset`が使え、プロセスを再起動せずに言語・翻訳・VAD設定の変更やセッションのリセットができる（詳細は後述の「組み込み: 実行時制御と構造化イベント」参照） |
 | OBSオーバーレイ+ダッシュボード | `--serve`でローカルHTTPサーバーを起動、ブラウザソースオーバーレイとライブダッシュボードを提供 |
 | ネットワーク音声入力 | `--input ws`でWebSocket経由のマイク音声（スマホ、ESP32/スタックチャン等）を受け付け、`--serve`のダッシュボード/オーバーレイにもそのまま流れる |
+| スピーカーループバック入力 | `--input speaker`でPC内部のスピーカー（システム音声出力）をWASAPIループバックで文字起こし（Windows専用、Stereo Mixの有効化は不要）。`--input mix`はマイクとスピーカー音声を合成した1本のストリームとして文字起こし（会議の文字起こしなどに） |
 | メモリ上限管理 | LRUモデル退避で常駐モデルを上限内（既定<2GB）に制御 |
 | CPUのみ | すべてのモデルがsherpa-onnx経由の量子化ONNXとして動作。GPU・PyTorch不要 |
 
@@ -84,6 +85,41 @@ localhostからしかアクセスできません。LAN上の他端末を受け�
 `--ws-host 0.0.0.0`を明示してください（`/ingest`に認証はないので、信頼できる
 ネットワークでのみ使うこと）。バインドしたアドレスは起動時にstderrへ出力されます。
 
+## スピーカー（PC音声）ループバック入力
+
+`--input speaker`は、マイクの代わりにPC内部のスピーカー（システム音声出力
+――通話相手の声や動画の音声など）を文字起こしします。`--input mix`は
+マイクとスピーカー音声を合成した1本のストリームを文字起こしするので、
+会議の文字起こし（自分の声＋通話相手の声を両方拾う）などに使えます。
+
+```bash
+.venv\Scripts\python scripts\realtime_transcribe.py --input speaker
+.venv\Scripts\python scripts\realtime_transcribe.py --input mix
+```
+
+`soundcard`パッケージ経由のWASAPIループバックを使っており、レンダー
+エンドポイントを直接タップするため、従来の「ステレオミキサー」のように
+Windowsのサウンド設定で事前に有効化する必要はなく、サウンドドライバーが
+ステレオミキサーを提供していない環境でも動作します。**Windows専用**です
+（他のOS向けのループバック経路はまだ実装していません）。
+
+`mix`は録音時刻が約48ms以内の音声を対応付け、合成後のサンプル値を
+[-1, 1]に制限します。マイクを基準に進み、認識が遅れた場合は両側の古い
+待機音声を破棄します。スピーカー録音の失敗はstderrへ通知してマイクのみで
+継続し、マイクの失敗ではストリームを停止します。合成した1本の文字起こしで、
+音源別トラックや音響エコー除去はありません。通話音声をマイクでも二重に
+拾わないよう、ヘッドホンの利用を推奨します。
+
+既定ではシステムの既定入力/出力デバイスを使います。マイクや出力デバイスが
+複数ある場合は`--list-audio-devices`で一覧を確認でき、`--mic-device NAME`
+/ `--speaker-device NAME`（部分一致）で個別に指定できます。リモート
+デスクトップ経由で接続している場合、PC本体の物理マイクは基本的に開けません
+（Windowsがセッションをまたいだアクセスをブロックするため）――代わりに
+RDPクライアント側でマイクリダイレクトを有効にするか（`mstsc`の場合:
+[オプションを表示] > [ローカル リソース] > [リモート オーディオ] >
+[録音] > [このコンピューターで録音する]）、PC本体のコンソールで直接
+実行してください。
+
 ## 他アプリへの組み込み
 
 `scripts/realtime_transcribe.py`の各部品（`RoutedASR`、`build_vad`、
@@ -119,6 +155,12 @@ python -m venv .venv
 .venv/Scripts/python scripts/realtime_transcribe.py     # Windows
 .venv/bin/python scripts/realtime_transcribe.py          # macOS/Linux
 
+# PC内部のスピーカー（システム音声出力）から認識 -- Windows専用
+.venv\Scripts\python scripts\realtime_transcribe.py --input speaker
+
+# マイク+スピーカーを合成して同時に認識（会議の文字起こしなどに）
+.venv\Scripts\python scripts\realtime_transcribe.py --input mix
+
 # ダッシュボード + OBSオーバーレイ付き
 .venv/Scripts/python scripts/realtime_transcribe.py --serve
 # -> ブラウザで http://localhost:8833/dashboard を開く
@@ -136,7 +178,10 @@ python -m venv .venv
 |---|---|---|
 | `--wav PATH` | マイク入力 | マイクの代わりに16kHzモノラルWAVファイルからのストリーミングをシミュレート |
 | `--no-realtime` | オフ | `--wav`使用時、チャンク間でスリープしない（高速バッチ処理） |
-| `--input {mic,wav,ws}` | mic、`--wav`指定時はwav | 音声入力元。`ws`はネットワーク経由で音声を受け付ける（上記参照） |
+| `--input {mic,wav,ws,speaker,mix}` | mic、`--wav`指定時はwav | 音声入力元。`ws`はネットワーク経由で音声を受け付ける（上記参照）。`speaker`はPC内部のスピーカー（システム音声出力）をWASAPIループバックで文字起こし（Windows専用）。`mix`はマイク+スピーカーを合成した1本のストリームを文字起こし |
+| `--mic-device NAME` | システムの既定入力デバイス | `--input mic`/`mix`が録音するデバイス名の部分一致指定。`--list-audio-devices`参照 |
+| `--speaker-device NAME` | システムの既定出力デバイス | `--input speaker`/`mix`がループバックするデバイス名の部分一致指定。`--list-audio-devices`参照 |
+| `--list-audio-devices` | オフ | 利用可能な音声デバイス一覧を表示して終了 |
 | `--ws-host HOST` | `127.0.0.1` | `--input ws`の`/ingest`エンドポイントのバインドホスト。LANクライアントを受け付けるには`0.0.0.0`を指定 |
 | `--ws-port PORT` | 8766 | `--input ws`の`/ingest`エンドポイントのポート |
 | `--threads N` | 4 | モデルごとの推論スレッド数 |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ models -- including the languages where hayamimi loses -- is in
 | Structured events + runtime config | every stage of the pipeline (finals, translations, model loads, warnings, session summaries...) publishes to an `EventHub` an embedding app can listen to directly; `--serve` additionally exposes `GET`/`POST /config` and `POST /reset` for changing language/translation/VAD settings and resetting a session without restarting the process -- see "Embedding: runtime control and structured events" below |
 | OBS overlay + dashboard | `--serve` starts a local HTTP server with a browser-source overlay and a live dashboard |
 | Network audio input | `--input ws` accepts mic audio over a WebSocket (phone, ESP32/stackchan) and feeds it through the same pipeline, including `--serve`'s dashboard/overlay |
+| Speaker loopback input | `--input speaker` transcribes whatever is playing on the PC's audio output (WASAPI loopback, Windows only, no Stereo Mix setup needed); `--input mix` sums it with the mic into one stream (e.g. meeting transcription) |
 | Memory-bounded | LRU model eviction keeps resident models under a configurable cap (default: <2GB total) |
 | CPU-only | every model runs as quantized ONNX via sherpa-onnx; no GPU or PyTorch required |
 
@@ -92,6 +93,41 @@ until you opt in with `--ws-host 0.0.0.0` -- do that only on a network you
 trust, since `/ingest` has no authentication. The bound address is printed
 to stderr on startup either way.
 
+## Speaker (system audio) loopback input
+
+`--input speaker` transcribes whatever is playing through the PC's audio
+output -- the other side of a call, a video -- instead of the microphone;
+`--input mix` transcribes the mic and the speaker output summed into one
+stream, e.g. for meeting transcription (your voice + the call audio
+together):
+
+```bash
+.venv\Scripts\python scripts\realtime_transcribe.py --input speaker
+.venv\Scripts\python scripts\realtime_transcribe.py --input mix
+```
+
+This uses WASAPI loopback via the `soundcard` package, which taps the
+render endpoint directly -- unlike the classic "Stereo Mix" recording
+device, no opt-in is needed in Windows Sound settings, and it works even
+when the sound driver doesn't expose Stereo Mix at all. **Windows only**
+(no loopback path is wired up for other platforms yet).
+
+`mix` matches capture timestamps within roughly 48ms and clips the summed
+samples to [-1, 1]. It uses the microphone as its clock and drops old queued
+audio on both sides if decoding falls behind. A failed speaker capture is
+reported on stderr and falls back to mic-only; a failed microphone stops the
+stream. This is one mixed transcript, with no separate tracks or acoustic
+echo cancellation. Use headphones to avoid capturing the call audio twice.
+
+By default both modes use the system's default input/output device. If you
+have more than one mic or output device, `--list-audio-devices` prints what's
+available, and `--mic-device NAME` / `--speaker-device NAME` (substring
+match) pick a specific one. Over a Remote Desktop session, the PC's own
+physical mic usually can't be opened at all (Windows blocks cross-session
+access) -- enable microphone redirection in your RDP client instead (in
+`mstsc`: Show Options > Local Resources > Remote audio > Recording >
+"Record from this computer"), or run hayamimi at the local console.
+
 ## Embedding in another app
 
 `scripts/realtime_transcribe.py`'s pieces (`RoutedASR`, `build_vad`,
@@ -127,6 +163,12 @@ python -m venv .venv
 .venv/Scripts/python scripts/realtime_transcribe.py     # Windows
 .venv/bin/python scripts/realtime_transcribe.py          # macOS/Linux
 
+# From the PC's audio output instead (a call, a video) -- Windows only
+.venv\Scripts\python scripts\realtime_transcribe.py --input speaker
+
+# Mic + PC audio output together, e.g. for meeting transcription
+.venv\Scripts\python scripts\realtime_transcribe.py --input mix
+
 # With the dashboard + OBS overlay
 .venv/Scripts/python scripts/realtime_transcribe.py --serve
 # -> open http://localhost:8833/dashboard in a browser
@@ -145,7 +187,10 @@ All flags are on `scripts/realtime_transcribe.py`:
 |---|---|---|
 | `--wav PATH` | mic input | simulate streaming from a 16kHz mono WAV file instead of the microphone |
 | `--no-realtime` | off | with `--wav`, don't sleep between chunks (fast batch processing) |
-| `--input {mic,wav,ws}` | mic, or wav if `--wav` is given | audio source; `ws` accepts audio over the network (see below) |
+| `--input {mic,wav,ws,speaker,mix}` | mic, or wav if `--wav` is given | audio source; `ws` accepts audio over the network (see below); `speaker` transcribes the PC's audio output (WASAPI loopback, Windows only); `mix` sums mic + speaker into one stream |
+| `--mic-device NAME` | system default input | substring match for the input device `--input mic`/`mix` captures from; see `--list-audio-devices` |
+| `--speaker-device NAME` | system default output | substring match for the output device `--input speaker`/`mix` loops back from; see `--list-audio-devices` |
+| `--list-audio-devices` | off | print available audio devices and exit |
 | `--ws-host HOST` | `127.0.0.1` | bind host for `--input ws`'s `/ingest` endpoint; pass `0.0.0.0` to accept LAN clients |
 | `--ws-port PORT` | 8766 | port for `--input ws`'s `/ingest` endpoint |
 | `--threads N` | 4 | inference threads per model |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -62,6 +62,7 @@ evaluation -- `asr_engine.py`'s routing does not use them.
 | [numpy](https://numpy.org/) | BSD-3-Clause | |
 | [soundfile](https://github.com/bastibe/python-soundfile) | BSD-3-Clause | |
 | [sounddevice](https://github.com/spatialaudio/python-sounddevice) | MIT | microphone capture |
+| [soundcard](https://github.com/bastibe/SoundCard) | BSD-3-Clause | WASAPI loopback capture of PC audio output for `--input speaker`/`mix` |
 | [fugashi](https://github.com/polm/fugashi) | MIT (MeCab itself is BSD/GPL/LGPL tri-license) | Japanese tokenization for punctuation restoration |
 | [unidic-lite](https://github.com/polm/unidic-lite) | MIT (dictionary data: BSD-modified, per UniDic) | dictionary for fugashi |
 | [kiwipiepy](https://github.com/bab2min/kiwipiepy) | **LGPL-2.1-or-later** | Korean tokenizer, used only to fix SenseVoice's spacing on `ko` output; optional at runtime (falls through silently if not installed) -- kept as an **optional/dev extra**, not a hard runtime dependency, to avoid LGPL obligations on the core install |

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,11 @@
 numpy==2.4.6
 soundfile==0.14.0
 sounddevice==0.5.6
+# WASAPI loopback capture for --input speaker/mix (records what's playing
+# on the PC's audio output, e.g. a call partner or a video). sounddevice's
+# bundled PortAudio build has no loopback support to do this with; sounddevice
+# stays the mic/--input mic path since that already works.
+soundcard==0.4.6; sys_platform == "win32"
 sherpa-onnx==1.13.6
 onnxruntime==1.29.0
 ctranslate2==4.8.1

--- a/scripts/realtime_transcribe.py
+++ b/scripts/realtime_transcribe.py
@@ -6,6 +6,8 @@ Usage:
     python scripts/realtime_transcribe.py --wav testdata/ja_test.wav --no-realtime
     python scripts/realtime_transcribe.py --wav testdata/ja_test.wav       # paced with sleeps
     python scripts/realtime_transcribe.py                                 # live microphone
+    python scripts/realtime_transcribe.py --input speaker                 # PC audio output (WASAPI loopback, Windows)
+    python scripts/realtime_transcribe.py --input mix                     # mic + PC audio output, summed
 """
 import argparse
 import os
@@ -14,7 +16,9 @@ import sys
 import threading
 import time
 import wave
-from typing import Callable
+from collections import deque
+from contextlib import contextmanager
+from typing import Callable, NamedTuple
 
 import numpy as np
 import sherpa_onnx
@@ -300,9 +304,71 @@ def wav_chunks(samples: np.ndarray, sample_rate: int, realtime: bool):
 
 
 MIC_QUEUE_TIMEOUT_S = 0.1  # how often the generator wakes up to check stop_event
+LOOPBACK_BLOCK_SIZE = WINDOW_SIZE * 4  # SoundCard recommends > record(numframes)
+MIX_QUEUE_MAXLEN = 64  # ~2.0s, bounded symmetrically for both hardware clocks
+CAPTURE_CHUNK_NS = int(WINDOW_SIZE / SAMPLE_RATE * 1_000_000_000)
+MIX_SYNC_TOLERANCE_NS = int(1.5 * CAPTURE_CHUNK_NS)
 
 
-def mic_chunks(stop_event: "threading.Event | None" = None):
+class _CapturedChunk(NamedTuple):
+    """A frame plus the monotonic time at which capture completed."""
+
+    end_ns: int
+    samples: np.ndarray
+
+
+def _next_capture_end_ns(previous_end_ns: "int | None") -> int:
+    """Timestamp fixed audio windows without collapsing buffered bursts.
+
+    SoundCard can satisfy a call from its internal pending buffer almost
+    immediately after the preceding call.  Wall-clocking both completions
+    would assign consecutive 32ms audio windows nearly the same time.  Keep
+    at least one window between them while still jumping forward after a real
+    capture pause.
+    """
+    now_ns = time.perf_counter_ns()
+    if previous_end_ns is None:
+        return now_ns
+    return max(now_ns, previous_end_ns + CAPTURE_CHUNK_NS)
+
+
+def _resolve_mic_device(name: "str | None" = None):
+    """Pick a sounddevice input device index for mic_chunks().
+
+    PortAudio's own "default input device" can be unset (-1, none at all)
+    -- e.g. a Remote Desktop session with microphone redirection turned
+    off has no default across MME/DirectSound/WASAPI; the remote machine's
+    own physical mic still enumerates under the WDM-KS host API but can't
+    actually be opened cross-session ("Invalid device"). So: honor an
+    explicit name/substring first, else PortAudio's default if it has one,
+    else just the first input-capable device of any kind -- mic_chunks()
+    wraps the actual open call to turn a bad guess here into an actionable
+    error rather than a raw PortAudioError.
+    """
+    import sounddevice as sd
+
+    devices = sd.query_devices()
+    if name:
+        matches = [i for i, d in enumerate(devices)
+                   if name.lower() in d["name"].lower() and d["max_input_channels"] > 0]
+        if not matches:
+            avail = ", ".join(f"[{i}] {d['name']}" for i, d in enumerate(devices)
+                              if d["max_input_channels"] > 0) or "(none)"
+            raise RuntimeError(f"no input device matching {name!r} -- available: {avail}")
+        return matches[0]
+
+    default_in = sd.default.device[0]
+    if isinstance(default_in, int) and default_in >= 0:
+        return default_in
+    for i, d in enumerate(devices):
+        if d["max_input_channels"] > 0:
+            return i
+    raise RuntimeError("no microphone input device found at all -- see --list-audio-devices")
+
+
+def mic_chunks(stop_event: "threading.Event | None" = None,
+               device_name: "str | None" = None,
+               _timestamped: bool = False):
     """Yield mic input frames until `stop_event` is set.
 
     `q.get()` alone blocks forever with no chunk to hand back control to the
@@ -312,18 +378,433 @@ def mic_chunks(stop_event: "threading.Event | None" = None):
     """
     import sounddevice as sd
 
-    q: "queue.Queue[np.ndarray]" = queue.Queue()
+    device = _resolve_mic_device(device_name)
+    q: "queue.Queue[np.ndarray | _CapturedChunk]" = queue.Queue()
+
+    last_end_ns = None
 
     def callback(indata, frames, time_info, status):
-        q.put(indata[:, 0].copy())
+        nonlocal last_end_ns
+        samples = indata[:, 0].copy()
+        # Timestamp in PortAudio's callback, not later in mix's drain
+        # thread: if that thread is briefly descheduled, queued old chunks
+        # must retain their real acquisition times.
+        if _timestamped:
+            last_end_ns = _next_capture_end_ns(last_end_ns)
+            item = _CapturedChunk(last_end_ns, samples)
+        else:
+            item = samples
+        q.put(item)
 
-    with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, dtype="float32",
-                         blocksize=WINDOW_SIZE, callback=callback):
+    try:
+        with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, dtype="float32",
+                             blocksize=WINDOW_SIZE, device=device, callback=callback):
+            while stop_event is None or not stop_event.is_set():
+                try:
+                    yield q.get(timeout=MIC_QUEUE_TIMEOUT_S)
+                except queue.Empty:
+                    continue
+    except sd.PortAudioError as exc:
+        raise RuntimeError(
+            f"couldn't open microphone [{device}] {sd.query_devices(device)['name']!r} "
+            f"({exc}). Over Remote Desktop, Windows blocks opening the remote machine's "
+            f"own physical mic across the session -- enable microphone redirection instead "
+            f"(mstsc: Show Options > Local Resources > Remote audio > Recording > Record "
+            f"from this computer). See --list-audio-devices, or pass --mic-device NAME to "
+            f"pick a different device.") from exc
+
+
+def _resolve_loopback_speaker(name: "str | None" = None):
+    """Pick a soundcard Speaker to WASAPI-loopback-capture for speaker_chunks().
+
+    WASAPI loopback taps the render endpoint directly -- unlike the classic
+    "Stereo Mix" recording device, it needs no opt-in in Windows Sound
+    settings and works even when the sound driver doesn't expose Stereo
+    Mix at all.
+    """
+    if sys.platform != "win32":
+        raise RuntimeError("--input speaker/mix needs Windows (WASAPI loopback via the "
+                            "soundcard package) -- --input mic/wav/ws work on any platform")
+    import soundcard as sc
+
+    if name:
+        matches = [s for s in sc.all_speakers() if name.lower() in s.name.lower()]
+        if not matches:
+            avail = ", ".join(repr(s.name) for s in sc.all_speakers()) or "(none)"
+            raise RuntimeError(f"no output device matching {name!r} -- available: {avail}")
+        return matches[0]
+    try:
+        return sc.default_speaker()
+    except Exception as exc:
+        raise RuntimeError(
+            f"no default output device to loop back from ({exc}). Over Remote Desktop this "
+            f"is usually the redirected 'Remote Audio' channel, not the PC's own speakers -- "
+            f"see --list-audio-devices, or pass --speaker-device NAME.") from exc
+
+
+def _import_soundcard():
+    """Import SoundCard on the long-lived caller that owns its global COM."""
+    import soundcard as sc
+    return sc
+
+
+@contextmanager
+def _windows_com_initialized(ole32=None):
+    """Initialize COM for the calling capture thread, then balance it.
+
+    SoundCard 0.4.6 initializes COM only in the thread that first imports
+    its Windows backend.  speaker_chunks() deliberately performs WASAPI
+    work on another thread, and COM apartments are per-thread, so that
+    worker needs its own CoInitializeEx/CoUninitialize pair.
+
+    ``ole32`` is injectable so the HRESULT behavior can be tested on CI
+    without a Windows audio endpoint.
+    """
+    if ole32 is None:
+        import ctypes
+        ole32 = ctypes.WinDLL("ole32", use_last_error=True)
+        ole32.CoInitializeEx.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+        ole32.CoInitializeEx.restype = ctypes.c_long
+        ole32.CoUninitialize.argtypes = []
+        ole32.CoUninitialize.restype = None
+
+    hr = int(ole32.CoInitializeEx(None, 0))  # COINIT_MULTITHREADED
+    code = hr & 0xFFFFFFFF
+    rpc_e_changed_mode = 0x80010106
+    initialized_here = code < 0x80000000
+    if not initialized_here and code != rpc_e_changed_mode:
+        raise RuntimeError(f"CoInitializeEx failed (HRESULT 0x{code:08X})")
+    try:
+        yield
+    finally:
+        # S_OK and S_FALSE both require a matching CoUninitialize.  A
+        # changed-mode result means another owner initialized this thread;
+        # using that existing apartment is valid, but it is not ours to undo.
+        if initialized_here:
+            ole32.CoUninitialize()
+
+
+def _downmix_loopback(block) -> np.ndarray:
+    """Validate a SoundCard frame matrix and average every native channel."""
+    frames = np.asarray(block, dtype=np.float32)
+    if frames.ndim != 2 or frames.shape[1] < 2:
+        raise RuntimeError(
+            "WASAPI loopback returned invalid single-channel data; "
+            f"expected frames x >=2 channels, got shape {frames.shape}")
+    if frames.shape[0] != WINDOW_SIZE:
+        raise RuntimeError(
+            f"WASAPI loopback returned {frames.shape[0]} frames; expected {WINDOW_SIZE}")
+    return np.ascontiguousarray(frames.mean(axis=1, dtype=np.float32))
+
+
+def speaker_chunks(stop_event: "threading.Event | None" = None,
+                    device_name: "str | None" = None,
+                    _timestamped: bool = False):
+    """Yield mono 16kHz frames captured from the PC's audio output (WASAPI
+    loopback via the `soundcard` package) -- whatever is playing through
+    the speakers/headphones (a call partner's voice, a video), transcribed
+    the same way mic audio is. `soundcard` resamples to 16kHz; native output
+    channels are captured together and NumPy-downmixed here because
+    SoundCard 0.4.6's Windows single-channel recording path is known to
+    return corrupted data.
+
+    The actual soundcard.recorder().record() calls run on a dedicated
+    background thread, polled through a queue exactly like mic_chunks()
+    polls sounddevice's callback queue -- NOT called inline in this
+    generator. soundcard.record() is a blocking pull, not a callback: if it
+    were called directly from run_stream()'s loop, a slow VAD/ASR decode
+    downstream (seen up to ~2s during two-pass refine) would stall the
+    *next* record() call long enough for WASAPI's own capture buffer to
+    overrun in the meantime, which soundcard surfaces as
+    "SoundcardRuntimeWarning: data discontinuity in recording" -- silently
+    dropped audio, confirmed by ear against a live TTS test before this was
+    threaded off. mic_chunks() never had this problem because
+    sounddevice's InputStream callback already runs on PortAudio's own
+    thread, independent of whatever the consumer is doing.
+    """
+    if stop_event is not None and stop_event.is_set():
+        return
+    if sys.platform != "win32":
+        raise RuntimeError("--input speaker/mix needs Windows (WASAPI loopback via the "
+                           "soundcard package) -- --input mic/wav/ws work on any platform")
+
+    # Import before initializing the worker's apartment.  SoundCard 0.4.6's
+    # module-global COM helper incorrectly treats S_FALSE (already initialized)
+    # as an error during its first import; the worker gets a separate, explicit
+    # COM scope below before it creates or touches any device wrapper.
+    sc = _import_soundcard()
+
+    capture_stop = threading.Event()
+    q: "queue.Queue[np.ndarray | _CapturedChunk]" = queue.Queue()
+    fatal: "queue.Queue[tuple[str, str]]" = queue.Queue()
+
+    def _capture():
+        label = device_name or "default output device"
+        last_end_ns = None
+        try:
+            with _windows_com_initialized():
+                # Resolve and use every COM-backed object in this apartment;
+                # only plain arrays/strings/exceptions cross the thread edge.
+                speaker = _resolve_loopback_speaker(device_name)
+                label = speaker.name
+                loopback_mic = sc.get_microphone(id=speaker.id, include_loopback=True)
+                record_channels = max(2, int(loopback_mic.channels))
+                with loopback_mic.recorder(
+                        samplerate=SAMPLE_RATE,
+                        channels=record_channels,
+                        blocksize=LOOPBACK_BLOCK_SIZE) as rec:
+                    while not capture_stop.is_set():
+                        samples = _downmix_loopback(
+                            rec.record(numframes=WINDOW_SIZE))
+                        if _timestamped:
+                            last_end_ns = _next_capture_end_ns(last_end_ns)
+                            item = _CapturedChunk(last_end_ns, samples)
+                        else:
+                            item = samples
+                        q.put(item)
+        except Exception as exc:
+            # Do not transport the exception/traceback: its frames can retain
+            # COM-backed recorder objects and later finalize them on the
+            # consumer thread after this apartment has been uninitialized.
+            fatal.put((label, str(exc)))
+
+    thread = threading.Thread(target=_capture, name="speaker-loopback-capture",
+                              daemon=True)
+    thread.start()
+    try:
         while stop_event is None or not stop_event.is_set():
             try:
                 yield q.get(timeout=MIC_QUEUE_TIMEOUT_S)
             except queue.Empty:
+                if not fatal.empty():
+                    label, message = fatal.get()
+                    raise RuntimeError(
+                        f"speaker loopback capture of {label!r} failed: {message}") from None
                 continue
+    finally:
+        capture_stop.set()
+        thread.join(timeout=2.0)
+
+
+def _put_latest(q, item) -> None:
+    """Put without blocking, dropping the oldest item when a queue is full."""
+    while True:
+        try:
+            q.put_nowait(item)
+            return
+        except queue.Full:
+            try:
+                q.get_nowait()
+            except queue.Empty:
+                # The consumer won the race between Full and get_nowait().
+                continue
+
+
+def _drain_available(q, pending) -> None:
+    """Move every currently queued packet into the chronological buffer."""
+    while True:
+        try:
+            pending.append(q.get_nowait())
+        except queue.Empty:
+            return
+
+
+def _pop_aligned_speaker(pending, target_ns: int,
+                         tolerance_ns: int = MIX_SYNC_TOLERANCE_NS):
+    """Pop the closest speaker packet in the target window, at most once.
+
+    Stale packets are discarded, packets too far in the future are retained,
+    and choosing one packet also discards older unchosen candidates.  The
+    deque is chronological because its single producer timestamps at capture.
+    """
+    lower = target_ns - tolerance_ns
+    upper = target_ns + tolerance_ns
+    while pending:
+        packet = pending[0]
+        if packet.end_ns < lower:
+            pending.popleft()
+            continue
+        break
+    if not pending or pending[0].end_ns > upper:
+        return None
+
+    best_index = 0
+    best_distance = abs(pending[0].end_ns - target_ns)
+    for index, packet in enumerate(pending):
+        if packet.end_ns > upper:
+            break
+        distance = abs(packet.end_ns - target_ns)
+        if distance < best_distance:
+            best_index = index
+            best_distance = distance
+    for _ in range(best_index):
+        pending.popleft()
+    return pending.popleft()
+
+
+def _wait_for_aligned_speaker(spk_q, pending, spk_done,
+                              target_ns: int):
+    """Collect available speaker packets, briefly waiting for the closest."""
+    _drain_available(spk_q, pending)
+    upper_ns = target_ns + MIX_SYNC_TOLERANCE_NS
+    while not spk_done.is_set():
+        has_nonpast_candidate = any(
+            target_ns <= packet.end_ns <= upper_ns
+            for packet in pending)
+        if has_nonpast_candidate:
+            break
+        if any(packet.end_ns > upper_ns for packet in pending):
+            # Timestamps are monotonic; once a newer packet
+            # arrived, no missing in-window packet can arrive behind it.
+            break
+        remaining_ns = upper_ns - time.perf_counter_ns()
+        if remaining_ns <= 0:
+            break
+        try:
+            pending.append(spk_q.get(timeout=remaining_ns / 1_000_000_000))
+        except queue.Empty:
+            break
+        _drain_available(spk_q, pending)
+    # The producer can enqueue its final packet and set spk_done in the
+    # narrow interval after the first drain but before the loop condition.
+    _drain_available(spk_q, pending)
+    return _pop_aligned_speaker(
+        pending, target_ns)
+
+
+def mix_chunks(stop_event: "threading.Event | None" = None,
+               mic_device_name: "str | None" = None,
+               speaker_device_name: "str | None" = None):
+    """Yield mic audio summed with speaker-loopback audio, one mono stream.
+
+    Runs mic_chunks() and speaker_chunks() concurrently on background
+    threads (each paced by its own hardware clock, ~32ms/chunk) and adds
+    only capture-timestamp-aligned windows so one pipeline transcribes both
+    what the user says into the mic and whatever else is playing on the PC
+    (a call partner, a video) -- e.g. for meeting transcription. The mic
+    clock paces output. Both queues use the same bounded, drop-oldest policy,
+    so a slow ASR consumer resumes near live time without pairing different
+    moments. A speaker chunk outside a small synchronization window is
+    silence. A dead mic is fatal; a dead speaker side falls back to mic-only.
+    """
+    if stop_event is not None and stop_event.is_set():
+        return
+
+    soundcard_preload_error = None
+    if sys.platform == "win32":
+        # Ensure SoundCard's module-global COM helper belongs to this
+        # long-lived caller, not the short-lived speaker drain thread.  The
+        # actual device objects still live exclusively in speaker_chunks()'
+        # explicitly initialized capture apartment.
+        try:
+            _import_soundcard()
+        except Exception as exc:
+            # SoundCard 0.4.6 rejects COM's legitimate S_FALSE result when an
+            # embedding host already initialized this apartment.  Do not
+            # retry the half-failed import on the short-lived drain thread;
+            # that would attach its module-global COM owner to the wrong
+            # lifetime.  The speaker side reports this once and mix remains
+            # usable as mic-only.
+            soundcard_preload_error = RuntimeError(
+                f"soundcard initialization on the mix caller failed: {exc}")
+
+    capture_stop = threading.Event()
+    mic_q: "queue.Queue[_CapturedChunk]" = queue.Queue(maxsize=MIX_QUEUE_MAXLEN)
+    spk_q: "queue.Queue[_CapturedChunk]" = queue.Queue(maxsize=MIX_QUEUE_MAXLEN)
+    mic_fatal: "queue.Queue[Exception]" = queue.Queue()
+    spk_fatal: "queue.Queue[Exception]" = queue.Queue()
+    mic_done = threading.Event()
+    spk_done = threading.Event()
+
+    def _drain_mic():
+        try:
+            kwargs = {"stop_event": capture_stop, "device_name": mic_device_name,
+                      "_timestamped": True}
+            for packet in mic_chunks(**kwargs):
+                _put_latest(mic_q, packet)
+        except Exception as exc:
+            mic_fatal.put(exc)
+            capture_stop.set()
+        finally:
+            mic_done.set()
+
+    def _drain_speaker():
+        try:
+            if soundcard_preload_error is not None:
+                raise soundcard_preload_error
+            kwargs = {"stop_event": capture_stop, "device_name": speaker_device_name,
+                      "_timestamped": True}
+            for packet in speaker_chunks(**kwargs):
+                _put_latest(spk_q, packet)
+        except Exception as exc:
+            spk_fatal.put(exc)
+        finally:
+            spk_done.set()
+
+    mic_thread = threading.Thread(target=_drain_mic, name="mix-mic-capture", daemon=True)
+    spk_thread = threading.Thread(target=_drain_speaker, name="mix-speaker-capture",
+                                  daemon=True)
+    mic_thread.start()
+    spk_thread.start()
+    pending_speaker = deque(maxlen=MIX_QUEUE_MAXLEN)
+    speaker_error_reported = False
+
+    def _raise_mic_failure() -> None:
+        try:
+            exc = mic_fatal.get_nowait()
+        except queue.Empty:
+            return
+        raise exc
+
+    def _report_speaker_failure() -> None:
+        nonlocal speaker_error_reported
+        if speaker_error_reported:
+            return
+        try:
+            exc = spk_fatal.get_nowait()
+        except queue.Empty:
+            return
+        speaker_error_reported = True
+        print(f"[mix] speaker loopback capture stopped: {exc}", file=sys.stderr)
+
+    try:
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                return
+            _raise_mic_failure()
+            _report_speaker_failure()
+            try:
+                mic_packet = mic_q.get(timeout=MIC_QUEUE_TIMEOUT_S)
+            except queue.Empty:
+                _raise_mic_failure()
+                _report_speaker_failure()
+                if mic_done.is_set():
+                    return
+                continue
+
+            # At live speed an older in-window speaker frame may already be
+            # queued while the exact matching one completes a few milliseconds
+            # later.  Do not consume the older candidate immediately: wait for
+            # a same-time/future candidate until this target's finite deadline,
+            # then choose the closest packet available.  For queued/stale mic
+            # audio the deadline is already past, so this never compounds ASR
+            # latency.
+            target_ns = mic_packet.end_ns
+            spk_packet = _wait_for_aligned_speaker(
+                spk_q, pending_speaker, spk_done, target_ns)
+
+            _report_speaker_failure()
+            mic_chunk = mic_packet.samples
+            if (spk_packet is not None and
+                    len(spk_packet.samples) == len(mic_chunk)):
+                mixed = np.clip(mic_chunk + spk_packet.samples, -1.0, 1.0)
+            else:
+                mixed = mic_chunk
+            yield mixed
+    finally:
+        capture_stop.set()
+        mic_thread.join(timeout=2.0)
+        spk_thread.join(timeout=2.0)
 
 
 def ws_chunks(ingest):
@@ -1674,8 +2155,24 @@ def main():
                          "supports it. Only zh/ko have measured translation quality so far "
                          "-- other targets print an 'unvalidated' note to stderr, see "
                          "docs/design/translate_m2m.md")
-    ap.add_argument("--input", choices=["mic", "wav", "ws"], default=None,
-                    help="audio source; default is mic, or wav if --wav is given")
+    ap.add_argument("--input", choices=["mic", "wav", "ws", "speaker", "mix"], default=None,
+                    help="audio source; default is mic, or wav if --wav is given. "
+                         "'speaker' transcribes whatever is playing on the PC's audio "
+                         "output (WASAPI loopback, Windows only -- no Stereo Mix setup "
+                         "needed); 'mix' transcribes mic + speaker summed into one "
+                         "stream (e.g. meeting transcription: your voice and the call "
+                         "audio together)")
+    ap.add_argument("--mic-device", default=None, metavar="NAME",
+                    help="substring match for the input device --input mic/mix captures "
+                         "from (default: system default input device). See "
+                         "--list-audio-devices.")
+    ap.add_argument("--speaker-device", default=None, metavar="NAME",
+                    help="substring match for the output device --input speaker/mix "
+                         "loops back from (default: system default output device). See "
+                         "--list-audio-devices.")
+    ap.add_argument("--list-audio-devices", action="store_true",
+                    help="print available audio input/output devices and exit -- use to "
+                         "find a name for --mic-device/--speaker-device")
     ap.add_argument("--ws-host", default="127.0.0.1", metavar="HOST",
                     help="bind host for --input ws (default 127.0.0.1, localhost-only; "
                          "pass --ws-host 0.0.0.0 to also accept connections from other "
@@ -1685,8 +2182,26 @@ def main():
                     help="port for the --input ws /ingest endpoint (default 8766)")
     args = ap.parse_args()
 
+    if args.list_audio_devices:
+        import sounddevice as sd
+
+        print(sd.query_devices())
+        if sys.platform == "win32":
+            try:
+                import soundcard as sc
+
+                default_id = sc.default_speaker().id
+                print("\nWASAPI output devices (for --speaker-device):")
+                for s in sc.all_speakers():
+                    print(f"  {s.name}" + ("  (default)" if s.id == default_id else ""))
+            except Exception as exc:
+                print(f"\n(soundcard loopback devices unavailable: {exc})", file=sys.stderr)
+        return
+
     if args.mode == "single" and not args.lang:
         ap.error("--mode single requires --lang CODE")
+    if args.input in ("speaker", "mix") and sys.platform != "win32":
+        ap.error("--input speaker/mix needs Windows (WASAPI loopback)")
     # --mode bundles defaults for the two hysteresis knobs; an explicitly
     # passed --lang-switch-guard/--lid-switch-confirm still wins. "single"
     # has no entry here: forced_lang (set below) bypasses all switch/
@@ -1891,8 +2406,20 @@ def main():
             run_stream(ws_chunks(ingest), live_vad, SAMPLE_RATE, asr, stats, printer, refiner,
                        history, translator_worker, speaker_labeler, stop_event=stop_event,
                        control=control)
+        elif input_mode == "speaker":
+            run_stream(speaker_chunks(stop_event=stop_event, device_name=args.speaker_device),
+                       live_vad, SAMPLE_RATE, asr, stats, printer, refiner, history,
+                       translator_worker, speaker_labeler, stop_event=stop_event,
+                       control=control)
+        elif input_mode == "mix":
+            run_stream(mix_chunks(stop_event=stop_event, mic_device_name=args.mic_device,
+                                  speaker_device_name=args.speaker_device),
+                       live_vad, SAMPLE_RATE, asr, stats, printer, refiner, history,
+                       translator_worker, speaker_labeler, stop_event=stop_event,
+                       control=control)
         else:
-            run_stream(mic_chunks(stop_event=stop_event), live_vad, SAMPLE_RATE, asr, stats,
+            run_stream(mic_chunks(stop_event=stop_event, device_name=args.mic_device),
+                       live_vad, SAMPLE_RATE, asr, stats,
                        printer, refiner, history, translator_worker, speaker_labeler,
                        stop_event=stop_event, control=control)
     except KeyboardInterrupt:

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -19,6 +19,26 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 import realtime_transcribe as rt  # noqa: E402
 
 
+class _RuntimeSys:
+    """Keep test overrides local while following pytest's current streams."""
+
+    def __getattr__(self, name):
+        return getattr(sys, name)
+
+
+@pytest.fixture(autouse=True)
+def isolated_runtime_sys(monkeypatch):
+    # Patching the real sys.platform breaks NumPy's lazy imports on Linux.
+    monkeypatch.setattr(rt, "sys", _RuntimeSys())
+
+
+@pytest.fixture(params=["linux", "win32"])
+def fake_mix_backend(monkeypatch, request, isolated_runtime_sys):
+    # Fake generators also need a fake caller-thread SoundCard preload.
+    monkeypatch.setattr(rt.sys, "platform", request.param)
+    monkeypatch.setattr(rt, "_import_soundcard", lambda: None)
+
+
 @pytest.mark.parametrize("input_mode", ["speaker", "mix"])
 def test_cli_rejects_loopback_on_non_windows_before_loading_models(monkeypatch, input_mode):
     monkeypatch.setattr(rt.sys, "platform", "linux")
@@ -352,7 +372,8 @@ def test_wait_for_speaker_drains_packet_enqueued_as_done_becomes_true():
     assert chosen is final_packet
 
 
-def test_mix_stall_drops_both_sides_symmetrically_and_keeps_time_alignment(monkeypatch):
+def test_mix_stall_drops_both_sides_symmetrically_and_keeps_time_alignment(
+        monkeypatch, fake_mix_backend):
     gate = threading.Event()
     mic_finished = threading.Event()
     speaker_finished = threading.Event()
@@ -398,7 +419,8 @@ def test_mix_stall_drops_both_sides_symmetrically_and_keeps_time_alignment(monke
         np.testing.assert_allclose(actual, expected, atol=1e-6)
 
 
-def test_mix_waits_for_a_closer_packet_instead_of_consuming_older_candidate(monkeypatch):
+def test_mix_waits_for_a_closer_packet_instead_of_consuming_older_candidate(
+        monkeypatch, fake_mix_backend):
     target = time.perf_counter_ns() + 10_000_000_000
     old_was_queued = threading.Event()
     release_exact = threading.Event()
@@ -460,7 +482,8 @@ def test_mix_does_not_retry_failed_soundcard_import_on_capture_thread(
     assert err.count("S_FALSE rejected") == 1
 
 
-def test_mix_speaker_failure_falls_back_once_to_mic_only(monkeypatch, capsys):
+def test_mix_speaker_failure_falls_back_once_to_mic_only(
+        monkeypatch, capsys, fake_mix_backend):
     base = time.perf_counter_ns()
 
     def fake_mic_chunks(*, stop_event, device_name, _timestamped):
@@ -478,7 +501,7 @@ def test_mix_speaker_failure_falls_back_once_to_mic_only(monkeypatch, capsys):
     assert capsys.readouterr().err.count("loopback lost") == 1
 
 
-def test_mix_microphone_failure_is_fatal_and_stops_speaker(monkeypatch):
+def test_mix_microphone_failure_is_fatal_and_stops_speaker(monkeypatch, fake_mix_backend):
     speaker_stopped = threading.Event()
 
     def broken_mic_chunks(*, stop_event, device_name, _timestamped):

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -1,0 +1,499 @@
+"""Hardware-free regression tests for loopback capture and mixed input."""
+import builtins
+import io
+import os
+import queue
+import sys
+import threading
+import time
+import types
+from collections import deque
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                "scripts"))
+
+import realtime_transcribe as rt  # noqa: E402
+
+
+@pytest.mark.parametrize("input_mode", ["speaker", "mix"])
+def test_cli_rejects_loopback_on_non_windows_before_loading_models(monkeypatch, input_mode):
+    monkeypatch.setattr(rt.sys, "platform", "linux")
+    monkeypatch.setattr(rt.sys, "argv", ["realtime_transcribe.py", "--input", input_mode])
+    output = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+    monkeypatch.setattr(rt.sys, "stdout", output)
+    monkeypatch.setattr(rt, "RoutedASR", lambda **kwargs: pytest.fail("loaded ASR"))
+    with pytest.raises(SystemExit) as exc:
+        rt.main()
+    assert exc.value.code == 2
+
+
+def test_microphone_device_selection_uses_input_only_case_insensitive_match(monkeypatch):
+    devices = [
+        {"name": "USB output", "max_input_channels": 0},
+        {"name": "USB microphone", "max_input_channels": 1},
+        {"name": "Other mic", "max_input_channels": 1},
+    ]
+    fake_sd = types.SimpleNamespace(
+        query_devices=lambda: devices,
+        default=types.SimpleNamespace(device=[2, 0]),
+    )
+    monkeypatch.setitem(sys.modules, "sounddevice", fake_sd)
+    assert rt._resolve_mic_device("usb") == 1
+    assert rt._resolve_mic_device() == 2
+    fake_sd.default.device[0] = -1
+    assert rt._resolve_mic_device() == 1
+    with pytest.raises(RuntimeError, match="no input device matching"):
+        rt._resolve_mic_device("missing")
+
+
+@pytest.mark.parametrize("shape", [(512,), (512, 1), (511, 2)])
+def test_loopback_rejects_corrupt_channel_or_window_shapes(shape):
+    with pytest.raises(RuntimeError, match="WASAPI loopback returned"):
+        rt._downmix_loopback(np.zeros(shape, dtype=np.float32))
+
+
+class _FakeOle32:
+    def __init__(self, result):
+        self.result = result
+        self.initialized = []
+        self.uninitialized = 0
+
+    def CoInitializeEx(self, reserved, mode):
+        self.initialized.append((reserved, mode))
+        return self.result
+
+    def CoUninitialize(self):
+        self.uninitialized += 1
+
+
+@pytest.mark.parametrize("result", [0, 1])
+def test_windows_com_scope_balances_every_success_result(result):
+    ole32 = _FakeOle32(result)
+    with rt._windows_com_initialized(ole32):
+        assert ole32.initialized == [(None, 0)]
+    assert ole32.uninitialized == 1
+
+
+def test_windows_com_scope_uses_existing_changed_mode_apartment():
+    ole32 = _FakeOle32(0x80010106)  # RPC_E_CHANGED_MODE
+    with rt._windows_com_initialized(ole32):
+        pass
+    assert ole32.uninitialized == 0
+
+
+def test_windows_com_scope_rejects_other_hresult_failures():
+    ole32 = _FakeOle32(0x80004005)  # E_FAIL
+    with pytest.raises(RuntimeError, match="0x80004005"):
+        with rt._windows_com_initialized(ole32):
+            pytest.fail("a failed CoInitializeEx must not enter the scope")
+    assert ole32.uninitialized == 0
+
+
+def test_speaker_capture_owns_com_objects_and_downmixes_native_channels(monkeypatch):
+    main_thread = threading.get_ident()
+    thread_state = threading.local()
+    calls = []
+    release_second_record = threading.Event()
+
+    def require_com(operation):
+        assert getattr(thread_state, "com_active", False), operation
+        calls.append((operation, threading.get_ident()))
+
+    @contextmanager
+    def fake_com_scope():
+        calls.append(("com_enter", threading.get_ident()))
+        thread_state.com_active = True
+        try:
+            yield
+        finally:
+            require_com("com_exit")
+            thread_state.com_active = False
+
+    class Speaker:
+        @property
+        def id(self):
+            require_com("speaker_id")
+            return "speaker-id"
+
+        @property
+        def name(self):
+            require_com("speaker_name")
+            return "Fake Speakers"
+
+    class Recorder:
+        records = 0
+
+        def __enter__(self):
+            require_com("recorder_enter")
+            return self
+
+        def __exit__(self, *exc_info):
+            require_com("recorder_exit")
+            return False
+
+        def record(self, numframes):
+            require_com("record")
+            assert numframes == rt.WINDOW_SIZE
+            self.records += 1
+            if self.records > 1:
+                release_second_record.wait(timeout=1.0)
+            left = np.full(numframes, 0.2, dtype=np.float32)
+            right = np.full(numframes, 0.6, dtype=np.float32)
+            return np.column_stack([left, right])
+
+    class Microphone:
+        @property
+        def channels(self):
+            require_com("microphone_channels")
+            return 2
+
+        def recorder(self, **kwargs):
+            require_com("recorder_create")
+            calls.append(("recorder_kwargs", kwargs))
+            return Recorder()
+
+    def default_speaker():
+        require_com("default_speaker")
+        return Speaker()
+
+    def get_microphone(*, id, include_loopback):
+        require_com("get_microphone")
+        assert id == "speaker-id"
+        assert include_loopback is True
+        return Microphone()
+
+    class FakeWarning(RuntimeWarning):
+        pass
+
+    fake_sc = types.SimpleNamespace(
+        default_speaker=default_speaker,
+        all_speakers=lambda: [Speaker()],
+        get_microphone=get_microphone,
+        SoundcardRuntimeWarning=FakeWarning,
+    )
+    monkeypatch.setattr(rt.sys, "platform", "win32")
+    monkeypatch.setattr(rt, "_windows_com_initialized", fake_com_scope)
+    monkeypatch.setitem(sys.modules, "soundcard", fake_sc)
+
+    stop = threading.Event()
+    chunks = rt.speaker_chunks(stop_event=stop, _timestamped=True)
+    packet = next(chunks)
+    assert isinstance(packet, rt._CapturedChunk)
+    assert packet.end_ns > 0
+    chunk = packet.samples
+    np.testing.assert_allclose(chunk, np.full(rt.WINDOW_SIZE, 0.4, dtype=np.float32))
+
+    stop.set()
+    release_second_record.set()
+    with pytest.raises(StopIteration):
+        next(chunks)
+
+    worker_ids = {thread_id for operation, thread_id in calls
+                  if operation != "recorder_kwargs"}
+    assert worker_ids == {next(iter(worker_ids))}
+    assert main_thread not in worker_ids
+    kwargs = next(value for operation, value in calls if operation == "recorder_kwargs")
+    assert kwargs == {
+        "samplerate": rt.SAMPLE_RATE,
+        "channels": 2,
+        "blocksize": rt.LOOPBACK_BLOCK_SIZE,
+    }
+    assert kwargs["blocksize"] > rt.WINDOW_SIZE
+    operations = [operation for operation, _ in calls]
+    assert operations.index("com_enter") < operations.index("default_speaker")
+    assert operations.index("recorder_exit") < operations.index("com_exit")
+
+
+def test_speaker_capture_rejects_non_windows_before_import_or_com(monkeypatch):
+    monkeypatch.setattr(rt.sys, "platform", "linux")
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "soundcard":
+            pytest.fail("the non-Windows guard must run before importing soundcard")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    monkeypatch.setattr(
+        rt, "_windows_com_initialized",
+        lambda: pytest.fail("the non-Windows path must not initialize COM"))
+
+    with pytest.raises(RuntimeError, match="needs Windows"):
+        next(rt.speaker_chunks())
+
+
+def test_mic_timestamp_is_taken_in_the_capture_callback(monkeypatch):
+    callback_thread = []
+
+    class Channel:
+        def copy(self):
+            return np.full(rt.WINDOW_SIZE, 0.25, dtype=np.float32)
+
+    class InputData:
+        def __getitem__(self, key):
+            assert key == (slice(None), 0)
+            return Channel()
+
+    class InputStream:
+        def __init__(self, *args, callback=None, **kwargs):
+            self.callback = callback
+
+        def __enter__(self):
+            callback_thread.append(threading.get_ident())
+            self.callback(InputData(), rt.WINDOW_SIZE, None, None)
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+    fake_sd = types.SimpleNamespace(
+        InputStream=InputStream,
+        query_devices=lambda *args: ({"name": "fake mic", "max_input_channels": 1}
+                                     if args else
+                                     [{"name": "fake mic", "max_input_channels": 1}]),
+        default=types.SimpleNamespace(device=[0, 0]),
+        PortAudioError=RuntimeError,
+    )
+    monkeypatch.setitem(sys.modules, "sounddevice", fake_sd)
+
+    stop = threading.Event()
+    chunks = rt.mic_chunks(stop_event=stop, _timestamped=True)
+    packet = next(chunks)
+    stop.set()
+    with pytest.raises(StopIteration):
+        next(chunks)
+
+    assert isinstance(packet, rt._CapturedChunk)
+    assert packet.end_ns > 0
+    np.testing.assert_allclose(packet.samples, 0.25)
+    assert callback_thread == [threading.get_ident()]
+
+
+def test_speaker_capture_failure_is_reported_with_endpoint_context(monkeypatch):
+    @contextmanager
+    def fake_com_scope():
+        yield
+
+    def default_speaker():
+        raise RuntimeError("device vanished")
+
+    fake_sc = types.SimpleNamespace(
+        default_speaker=default_speaker,
+        all_speakers=lambda: [],
+        get_microphone=lambda **kwargs: None,
+        SoundcardRuntimeWarning=RuntimeWarning,
+    )
+    monkeypatch.setattr(rt.sys, "platform", "win32")
+    monkeypatch.setattr(rt, "_windows_com_initialized", fake_com_scope)
+    monkeypatch.setitem(sys.modules, "soundcard", fake_sc)
+
+    with pytest.raises(RuntimeError, match="default output device.*device vanished"):
+        next(rt.speaker_chunks())
+
+
+def _packet(end_ns, value):
+    return rt._CapturedChunk(
+        end_ns, np.full(rt.WINDOW_SIZE, value, dtype=np.float32))
+
+
+def test_capture_timestamps_keep_audio_spacing_when_backend_returns_a_burst(monkeypatch):
+    readings = iter([1_000_000_000, 1_000_000_001, 2_000_000_000])
+    monkeypatch.setattr(rt.time, "perf_counter_ns", lambda: next(readings))
+
+    first = rt._next_capture_end_ns(None)
+    second = rt._next_capture_end_ns(first)
+    third = rt._next_capture_end_ns(second)
+
+    assert first == 1_000_000_000
+    assert second == first + rt.CAPTURE_CHUNK_NS
+    assert third == max(2_000_000_000, second + rt.CAPTURE_CHUNK_NS)
+
+
+def test_put_latest_keeps_only_newest_bounded_items():
+    items = queue.Queue(maxsize=3)
+    for value in range(8):
+        rt._put_latest(items, value)
+    assert [items.get_nowait() for _ in range(3)] == [5, 6, 7]
+
+
+def test_aligned_speaker_match_discards_stale_and_retains_future():
+    stale = _packet(70, 0.1)
+    near = _packet(98, 0.2)
+    less_near = _packet(94, 0.3)
+    future = _packet(130, 0.4)
+    pending = deque([stale, less_near, near, future])
+
+    chosen = rt._pop_aligned_speaker(pending, target_ns=100, tolerance_ns=10)
+
+    assert chosen is near
+    assert list(pending) == [future]
+    assert rt._pop_aligned_speaker(pending, target_ns=100, tolerance_ns=10) is None
+    assert list(pending) == [future], "far-future audio must remain for a later mic frame"
+
+
+def test_wait_for_speaker_drains_packet_enqueued_as_done_becomes_true():
+    target = time.perf_counter_ns()
+    packets = queue.Queue()
+    pending = deque()
+    final_packet = _packet(target, 0.4)
+
+    class Done:
+        def is_set(self):
+            packets.put_nowait(final_packet)
+            return True
+
+    chosen = rt._wait_for_aligned_speaker(
+        packets, pending, Done(), target_ns=target)
+
+    assert chosen is final_packet
+
+
+def test_mix_stall_drops_both_sides_symmetrically_and_keeps_time_alignment(monkeypatch):
+    gate = threading.Event()
+    mic_finished = threading.Event()
+    speaker_finished = threading.Event()
+    speaker_first_queued = threading.Event()
+    base = time.perf_counter_ns()
+
+    def fake_mic_chunks(*, stop_event, device_name, _timestamped):
+        assert _timestamped is True
+        assert speaker_first_queued.wait(5.0)
+        yield _packet(base, 0.00)
+        gate.wait(timeout=5.0)
+        for index in range(1, 8):
+            yield _packet(base + index * 10_000_000, index * 0.10)
+        mic_finished.set()
+
+    def fake_speaker_chunks(*, stop_event, device_name, _timestamped):
+        assert _timestamped is True
+        yield _packet(base, 0.01)
+        # The drain loop put the yielded packet before requesting the next
+        # generator value and reaching this line.
+        speaker_first_queued.set()
+        gate.wait(timeout=5.0)
+        for index in range(1, 8):
+            yield _packet(base + index * 10_000_000, index * 0.01)
+        speaker_finished.set()
+
+    monkeypatch.setattr(rt, "MIX_QUEUE_MAXLEN", 3)
+    monkeypatch.setattr(rt, "mic_chunks", fake_mic_chunks)
+    monkeypatch.setattr(rt, "speaker_chunks", fake_speaker_chunks)
+
+    mixed = rt.mix_chunks()
+    first = next(mixed)
+    gate.set()
+    assert mic_finished.wait(5.0)
+    assert speaker_finished.wait(5.0)
+
+    after_stall = [next(mixed) for _ in range(3)]
+    with pytest.raises(StopIteration):
+        next(mixed)
+
+    np.testing.assert_allclose(first, 0.01)
+    for actual, expected in zip(after_stall, [0.55, 0.66, 0.77]):
+        np.testing.assert_allclose(actual, expected, atol=1e-6)
+
+
+def test_mix_waits_for_a_closer_packet_instead_of_consuming_older_candidate(monkeypatch):
+    target = time.perf_counter_ns() + 10_000_000_000
+    old_was_queued = threading.Event()
+    release_exact = threading.Event()
+    result_ready = threading.Event()
+    result = []
+
+    def fake_mic_chunks(*, stop_event, device_name, _timestamped):
+        yield _packet(target, 0.10)
+
+    def fake_speaker_chunks(*, stop_event, device_name, _timestamped):
+        yield _packet(target - 20_000_000, 0.20)
+        # The drain loop has already put the yielded packet before asking the
+        # generator for its next value and reaching this line.
+        old_was_queued.set()
+        release_exact.wait(timeout=5.0)
+        yield _packet(target, 0.40)
+
+    monkeypatch.setattr(rt, "mic_chunks", fake_mic_chunks)
+    monkeypatch.setattr(rt, "speaker_chunks", fake_speaker_chunks)
+    mixed = rt.mix_chunks()
+
+    def consume_one():
+        result.append(next(mixed))
+        result_ready.set()
+
+    consumer = threading.Thread(target=consume_one, daemon=True)
+    consumer.start()
+    assert old_was_queued.wait(5.0)
+    assert not result_ready.wait(0.05), "mix consumed the older candidate too early"
+    release_exact.set()
+    assert result_ready.wait(5.0)
+    consumer.join(timeout=5.0)
+    mixed.close()
+
+    np.testing.assert_allclose(result[0], 0.50, atol=1e-6)
+
+
+def test_mix_does_not_retry_failed_soundcard_import_on_capture_thread(
+        monkeypatch, capsys):
+    base = time.perf_counter_ns()
+
+    def failed_import():
+        raise RuntimeError("S_FALSE rejected")
+
+    def fake_mic_chunks(*, stop_event, device_name, _timestamped):
+        yield _packet(base, 0.25)
+
+    def speaker_must_not_start(**kwargs):
+        pytest.fail("a failed caller-thread import must not be retried")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(rt.sys, "platform", "win32")
+    monkeypatch.setattr(rt, "_import_soundcard", failed_import)
+    monkeypatch.setattr(rt, "mic_chunks", fake_mic_chunks)
+    monkeypatch.setattr(rt, "speaker_chunks", speaker_must_not_start)
+
+    assert [float(chunk[0]) for chunk in rt.mix_chunks()] == [0.25]
+    err = capsys.readouterr().err
+    assert err.count("S_FALSE rejected") == 1
+
+
+def test_mix_speaker_failure_falls_back_once_to_mic_only(monkeypatch, capsys):
+    base = time.perf_counter_ns()
+
+    def fake_mic_chunks(*, stop_event, device_name, _timestamped):
+        yield _packet(base, 0.25)
+        yield _packet(base + 10_000_000, 0.50)
+
+    def broken_speaker_chunks(*, stop_event, device_name, _timestamped):
+        raise RuntimeError("loopback lost")
+        yield  # pragma: no cover - makes this a generator
+
+    monkeypatch.setattr(rt, "mic_chunks", fake_mic_chunks)
+    monkeypatch.setattr(rt, "speaker_chunks", broken_speaker_chunks)
+
+    assert [float(chunk[0]) for chunk in rt.mix_chunks()] == [0.25, 0.5]
+    assert capsys.readouterr().err.count("loopback lost") == 1
+
+
+def test_mix_microphone_failure_is_fatal_and_stops_speaker(monkeypatch):
+    speaker_stopped = threading.Event()
+
+    def broken_mic_chunks(*, stop_event, device_name, _timestamped):
+        raise ValueError("microphone lost")
+        yield  # pragma: no cover - makes this a generator
+
+    def waiting_speaker_chunks(*, stop_event, device_name, _timestamped):
+        while not stop_event.wait(0.01):
+            if False:
+                yield None
+        speaker_stopped.set()
+
+    monkeypatch.setattr(rt, "mic_chunks", broken_mic_chunks)
+    monkeypatch.setattr(rt, "speaker_chunks", waiting_speaker_chunks)
+
+    with pytest.raises(ValueError, match="microphone lost"):
+        next(rt.mix_chunks())
+    assert speaker_stopped.wait(1.0)

--- a/tests/test_process_safety.py
+++ b/tests/test_process_safety.py
@@ -198,7 +198,12 @@ class _FakeInputStream:
 def test_mic_chunks_notices_stop_event_without_audio(monkeypatch):
     import realtime_transcribe as rt
 
-    fake_sd = types.SimpleNamespace(InputStream=_FakeInputStream)
+    fake_sd = types.SimpleNamespace(
+        InputStream=_FakeInputStream,
+        query_devices=lambda: [{"name": "fake mic", "max_input_channels": 1}],
+        default=types.SimpleNamespace(device=[0, 0]),
+        PortAudioError=RuntimeError,
+    )
     monkeypatch.setitem(sys.modules, "sounddevice", fake_sd)
 
     stop_event = threading.Event()


### PR DESCRIPTION
Windows users currently need an external capture or routing setup to transcribe a call partner or video playing on their PC. This adds `--input speaker` for WASAPI loopback capture and `--input mix` for a single transcript combining microphone and system audio.

```powershell
python scripts/realtime_transcribe.py --input speaker --serve
python scripts/realtime_transcribe.py --input mix --serve
python scripts/realtime_transcribe.py --list-audio-devices
```

The implementation captures loopback audio on a dedicated thread, initializes COM on the thread that owns the device objects, and downmixes native channels to mono in NumPy. Mixed input pairs windows by capture timestamps, bounds both mixer queues, and drops old queued windows when decoding falls behind. Speaker failure is reported once and falls back to microphone input; microphone failure stops the mixed stream. Both sources honor the existing stop token.

`--mic-device` and `--speaker-device` select devices by case-insensitive name substring. The SoundCard dependency is restricted to Windows, with its license recorded in `THIRD_PARTY_NOTICES.md`. Both READMEs describe usage and mixed-input behavior.

Validation on Windows with Python 3.11:

- `python -m pytest tests -q`: **325 passed, 12 skipped**, with local models and speech fixtures available; the existing Japanese golden-output test passes.
- Hardware-free capture tests cover COM lifetime, channel downmixing, device selection, cancellation, timestamp matching, backlog handling, and source failures.
- `python scripts/check_doc_links.py` and `git diff --check` pass; CLI help includes the new options.

This changes the input layer without changing ASR routing, decoding, finalization, or refinement. The mixed stream has no separate tracks or acoustic echo cancellation. Timestamp matching is approximate, and overloaded mixer queues intentionally discard audio. Hardware playback/recording was not rerun during this preparation; the automated capture tests use fake devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows support for transcribing PC system audio through speaker loopback capture.
  - Added a mixed input mode that combines microphone and speaker audio into one transcription stream.
  - Added options to select microphone and speaker devices and list available audio devices.
  - Added handling for unavailable audio sources, including fallback to microphone-only capture when speaker capture fails.

- **Documentation**
  - Updated English and Japanese guides with setup instructions, examples, limitations, supported input modes, and CLI reference details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->