### PR TITLE
asr: give RoutedASR/Refiner a close() so pytest no longer leaks 19GB

### DIFF
--- a/docs/guide/embedding.md
+++ b/docs/guide/embedding.md
@@ -19,6 +19,30 @@ letting sherpa-onnx's C++ layer call `exit()` on a missing model path, and
 its own thread can stop it cleanly (`stop_event.set()`) without relying on
 `KeyboardInterrupt`, which only works for the CLI's own process.
 
+**Shutting down a pipeline.** Stopping `run_stream` is not the same as
+releasing the engine. `Refiner`, `TranslationWorker` and `RoutedASR` each
+run background threads, and a running thread holds its owner alive -- so a
+host app that merely dropped its references kept every sherpa-onnx
+recognizer (several GB) resident for the life of the process, and building
+a second pipeline added a second set. Call `close()` when a pipeline is
+done, refiner first (it decodes through the engine):
+
+```python
+refiner.close()          # drains whatever refine work is still queued, then stops
+translator_worker.close()
+asr.close()              # joins the preload/prefetch threads, frees the models
+```
+
+All three are idempotent and usable as context managers. `close()` is the
+end of that object's life, not a pause: `RoutedASR.transcribe()/partial()/
+identify()` and `Refiner.add_span()/maybe_refine()` raise `RuntimeError`
+afterwards, so build a new pipeline for a new session -- or, to start a
+fresh conversation on the models already loaded, use
+`realtime_transcribe.reset_live_session()` instead, which resets session
+state and keeps every model resident. `main()` closes all three at
+shutdown, after the final `session_summary` is published, so the event
+stream an embedder sees is unchanged.
+
 ## Embedding: runtime control and structured events
 
 Two gaps remained even with the pieces above importable. First, session

--- a/scripts/asr_engine.py
+++ b/scripts/asr_engine.py
@@ -716,6 +716,12 @@ class RoutedASR:
         # same EventHub every other structured event goes through.
         self._on_event = on_event
         self._threads = threads
+        # close() bookkeeping. Set before ANY thread is started below (the
+        # preload thread at the end of this constructor) so _spawn_bg() and
+        # close() can never see them half-built.
+        self._closed = False
+        self._bg_threads: list[threading.Thread] = []
+        self._bg_lock = threading.Lock()  # guards _closed + _bg_threads
         self.dual_confirm = dual_confirm  # --mode balanced (default); False = --mode fast
         self.forced_lang = forced_lang    # --mode single: skip all LID/switch logic
         self._models: dict[str, object] = {}
@@ -760,7 +766,99 @@ class RoutedASR:
         if preload:
             # pull the other tiers in on a daemon thread so the first
             # non-tier-0 utterance doesn't pay the ~2s model-load cost.
-            threading.Thread(target=self._preload_rest, daemon=True).start()
+            # Registered with _spawn_bg so close() can wait for it: this
+            # thread holds a reference to `self` for as long as it runs,
+            # and through self to every recognizer loaded so far, so a
+            # RoutedASR whose preload is still in flight is not
+            # collectable no matter what the caller drops.
+            self._spawn_bg(self._preload_rest)
+
+    def _spawn_bg(self, target, *args) -> "threading.Thread | None":
+        """Start a daemon worker and remember it, so close() can join it.
+
+        Every background thread this class starts keeps `self` alive (its
+        frame holds the bound method), and `self` keeps the sherpa-onnx
+        recognizers -- several GB of native allocation -- alive with it.
+        Untracked, those threads made a RoutedASR permanently
+        uncollectable: re-running the ja golden set built eight engines
+        and freed none of them, so `pytest tests` peaked near 19 GB.
+        Tracking them here is what lets close() actually end an engine's
+        life.
+
+        Finished threads are pruned on every call so a long session's
+        per-utterance prefetches (identify()) don't grow this list without
+        bound. Returns None if the engine is already closed -- no new
+        background work is started after close().
+        """
+        with self._bg_lock:
+            if self._closed:
+                return None
+            self._bg_threads = [t for t in self._bg_threads if t.is_alive()]
+            thread = threading.Thread(target=target, args=args, daemon=True)
+            # started under the lock so close() can never join() a thread
+            # that has been registered but not yet started (join() on an
+            # unstarted Thread raises RuntimeError).
+            thread.start()
+            self._bg_threads.append(thread)
+            return thread
+
+    def close(self) -> None:
+        """End this engine's life: stop its background threads, then drop
+        every model it holds. Idempotent; safe to call from any thread.
+
+        Order matters, and the wait is deliberate:
+
+          1. mark closed, so _spawn_bg() starts nothing new and
+             _preload_rest() stops at its next tier boundary;
+          2. JOIN the background threads. A model load already inside
+             sherpa-onnx's C++ constructor cannot be interrupted, so
+             close() waits for it rather than pretending it isn't running
+             -- worst case one tier (~2s) -- and that makes step 3 the
+             only writer of self._models;
+          3. drop the recognizers, punctuator, ko_spacer, LID and
+             segmentation VAD. This is the step that actually returns the
+             memory: with no Python reference left, onnxruntime frees the
+             native arenas on those objects' destructors.
+
+        After this, transcribe()/partial()/identify() raise RuntimeError
+        rather than silently rebuilding what was just released (see
+        _check_open()); build a new RoutedASR to transcribe again. The
+        registry is left empty rather than repopulated, so
+        resident_models is [] and _evict_if_needed has nothing to do.
+        """
+        with self._bg_lock:
+            if self._closed:
+                return
+            self._closed = True
+            threads = self._bg_threads
+            self._bg_threads = []
+        for thread in threads:
+            thread.join()
+        # _load_lock is the same lock _get() takes around registry
+        # bookkeeping, so this cannot race a load that slipped in just
+        # before _closed was set.
+        with self._load_lock:
+            self._models.clear()
+            self._last_used.clear()
+            self._punct = None
+            self._punctuate = False     # stops the punct property rebuilding it
+            self._ko_spacer = None
+            self._ko_spacer_ok = False  # ditto for ko_spacer
+        self.lid = None
+        self._seg_vad = None
+        self._seg_vad_ok = False
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise RuntimeError(
+                "this RoutedASR is closed (close() released its models); "
+                "build a new RoutedASR to transcribe again")
+
+    def __enter__(self) -> "RoutedASR":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
 
     def _emit(self, event: dict) -> None:
         """Forward a structured event (model_load/model_fallback/warning) to
@@ -814,12 +912,20 @@ class RoutedASR:
         self._emit({"type": "warning", "code": "hotwords_unencodable", "message": message})
 
     def _preload_rest(self):
-        if self._punctuate:
+        # self._closed is re-read at every step so close() doesn't have to
+        # wait out the whole preload, only whatever single load is already
+        # inside sherpa-onnx's C++ constructor. A plain bool read needs no
+        # lock (one pointer store under the GIL).
+        if self._punctuate and not self._closed:
             self.punct  # first: ja finals need this almost immediately
+        if self._closed:
+            return
         self.ko_spacer  # cheap (~1s); fixes SenseVoice's over-split Korean
         silence = np.zeros(16000, dtype=np.float32)
         budget = None if self._max_resident is None else self._max_resident
         for name in _PRELOAD_ORDER:
+            if self._closed:
+                break
             if budget is not None and budget <= 0:
                 break
             try:
@@ -1235,6 +1341,7 @@ class RoutedASR:
         draft always routes straight to the forced language, same as
         transcribe(), with no LID/SenseVoice probing at all.
         """
+        self._check_open()
         if self.forced_lang is not None:
             rec, _ = self._route(self.forced_lang)
             return self._replace(self._decode(rec, samples, sample_rate))
@@ -1315,8 +1422,12 @@ class RoutedASR:
         Also kicks off a background prefetch of that language's model, so by
         the time the utterance finalizes the recognizer is already resident.
         """
+        self._check_open()
         lang = self._identify_lang(samples, sample_rate)
-        threading.Thread(target=self._route, args=(lang,), daemon=True).start()
+        # tracked (see _spawn_bg): short-lived, but it holds `self` while
+        # it loads a model, so close() has to be able to wait for it
+        # before dropping the registry out from under it.
+        self._spawn_bg(self._route, lang)
         return lang
 
     min_switch_s = 2.0  # a shorter utterance can't establish a new language
@@ -1456,6 +1567,7 @@ class RoutedASR:
         None (default) resolves to "enabled by the constructor AND this is a
         refine decode (live=False)" -- live finals never pay the second
         decode. Pass True/False to override (evaluation harnesses)."""
+        self._check_open()
         if self.forced_lang is not None:
             # --mode single: no LID, no switch logic, ever.
             lang, lid_ms = self.forced_lang, 0.0

--- a/scripts/make_ja_golden.py
+++ b/scripts/make_ja_golden.py
@@ -133,6 +133,14 @@ def run_clip(wav_path: str) -> dict:
 
     Everything heavy is imported here rather than at module scope so this
     file stays importable (for ja_cer) without models, numpy or sherpa-onnx.
+
+    Builds a whole pipeline per clip and TEARS IT DOWN AGAIN (the finally
+    below). Both objects own background threads that hold the multi-GB
+    sherpa-onnx recognizers alive, so a run that only dropped its local
+    references leaked one full engine per clip: eight clips took
+    `pytest tests` to ~19 GB RSS. build_golden() and
+    tests/test_ja_golden.py both call this in a loop, which is why the
+    teardown lives here and not at either call site.
     """
     sys.path.insert(0, os.path.join(ROOT, "scripts"))
     import realtime_transcribe as rt
@@ -150,21 +158,29 @@ def run_clip(wav_path: str) -> dict:
                     forced_lang=SETTINGS["lang"],
                     ja_second_opinion=False,
                     on_event=hub.publish)
-    asr.min_switch_s = 2.0
-    live_vad = rt.LiveVad(0.35, 12.0)
-    stats = rt.SessionStats()
-    printer = rt.PartialPrinter(enabled=SETTINGS["partials"], hub=hub)
-    history = rt.AudioHistory(rt.SAMPLE_RATE)
-    refiner = rt.Refiner(asr, history, rt.SAMPLE_RATE, printer, stats=stats)
-
-    samples, sr = rt.read_wave(wav_path)
-    rt.run_stream(rt.wav_chunks(samples, sr, realtime=False), live_vad, sr,
-                  asr, stats, printer, refiner, history)
-    # main()'s finish(sr), minus the speaker bookkeeping --speakers adds
-    live_vad.flush()
-    rt.drain_segments(live_vad, sr, asr, stats, printer, history, refiner=refiner)
-    refiner.maybe_refine(0, force=True)
-    refiner._task_queue.join()  # noqa: SLF001 -- exactly what finish() does
+    try:
+        asr.min_switch_s = 2.0
+        live_vad = rt.LiveVad(0.35, 12.0)
+        stats = rt.SessionStats()
+        printer = rt.PartialPrinter(enabled=SETTINGS["partials"], hub=hub)
+        history = rt.AudioHistory(rt.SAMPLE_RATE)
+        refiner = rt.Refiner(asr, history, rt.SAMPLE_RATE, printer, stats=stats)
+        try:
+            samples, sr = rt.read_wave(wav_path)
+            rt.run_stream(rt.wav_chunks(samples, sr, realtime=False), live_vad, sr,
+                          asr, stats, printer, refiner, history)
+            # main()'s finish(sr), minus the speaker bookkeeping --speakers adds
+            live_vad.flush()
+            rt.drain_segments(live_vad, sr, asr, stats, printer, history, refiner=refiner)
+            refiner.maybe_refine(0, force=True)
+        finally:
+            # close() drains the queue the way finish()'s _task_queue.join()
+            # did, then ends the worker thread -- so this is the flush AND
+            # the teardown, and every refine event is on `hub` by the time
+            # the events are read below.
+            refiner.close()
+    finally:
+        asr.close()
 
     finals = [e["text"] for e in events if e.get("type") == "final"]
     refines = [e["text"] for e in events if e.get("type") == "refine"]

--- a/scripts/realtime_transcribe.py
+++ b/scripts/realtime_transcribe.py
@@ -710,6 +710,18 @@ def build_translators(langs: str, pool: "TranslatorPool") -> None:
             print(str(exc), file=sys.stderr)
 
 
+# Queue sentinel for the two "one daemon thread draining a Queue forever"
+# workers below (TranslationWorker, Refiner). Both used to loop on
+# `while True: q.get()` with no way out, which meant the thread's frame
+# held its owner -- and through the Refiner, the RoutedASR and its
+# multi-GB sherpa-onnx recognizers -- alive for the life of the process.
+# Nothing could be garbage collected, so re-running the ja golden set
+# (eight pipelines, one per clip) took `pytest tests` to ~19 GB RSS.
+# Enqueuing this object tells the loop to return; because both queues are
+# FIFO, everything submitted before it still runs first.
+_WORKER_STOP = object()
+
+
 class TranslationWorker:
     """Async ja->target translation of finalized lines (console display).
 
@@ -724,15 +736,49 @@ class TranslationWorker:
     def __init__(self, pool: TranslatorPool, hub: "EventHub"):
         self._pool = pool
         self._hub = hub
-        self._q: "queue.Queue[str]" = queue.Queue()
-        threading.Thread(target=self._run, daemon=True).start()
+        self._q: "queue.Queue" = queue.Queue()
+        self._closed = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
 
     def submit(self, text: str):
+        """Queue one finalized ja line for translation.
+
+        A no-op after close(): the worker is gone, so anything queued now
+        would sit unread forever. Unlike Refiner.maybe_refine() (which
+        raises, because losing refine text loses transcript content), a
+        dropped console translation of a line that was already printed in
+        its original language costs the user nothing at shutdown.
+        """
+        if self._closed:
+            return
         self._q.put(text)
+
+    def close(self) -> None:
+        """Stop the worker thread once everything already queued has been
+        translated. Idempotent.
+
+        Same reason Refiner.close() exists: this thread's frame holds
+        `self`, and through it the TranslatorPool's M2M models, so an
+        unterminated worker keeps them alive for the life of the process.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._q.put(_WORKER_STOP)
+        self._thread.join()
+
+    def __enter__(self) -> "TranslationWorker":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
 
     def _run(self):
         while True:
             text = self._q.get()
+            if text is _WORKER_STOP:
+                return
             for lang, tr in self._pool.items():
                 out = safe_translate(tr, text)
                 if out != text:  # fallback returns the source: nothing worth showing
@@ -842,12 +888,53 @@ class Refiner:
         # out of chronological sequence. A single consumer thread draining a
         # Queue processes strictly in enqueue order, so this can't happen.
         self._task_queue: "queue.Queue" = queue.Queue()
+        self._closed = False
+        self._close_lock = threading.Lock()
         self._worker_thread = threading.Thread(target=self._worker_loop, daemon=True)
         self._worker_thread.start()
+
+    def close(self) -> None:
+        """Finish the queued refine work, stop the worker, close the
+        transcript file. Idempotent; safe to call from any thread.
+
+        This is the counterpart to the `_task_queue.join()` main()'s
+        finish() already did, and it drains exactly the same way: the stop
+        sentinel goes in at the BACK of the FIFO, so every group queued
+        before it is still decoded, printed, published and written to the
+        transcript before the worker returns. close() then waits for the
+        thread to actually end.
+
+        Why it has to exist at all: _worker_loop's frame holds `self`,
+        `self` holds the RoutedASR, and the RoutedASR holds several GB of
+        sherpa-onnx recognizers. A Refiner whose worker never returns is
+        therefore uncollectable no matter what its owner drops -- which is
+        how running the eight golden ja clips in one process (a fresh
+        Refiner + RoutedASR per clip) grew `pytest tests` to ~19 GB. Pair
+        this with RoutedASR.close(); scripts/make_ja_golden.run_clip() and
+        main() both do, in that order.
+        """
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._task_queue.put(_WORKER_STOP)
+        self._worker_thread.join()
+        if self._transcript is not None:
+            self._transcript.close()
+            self._transcript = None
+
+    def __enter__(self) -> "Refiner":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
 
     def _worker_loop(self):
         while True:
             task = self._task_queue.get()
+            if task is _WORKER_STOP:
+                self._task_queue.task_done()
+                return
             try:
                 task()
             except Exception:
@@ -897,7 +984,10 @@ class Refiner:
         visually swallowing an en segment sandwiched between two ja ones
         into a "[refine/ja] ..." line. Refine groups now never cross a
         language boundary.
+
+        Raises RuntimeError after close() -- see maybe_refine().
         """
+        self._check_open()
         corrected = script_corrected_lang(lang, text)
         if self.spans:
             group_lang = script_corrected_lang(self.spans[-1][2], self.spans[-1][3])
@@ -1165,7 +1255,25 @@ class Refiner:
         self.printer.hub.publish({"type": "recluster", **stats})
         return stats
 
+    def _check_open(self) -> None:
+        """Refuse work on a closed Refiner, loudly.
+
+        A no-op would be the friendlier-looking choice, but every caller
+        here (run_stream/drain_segments' ingestion path, main()'s finish(),
+        reset_live_session()) is submitting audio that is supposed to end
+        up in the console/SSE/transcript output -- silently dropping it
+        would lose transcript content with nothing to show for it. Worse,
+        a `force_sync=True` refine enqueued after close() would block its
+        caller forever on an Event no worker is left to set, so this turns
+        a deadlock into an immediate, traceable error.
+        """
+        if self._closed:
+            raise RuntimeError(
+                "this Refiner is closed (close() stopped its worker thread); "
+                "build a new Refiner for a new session")
+
     def maybe_refine(self, now_sample: int, force: bool = False, force_sync: bool | None = None):
+        self._check_open()
         if not self.spans:
             return
         first_start = self.spans[0][0]
@@ -1929,6 +2037,17 @@ def main():
         # shutdown too, right after the console prints above so both
         # report identical numbers.
         hub.publish(_session_summary_event(stats, speaker_labeler))
+        # Release the pipeline explicitly, AFTER every event above has been
+        # published -- Refiner.close() drains whatever refine work is still
+        # queued (the same drain finish() does) and asr.close() then frees
+        # the recognizers, so a caller that imports this module and calls
+        # main() in-process gets its memory back instead of holding it
+        # until the interpreter exits. Order matters: the refiner decodes
+        # through the engine, so it stops first.
+        if refiner is not None:
+            refiner.close()
+        translator_worker.close()
+        asr.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,300 @@
+"""close() actually ends a pipeline's life: no threads left, nothing kept alive.
+
+The bug these guard: `pytest tests` grew to ~19 GB RSS, all of it from
+tests/test_ja_golden.py building one full pipeline per golden clip.
+Neither RoutedASR nor Refiner could ever be collected, because each had
+started a daemon thread that never returns -- Refiner._worker_loop's
+`while True: queue.get()`, RoutedASR's preload -- and a running thread's
+frame holds its owner. Refiner holds the RoutedASR, and the RoutedASR
+holds several GB of sherpa-onnx recognizers, so eight clips meant eight
+live engines.
+
+Everything except the last test runs model-free (stubs in the same style
+as tests/test_units.py), so CI covers the fix. The one test that runs the
+real ja pipeline is skipped without models/ -- sherpa-onnx's C++ layer
+calls exit() rather than raising when handed a missing model path, so
+there is no "try it and see" here.
+"""
+
+import gc
+import os
+import sys
+import threading
+import time
+import weakref
+
+import numpy as np
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import asr_engine  # noqa: E402
+from realtime_transcribe import (AudioHistory, PartialPrinter,  # noqa: E402
+                                 Refiner, TranslationWorker, TranslatorPool)
+
+MODELS_DIR = os.path.join(ROOT, "models")
+GOLDEN_DIR = os.path.join(ROOT, "tests", "golden", "ja")
+
+
+@pytest.fixture
+def no_thread_leak():
+    """Fail the test if it leaves a thread running that wasn't there before.
+
+    Identity-based rather than name-based: threading.Thread(target=...)
+    names its threads "Thread-N", so there is nothing in the name to match
+    _worker_loop or _preload_rest on. Comparing the live set before and
+    after says the same thing and says it about every worker at once.
+    """
+    before = set(threading.enumerate())
+    yield
+    # a joined thread can linger in enumerate() for an instant on some
+    # platforms; give it a moment before calling it a leak
+    for _ in range(50):
+        leaked = set(threading.enumerate()) - before
+        if not leaked:
+            break
+        time.sleep(0.02)
+    assert not leaked, f"threads still running after the test: {leaked}"
+
+
+class _FakeAsr:
+    """Stands in for RoutedASR in the Refiner tests: no models, no threads."""
+
+    forced_lang = "ja"
+
+    def _identify_lang(self, buf, sample_rate):
+        return "ja"
+
+    def transcribe(self, buf, sample_rate, known_lang=None, live=False, **kw):
+        return {"text": "refined"}
+
+
+def _refiner(asr=None) -> Refiner:
+    sample_rate = 16000
+    history = AudioHistory(sample_rate, keep_s=30.0)
+    history.push(np.zeros(sample_rate * 3, dtype=np.float32))
+    return Refiner(asr if asr is not None else _FakeAsr(), history, sample_rate,
+                   PartialPrinter(enabled=False))
+
+
+# ---- Refiner ---------------------------------------------------------------
+
+def test_refiner_close_ends_the_worker_thread(no_thread_leak):
+    refiner = _refiner()
+    assert refiner._worker_thread.is_alive()
+    refiner.close()
+    assert not refiner._worker_thread.is_alive()
+
+
+def test_refiner_close_is_idempotent(no_thread_leak):
+    refiner = _refiner()
+    refiner.close()
+    refiner.close()  # must not hang on a second join or re-queue a sentinel
+    assert not refiner._worker_thread.is_alive()
+
+
+def test_refiner_close_runs_the_queued_backlog_first(no_thread_leak):
+    """The stop sentinel goes in at the back of the FIFO, so close() is the
+    same drain main()'s finish() did with _task_queue.join()."""
+    refiner = _refiner()
+    ran = []
+    started = threading.Event()
+
+    def slow():
+        started.set()
+        time.sleep(0.2)
+        ran.append("slow")
+
+    refiner._task_queue.put(slow)
+    started.wait(timeout=2.0)
+    refiner._task_queue.put(lambda: ran.append("queued-after"))
+    refiner.close()
+    assert ran == ["slow", "queued-after"]
+
+
+def test_refiner_refuses_work_after_close(no_thread_leak):
+    refiner = _refiner()
+    refiner.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        refiner.add_span(0, 16000, "ja", "text", "")
+    with pytest.raises(RuntimeError, match="closed"):
+        # the deadlock case: a sync refine would wait forever on an Event
+        # no worker is left to set
+        refiner.maybe_refine(0, force=True)
+
+
+def test_closing_the_refiner_releases_the_engine(no_thread_leak):
+    """The leak itself, model-free: _worker_loop's frame held `self`, and
+    `self` held the ASR engine, so neither could ever be collected."""
+    asr = _FakeAsr()
+    ref = weakref.ref(asr)
+    refiner = _refiner(asr)
+    del asr
+
+    gc.collect()
+    assert ref() is not None, "the live Refiner should still hold the engine"
+
+    refiner.close()
+    del refiner
+    gc.collect()
+    assert ref() is None, (
+        "the engine outlived its closed Refiner -- something still holds a "
+        "reference to it (this is the pytest-memory-leak bug)")
+
+
+def test_refiner_close_closes_the_transcript_file(tmp_path, no_thread_leak):
+    path = tmp_path / "transcript.txt"
+    sample_rate = 16000
+    history = AudioHistory(sample_rate, keep_s=30.0)
+    refiner = Refiner(_FakeAsr(), history, sample_rate, PartialPrinter(enabled=False),
+                      transcript_path=str(path))
+    refiner.close()
+    assert refiner._transcript is None
+
+
+# ---- TranslationWorker -----------------------------------------------------
+
+def test_translation_worker_close_ends_its_thread(no_thread_leak):
+    worker = TranslationWorker(TranslatorPool(), _NullHub())
+    assert worker._thread.is_alive()
+    worker.close()
+    worker.close()  # idempotent
+    assert not worker._thread.is_alive()
+
+
+def test_translation_worker_submit_after_close_is_a_no_op(no_thread_leak):
+    worker = TranslationWorker(TranslatorPool(), _NullHub())
+    worker.close()
+    worker.submit("もう終わっている")  # must not raise, must not queue forever
+    assert worker._q.empty()
+
+
+class _NullHub:
+    def publish(self, event):
+        pass
+
+
+# ---- RoutedASR (stubbed builders: no models, no sherpa-onnx) ---------------
+
+@pytest.fixture
+def stub_engine_builders(monkeypatch):
+    """Make RoutedASR constructible without models/.
+
+    sherpa-onnx's C++ layer exits the process on a missing model path, so
+    every construction site has to be replaced, not just guarded: the LID
+    build in __init__, the six _BUILDERS, the on-disk presence check, and
+    the warm-up decode _preload_rest runs per tier. The punct/ko_spacer
+    properties are replaced with plain None class attributes for the same
+    reason (and to keep this test fast).
+    """
+    built = []
+
+    def _builder(threads, _name="model"):
+        time.sleep(0.05)  # a real tier takes ~2s; enough to be in flight
+        built.append(_name)
+        return object()
+
+    monkeypatch.setattr(asr_engine, "_model_present", lambda name: True)
+    monkeypatch.setattr(asr_engine, "_build_lid_guarded", lambda threads: object())
+    monkeypatch.setattr(asr_engine, "_BUILDERS",
+                        {name: (lambda threads, _n=name: _builder(threads, _n))
+                         for name in asr_engine._BUILDERS})
+    monkeypatch.setattr(asr_engine.RoutedASR, "_decode",
+                        staticmethod(lambda rec, samples, sample_rate: ""))
+    monkeypatch.setattr(asr_engine.RoutedASR, "punct", None)
+    monkeypatch.setattr(asr_engine.RoutedASR, "ko_spacer", None)
+    return built
+
+
+def _stub_engine(**kw) -> asr_engine.RoutedASR:
+    kw.setdefault("threads", 1)
+    kw.setdefault("warmup", False)
+    kw.setdefault("punctuate", False)
+    kw.setdefault("max_resident", 3)
+    return asr_engine.RoutedASR(**kw)
+
+
+def test_engine_close_joins_the_preload_thread(stub_engine_builders, no_thread_leak):
+    """close() called while _preload_rest is still loading tiers must not
+    leave that thread running: it holds `self`, and through it every
+    recognizer loaded so far."""
+    asr = _stub_engine(preload=True)
+    asr.close()
+    assert asr._bg_threads == []
+    assert asr.resident_models == []
+
+
+def test_engine_close_drops_every_model_reference(stub_engine_builders, no_thread_leak):
+    asr = _stub_engine(preload=False)
+    asr._get("sv")
+    assert asr.resident_models == ["sv"]
+    asr.close()
+    assert asr.resident_models == []
+    assert asr.lid is None
+    assert asr._punct is None and asr._ko_spacer is None
+
+
+def test_engine_close_is_idempotent(stub_engine_builders, no_thread_leak):
+    asr = _stub_engine(preload=True)
+    asr.close()
+    asr.close()
+
+
+def test_engine_refuses_work_after_close(stub_engine_builders, no_thread_leak):
+    asr = _stub_engine(preload=False)
+    asr.close()
+    silence = np.zeros(16000, dtype=np.float32)
+    for call in (lambda: asr.transcribe(silence, 16000),
+                 lambda: asr.partial(silence, 16000),
+                 lambda: asr.identify(silence, 16000)):
+        with pytest.raises(RuntimeError, match="closed"):
+            call()
+
+
+def test_closed_engine_starts_no_new_background_work(stub_engine_builders,
+                                                     no_thread_leak):
+    asr = _stub_engine(preload=False)
+    asr.close()
+    assert asr._spawn_bg(lambda: None) is None
+
+
+def test_closed_engine_is_collectable(stub_engine_builders, no_thread_leak):
+    asr = _stub_engine(preload=True)
+    ref = weakref.ref(asr)
+    asr.close()
+    del asr
+    gc.collect()
+    assert ref() is None, (
+        "a closed RoutedASR is still reachable -- a background thread or "
+        "another holder is keeping its recognizers alive")
+
+
+# ---- the real pipeline, one clip, twice -----------------------------------
+
+def _golden_wavs() -> list:
+    if not os.path.isdir(GOLDEN_DIR):
+        return []
+    return sorted(f for f in os.listdir(GOLDEN_DIR) if f.endswith(".wav"))
+
+
+@pytest.mark.skipif(not os.path.isdir(MODELS_DIR) or not _golden_wavs(),
+                    reason="ja route models / golden clips not present")
+def test_run_clip_leaves_no_engine_behind(no_thread_leak):
+    """make_ja_golden.run_clip() is what tests/test_ja_golden.py calls once
+    per clip. Two calls used to mean two live engines (~2.4 GB each) for
+    the rest of the session; now the second call starts from where the
+    first one did."""
+    import make_ja_golden
+
+    wav = os.path.join(GOLDEN_DIR, _golden_wavs()[0])
+    for _ in range(2):
+        result = make_ja_golden.run_clip(wav)
+        assert result["finals"], "the clip produced no text -- wrong bug found"
+
+    gc.collect()
+    alive = [o for o in gc.get_objects() if isinstance(o, asr_engine.RoutedASR)]
+    assert alive == [], (
+        f"{len(alive)} RoutedASR instance(s) survived run_clip() -- each one "
+        f"pins its sherpa-onnx recognizers, which is what took `pytest tests` "
+        f"to ~19 GB")

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -341,6 +341,11 @@ def test_partial_forced_lang_routes_directly_without_lid_or_sv_probe():
     class _Stub:
         forced_lang = "ko"
         last_lang = "en"  # deliberately different, to prove it's ignored
+        # transcribe()/partial() now refuse to run on a closed engine
+        # (RoutedASR.close()); borrowed rather than faked so this stub
+        # keeps checking whatever the real guard checks.
+        _closed = False
+        _check_open = asr_engine.RoutedASR._check_open
 
         def _route(self, lang):
             assert lang == "ko"
@@ -530,6 +535,11 @@ def test_transcribe_bootstrap_too_short_decodes_but_does_not_seed_last_lang():
         _pending_lang = None
         _pending_count = 0
         _unavailable = set()
+        # transcribe()/partial() now refuse to run on a closed engine
+        # (RoutedASR.close()); borrowed rather than faked so this stub
+        # keeps checking whatever the real guard checks.
+        _closed = False
+        _check_open = asr_engine.RoutedASR._check_open
 
         def _decode_full(self, rec, samples, sample_rate):
             return ("hi", "<|en|>0.9")
@@ -580,6 +590,11 @@ def test_transcribe_bootstrap_zh_yue_reuses_single_sv_probe_decode():
         _pending_count = 0
         _unavailable = set()
         _itn_overrides = asr_engine.itn_cjk.EMPTY_OVERRIDES
+        # transcribe()/partial() now refuse to run on a closed engine
+        # (RoutedASR.close()); borrowed rather than faked so this stub
+        # keeps checking whatever the real guard checks.
+        _closed = False
+        _check_open = asr_engine.RoutedASR._check_open
         ko_spacer = None
         punct = None
 
@@ -744,6 +759,11 @@ class _FakeRefiner:
     the real method's effect on self.spans: a forced flush empties it)."""
 
     add_span = Refiner.add_span
+    # add_span() now refuses to run on a closed Refiner (Refiner.close());
+    # borrowed, same as add_span itself, so this stub checks what the real
+    # guard checks.
+    _closed = False
+    _check_open = Refiner._check_open
 
     def __init__(self):
         self.spans = []
@@ -957,6 +977,11 @@ def _omni_safety_net_stub(omni_available: bool):
         _pending_count = 0
         _unavailable = set() if omni_available else {"omni"}
         _itn_overrides = asr_engine.itn_cjk.EMPTY_OVERRIDES
+        # transcribe()/partial() now refuse to run on a closed engine
+        # (RoutedASR.close()); borrowed rather than faked so this stub
+        # keeps checking whatever the real guard checks.
+        _closed = False
+        _check_open = asr_engine.RoutedASR._check_open
         ko_spacer = None
         punct = None
         _looks_truncated = staticmethod(asr_engine.RoutedASR._looks_truncated)


### PR DESCRIPTION
## なぜ / Why

`pytest tests` を回すたびにプロセスの RSS が約 19GB に達し、GPU 学習と同時に走ると pagefile へのスワップでマシンが固まっていた。原因は `tests/test_ja_golden.py` が 8 クリップそれぞれに `RoutedASR` と `Refiner` を新規構築するのに、どちらも daemon スレッド（`_preload_rest` と `_worker_loop`）が `self` を握ったまま終了手段が無く、sherpa-onnx の認識器（ネイティブ数 GB）が GC 不能だったこと。1 クリップあたり約 2.4GB ずつ積み上がっていた。

Running `pytest tests` grew the process to ~19GB RSS. `RoutedASR` and `Refiner` each start a daemon thread with no way to stop it; the thread frame keeps `self` alive, and through it the multi-GB sherpa-onnx recognizers. Eight golden clips = eight leaked engines.

## 何をしたか / What

- `RoutedASR.close()`: 起動する全バックグラウンドスレッド（プリロード、発話ごとのプリフェッチ）を `_spawn_bg()` で登録し、close で join してから認識器・句読点・LID・ko_spacer の参照を落とす。C++ 内のロード中は中断できないので完了を待つ（最悪 1 tier 分 ~2s）。close 後の `transcribe`/`partial`/`identify` は `RuntimeError`。
- `Refiner.close()` / `TranslationWorker.close()`: FIFO の末尾に停止番兵を入れ、積み残しを処理してからワーカーを終了。`Refiner` は close 後の `add_span`/`maybe_refine` を例外にする（黙って捨てるとトランスクリプトの内容が消え、`force_sync` の呼び出しは永久に待つため）。翻訳側は表示済み行の訳なので no-op。
- `main()` の finally と `make_ja_golden.run_clip()` の try/finally から close を呼ぶ。`build_golden()` も同じ経路。
- `tests/test_lifecycle.py`: モデル無しでも走るスタブで、スレッドが残らないこと・`gc.collect()` 後に `RoutedASR` が残らないことを固定。実モデル経路は models/ がある環境だけ。
- `docs/guide/embedding.md` にシャットダウン手順を追記。

## 検証 / Verification

| | before (origin/main) | after |
|---|---|---|
| `tests/test_ja_golden.py` peak RSS | 15,120 MB | 2,907 MB |
| full suite peak RSS (teardown 計測) | – | 1,180 MB |
| full suite | – | 325 passed / 4 skipped (既存) |

golden の期待テキストと CER 許容値は無変更（8/8 完全一致、CER 0）。`tests/test_ja_pipeline_spec.py`、`check_doc_links.py`、`--minimal` での `make_ja_golden` import を確認。CLI を `--wav` と `--transcript` 付きで通し、終了時のハングなし。

## ロールバック / Rollback

revert で戻せる。データ移行なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit shutdown support for transcription, translation, and refinement components.
  - Added context-manager support for easier resource management.
  - Closed components now prevent further processing and release loaded models and resources.
  - Real-time transcription shutdown preserves the final published session events.

- **Documentation**
  - Added guidance for shutting down pipelines and resetting live sessions.

- **Tests**
  - Added coverage for clean shutdown, repeated closure, thread termination, resource release, and post-shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->